### PR TITLE
Fix race condition in channel

### DIFF
--- a/include/bitcoin/bitcoin/network/channel.hpp
+++ b/include/bitcoin/bitcoin/network/channel.hpp
@@ -248,7 +248,7 @@ private:
     void stop_impl();
     void clear_subscriptions();
 
-    boost::asio::io_service::strand strand_;
+    async_strand strand_;
     socket_ptr socket_;
     // We keep the service alive for lifetime rules
     boost::asio::deadline_timer timeout_, heartbeat_;

--- a/include/bitcoin/bitcoin/network/channel.hpp
+++ b/include/bitcoin/bitcoin/network/channel.hpp
@@ -250,6 +250,8 @@ private:
 
     async_strand strand_;
     socket_ptr socket_;
+    // Used to ensure that the socket only gets closed once.
+    std::mutex stop_mutex_;
     // We keep the service alive for lifetime rules
     boost::asio::deadline_timer timeout_, heartbeat_;
     std::atomic<bool> stopped_;

--- a/src/network/channel.cpp
+++ b/src/network/channel.cpp
@@ -91,7 +91,7 @@ void channel_stream_loader::load_lookup(const std::string& symbol,
 }
 
 channel_proxy::channel_proxy(threadpool& pool, socket_ptr socket)
-  : strand_(pool.service()), socket_(socket),
+  : strand_(pool), socket_(socket),
     timeout_(pool.service()), heartbeat_(pool.service()), stopped_(false)
 {
 #define CHANNEL_TRANSPORT_MECHANISM(MESSAGE_TYPE) \
@@ -255,23 +255,23 @@ bool channel_proxy::problems_check(const boost::system::error_code& ec)
 void channel_proxy::read_header()
 {
     async_read(*socket_, buffer(inbound_header_),
-        strand_.wrap(std::bind(&channel_proxy::handle_read_header,
-            shared_from_this(), _1, _2)));
+        strand_.wrap(&channel_proxy::handle_read_header,
+            shared_from_this(), _1, _2));
 }
 
 void channel_proxy::read_checksum(const header_type& header_msg)
 {
     async_read(*socket_, buffer(inbound_checksum_),
-        strand_.wrap(std::bind(&channel_proxy::handle_read_checksum,
-            shared_from_this(), _1, _2, header_msg)));
+        strand_.wrap(&channel_proxy::handle_read_checksum,
+            shared_from_this(), _1, _2, header_msg));
 }
 
 void channel_proxy::read_payload(const header_type& header_msg)
 {
     inbound_payload_.resize(header_msg.payload_length);
     async_read(*socket_, buffer(inbound_payload_, header_msg.payload_length),
-        strand_.wrap(std::bind(&channel_proxy::handle_read_payload,
-            shared_from_this(), _1, _2, header_msg)));
+        strand_.wrap(&channel_proxy::handle_read_payload,
+            shared_from_this(), _1, _2, header_msg));
 }
 
 bool verify_header(const header_type& header_msg)
@@ -455,8 +455,8 @@ void channel_proxy::send_raw(const header_type& packet_header,
     if (stopped_)
         handle_send(error::service_stopped);
     else
-        strand_.post(std::bind(&channel_proxy::do_send_raw,
-            shared_from_this(), packet_header, payload, handle_send));
+        strand_.queue(&channel_proxy::do_send_raw,
+            shared_from_this(), packet_header, payload, handle_send);
 }
 
 void channel_proxy::do_send_raw(const header_type& packet_header,
@@ -480,7 +480,7 @@ void channel_proxy::send_common(const data_chunk& whole_message,
     else
     {
         auto this_ptr = shared_from_this();
-        strand_.post(
+        strand_.queue(
             [this, this_ptr, whole_message, handle_send]
             {
                 do_send_common(whole_message, handle_send);


### PR DESCRIPTION
Basically the stopped_ variable exists to avoid code which closes the socket and calls the handlers from being called twice.

Since the stop_impl() code may be called by different threads, it can happen that the code gets executed eventhough the check at the beginning [if (stopped_) return...] passes. This fixes that by adding a mutex.