### PR TITLE
added sign byte back to stealth.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/libbitcoin/libbitcoin.svg?branch=version2)](https://travis-ci.org/libbitcoin/libbitcoin)
+[![Build Status](https://travis-ci.org/libbitcoin/libbitcoin.svg?branch=master)](https://travis-ci.org/libbitcoin/libbitcoin)
 
 # Libbitcoin
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Next install the [build system](http://en.wikipedia.org/wiki/GNU_build_system):
 ```sh
   $ sudo apt-get install build-essential autoconf automake libtool pkg-config
 ```
-Next install [Boost](http://www.boost.org) (1.50.0 or newer) and [GMP](https://gmplib.org/)  (5.0.0 or newer).
+Next install [Boost](http://www.boost.org) (1.49.0 or newer) and [GMP](https://gmplib.org/)  (5.0.0 or newer).
 ```sh
   $ sudo apt-get install libboost-all-dev libgmp-dev
 ```

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1483,7 +1483,7 @@ bool is_stealth_info_type(const operation_stack& ops)
     return ops.size() == 2 &&
         ops[0].code == opcode::return_ &&
         ops[1].code == opcode::special &&
-        ops[1].data.size() >= hash_size;
+        ops[1].data.size() >= ec_compressed_size;
 }
 bool is_multisig_type(const operation_stack&)
 {


### PR DESCRIPTION
This increases the number of client side computations, which reduces the
anonymity. It is trivial for the server to store this data and halves
the computation workload for the client, thereby increasing the
acceptable working dataset & improving anonymity for the client.
In fetch_stealth it returns rows with the ephemeral key. The beginning sign byte (02
and 03) was remove and have the client test both combinations.
On further reflection after speaking with caedes, it is a bad idea and
reduces anonymity.
We want to lessen the processing burden on clients, so they can use a
smaller prefix (= more data) to remain more anonymous.
