### PR TITLE
Added fix for compile error on Debian.

### DIFF
--- a/include/bitcoin/bitcoin/constants.hpp
+++ b/include/bitcoin/bitcoin/constants.hpp
@@ -81,7 +81,12 @@ constexpr uint64_t max_uint64 = MAX_UINT64;
 constexpr uint32_t max_uint32 = MAX_UINT32;
 constexpr uint16_t max_uint16 = MAX_UINT16;
 constexpr uint8_t max_uint8 = MAX_UINT8;
+// Debian complains about missing UINTPTR_MAX definition for some weird reason.
+#ifdef UINTPTR_MAX
 constexpr uint64_t max_size_t = UINTPTR_MAX;
+#else
+constexpr uint64_t max_size_t = std::numeric_limits<size_t>::max();
+#endif
 
 constexpr uint32_t max_index = max_uint32;
 constexpr uint32_t max_height = max_uint32;


### PR DESCRIPTION
For some strange reason I get this compile error on Debian.

  CXX    src/network/src_libbitcoin_la-network.lo
In file included from ./include/bitcoin/bitcoin/satoshi_serialize.hpp:24:0,
                 from ./include/bitcoin/bitcoin/network/channel.hpp:36,
                 from src/network/channel.cpp:20:
./include/bitcoin/bitcoin/constants.hpp:84:33: error: 'UINTPTR_MAX' was not declared in this scope
In file included from ./include/bitcoin/bitcoin/satoshi_serialize.hpp:24:0,
                 from ./include/bitcoin/bitcoin/network/channel.hpp:36,
                 from src/network/handshake.cpp:26:
./include/bitcoin/bitcoin/constants.hpp:84:33: error: 'UINTPTR_MAX' was not declared in this scope
make: *** [src/network/src_libbitcoin_la-handshake.lo] Error 1
make: *** Waiting for unfinished jobs....
make: *** [src/network/src_libbitcoin_la-channel.lo] Error 1

Yet it works in a standalone cpp file when I include the file in an empty main.cpp. Compile error only happens on Debian which has an outdated g++ so this seems like a fine no-hassle temporary fix.