### PR TITLE
Improve rfc6979 compatibility

### DIFF
--- a/include/bitcoin/bitcoin/math/ec_keys.hpp
+++ b/include/bitcoin/bitcoin/math/ec_keys.hpp
@@ -69,15 +69,32 @@ BC_API bool verify_public_key_fast(const ec_point& public_key);
 BC_API bool verify_private_key(const ec_secret& private_key);
 
 /**
- * Create a deterministic signature nonce according to rfc6979.
+ * Create a deterministic EC signature using a private key.
+ * This function will always produce a valid signature.
  */
-BC_API ec_secret create_nonce(ec_secret secret, hash_digest hash);
+BC_API endorsement sign(ec_secret secret, hash_digest hash);
+
+/**
+ * Create an compact EC signature for use in message signing.
+ * This function will always produce a valid signature.
+ */
+BC_API compact_signature sign_compact(ec_secret secret, hash_digest hash);
+
+/**
+ * Create a deterministic signature nonce according to rfc6979.
+ * @param index It is possible that the generated nonce is unacceptable,
+ * either because it is out of range or because it creates a bad signature.
+ * If this happens, increment index and try again.
+ */
+BC_API ec_secret create_nonce(ec_secret secret, hash_digest hash,
+    unsigned index=0);
 
 /**
  * Create an EC signature using a private key.
+ * DO NOT USE! A bad nonce is an easy way to get Bitcoins stolen.
+ * Consider using the deterministic version above instead.
  * The nonce must be a cryptographically-secure random number,
  * or the signature will leak information about the private key.
- * Consider using the `create_nonce` function here.
  * @return an EC signature, or a zero-length chunk if something goes wrong.
  * Try another nonce if this happens.
  */
@@ -85,9 +102,10 @@ BC_API endorsement sign(ec_secret secret, hash_digest hash, ec_secret nonce);
 
 /**
  * Create an compact EC signature for use in message signing.
+ * DO NOT USE! A bad nonce is an easy way to get Bitcoins stolen.
+ * Consider using the deterministic version above instead.
  * The nonce must be a cryptographically-secure random number,
  * or the signature will leak information about the private key.
- * Consider using the `create_nonce` function here.
  * @return a compact signature. This will be all-zero if something goes wrong.
  * Try another nonce if this happens.
  */

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -995,12 +995,8 @@ bool create_signature(data_chunk& signature, const ec_secret& private_key,
         script_type::generate_signature_hash(
             new_tx, input_index, prevout_script, hash_type);
 
-    const auto deterministic_nonce = create_nonce(private_key, sighash);
-
     // Create the EC signature.
-    signature = sign(private_key, sighash, deterministic_nonce);
-    if (signature.empty())
-        return false;
+    signature = sign(private_key, sighash);
 
     // Add the sighash type to the end of the signature.
     signature.push_back(hash_type);

--- a/src/wallet/message.cpp
+++ b/src/wallet/message.cpp
@@ -57,7 +57,7 @@ message_signature sign_message(data_slice message,
 {
     auto hash = hash_message(message);
 
-    auto cs = sign_compact(secret, hash, create_nonce(secret, hash));
+    auto cs = sign_compact(secret, hash);
 
     int magic = 27 + cs.recid;
     if (compressed)

--- a/test/ec_keys.cpp
+++ b/test/ec_keys.cpp
@@ -96,15 +96,113 @@ BOOST_AUTO_TEST_CASE(rfc6979_nonce_test)
     }
 }
 
+BOOST_AUTO_TEST_CASE(rfc6979_nonce_index_test)
+{
+    struct rfc6979_index_test
+    {
+        ec_secret secret;
+        std::string message;
+        std::string nonce00;
+        std::string nonce01;
+        std::string nonce15;
+    };
+
+    // These test vectors were provided by user bip32JP on Github:
+    // https://github.com/bitcoinjs/bitcoinjs-lib/pull/337#issuecomment-68620793
+    const std::vector<rfc6979_index_test> rfc6979_index_tests
+    {
+        {
+            base16_literal("fee0a1f7afebf9d2a5a80c0c98a31c709681cce195cbcd06342b517970c0be1e"),
+            "test data",
+            "fcce1de7a9bcd6b2d3defade6afa1913fb9229e3b7ddf4749b55c4848b2a196e",
+            "727fbcb59eb48b1d7d46f95a04991fc512eb9dbf9105628e3aec87428df28fd8",
+            "398f0e2c9f79728f7b3d84d447ac3a86d8b2083c8f234a0ffa9c4043d68bd258"
+        },
+        {
+            base16_literal("0000000000000000000000000000000000000000000000000000000000000001"),
+            "Everything should be made as simple as possible, but not simpler.",
+            "ec633bd56a5774a0940cb97e27a9e4e51dc94af737596a0c5cbb3d30332d92a5",
+            "df55b6d1b5c48184622b0ead41a0e02bfa5ac3ebdb4c34701454e80aabf36f56",
+            "def007a9a3c2f7c769c75da9d47f2af84075af95cadd1407393dc1e26086ef87"
+        },
+        {
+            base16_literal("0000000000000000000000000000000000000000000000000000000000000002"),
+            "Satoshi Nakamoto",
+            "d3edc1b8224e953f6ee05c8bbf7ae228f461030e47caf97cde91430b4607405e",
+            "f86d8e43c09a6a83953f0ab6d0af59fb7446b4660119902e9967067596b58374",
+            "241d1f57d6cfd2f73b1ada7907b199951f95ef5ad362b13aed84009656e0254a"
+        },
+        {
+            base16_literal("7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f"),
+            "Diffie Hellman",
+            "c378a41cb17dce12340788dd3503635f54f894c306d52f6e9bc4b8f18d27afcc",
+            "90756c96fef41152ac9abe08819c4e95f16da2af472880192c69a2b7bac29114",
+            "7b3f53300ab0ccd0f698f4d67db87c44cf3e9e513d9df61137256652b2e94e7c"
+        },
+        {
+            base16_literal("8080808080808080808080808080808080808080808080808080808080808080"),
+            "Japan",
+            "f471e61b51d2d8db78f3dae19d973616f57cdc54caaa81c269394b8c34edcf59",
+            "6819d85b9730acc876fdf59e162bf309e9f63dd35550edf20869d23c2f3e6d17",
+            "d8e8bae3ee330a198d1f5e00ad7c5f9ed7c24c357c0a004322abca5d9cd17847"
+        },
+        {
+            base16_literal("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140"),
+            "Bitcoin",
+            "36c848ffb2cbecc5422c33a994955b807665317c1ce2a0f59c689321aaa631cc",
+            "4ed8de1ec952a4f5b3bd79d1ff96446bcd45cabb00fc6ca127183e14671bcb85",
+            "56b6f47babc1662c011d3b1f93aa51a6e9b5f6512e9f2e16821a238d450a31f8"
+        },
+        {
+            base16_literal("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140"),
+            "i2FLPP8WEus5WPjpoHwheXOMSobUJVaZM1JPMQZq",
+            "6e9b434fcc6bbb081a0463c094356b47d62d7efae7da9c518ed7bac23f4e2ed6",
+            "ae5323ae338d6117ce8520a43b92eacd2ea1312ae514d53d8e34010154c593bb",
+            "3eaa1b61d1b8ab2f1ca71219c399f2b8b3defa624719f1e96fe3957628c2c4ea"
+        },
+        {
+            base16_literal("3881e5286abc580bb6139fe8e83d7c8271c6fe5e5c2d640c1f0ed0e1ee37edc9"),
+            "lEE55EJNP7aLrMtjkeJKKux4Yg0E8E1SAJnWTCEh",
+            "5b606665a16da29cc1c5411d744ab554640479dd8abd3c04ff23bd6b302e7034",
+            "f8b25263152c042807c992eacd2ac2cc5790d1e9957c394f77ea368e3d9923bd",
+            "ea624578f7e7964ac1d84adb5b5087dd14f0ee78b49072aa19051cc15dab6f33"
+        },
+        {
+            base16_literal("7259dff07922de7f9c4c5720d68c9745e230b32508c497dd24cb95ef18856631"),
+            "2SaVPvhxkAPrayIVKcsoQO5DKA8Uv5X/esZFlf+y",
+            "3ab6c19ab5d3aea6aa0c6da37516b1d6e28e3985019b3adb388714e8f536686b",
+            "19af21b05004b0ce9cdca82458a371a9d2cf0dc35a813108c557b551c08eb52e",
+            "117a32665fca1b7137a91c4739ac5719fec0cf2e146f40f8e7c21b45a07ebc6a"
+        },
+        {
+            base16_literal("0d6ea45d62b334777d6995052965c795a4f8506044b4fd7dc59c15656a28f7aa"),
+            "00A0OwO2THi7j5Z/jp0FmN6nn7N/DQd6eBnCS+/b",
+            "79487de0c8799158294d94c0eb92ee4b567e4dc7ca18addc86e49d31ce1d2db6",
+            "9561d2401164a48a8f600882753b3105ebdd35e2358f4f808c4f549c91490009",
+            "b0d273634129ff4dbdf0df317d4062a1dbc58818f88878ffdb4ec511c77976c0"
+        }
+    };
+
+    for (auto& test: rfc6979_index_tests)
+    {
+        hash_digest hash = sha256_hash(to_data_chunk(test.message));
+        ec_secret nonce00 = create_nonce(test.secret, hash);
+        ec_secret nonce01 = create_nonce(test.secret, hash, 1);
+        ec_secret nonce15 = create_nonce(test.secret, hash, 15);
+        BOOST_REQUIRE_EQUAL(encode_base16(nonce00), test.nonce00);
+        BOOST_REQUIRE_EQUAL(encode_base16(nonce01), test.nonce01);
+        BOOST_REQUIRE_EQUAL(encode_base16(nonce15), test.nonce15);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(ec_signature_test)
 {
     ec_point public_key = secret_to_public_key(secret, true);
     data_chunk data{'d', 'a', 't', 'a'};
     hash_digest hash = bitcoin_hash(data);
-    ec_secret nonce{{42}};
 
     // Correct signature:
-    data_chunk signature = sign(secret, hash, nonce);
+    data_chunk signature = sign(secret, hash);
     BOOST_REQUIRE(verify_signature(public_key, hash, signature));
 
     // Incorrect data:
@@ -112,7 +210,7 @@ BOOST_AUTO_TEST_CASE(ec_signature_test)
     BOOST_REQUIRE(!verify_signature(public_key, hash, signature));
 
     // Invalid nonce:
-    nonce = ec_secret{{0}};
+    ec_secret nonce = ec_secret{{0}};
     BOOST_REQUIRE(!sign(secret, hash, nonce).size());
 }
 


### PR DESCRIPTION
The previous implementation didn't provide any way to try a different
nonce if the signature is invalid.