### PR TITLE
[build] Use libsecp256k1_LIBS flag

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,5 +54,5 @@ endif
 
 libbitcoin_la_LIBADD = \
     -lboost_thread -lboost_system -lboost_regex -lboost_filesystem -lpthread \
-    -lcurl -lsecp256k1 @LDFLAG_LEVELDB@ -lcrypto -ldl -lz
+    -lcurl @libsecp256k1_LIBS@ @LDFLAG_LEVELDB@ -lcrypto -ldl -lz
 


### PR DESCRIPTION
Fix building when libsecp256k1 is not in the default path.
(continues from https://github.com/libbitcoin/libbitcoin/pull/172)

Found! :)
FYI:
libsecp256k1_LIBS='-L/home/sx/sx/lib -lsecp256k1  '