### PR TITLE
ENABLE_TESTNET propagation through pc.in.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ AC_ARG_ENABLE([ndebug],
 AC_MSG_RESULT([$enable_ndebug])
 AS_IF([test x$enable_ndebug != xno], AC_DEFINE([NDEBUG]))
 
-# Implement --enable-testnet option and define ENABLE_TESTNET.
+# Implement --enable-testnet option and define ENABLE_TESTNET and output ${testnet}.
 #------------------------------------------------------------------------------
 AC_MSG_CHECKING(--enable-testnet option)
 AC_ARG_ENABLE([testnet],
@@ -106,6 +106,7 @@ AC_ARG_ENABLE([testnet],
     [enable_testnet=no])
 AC_MSG_RESULT([$enable_testnet])
 AS_IF([test x$enable_testnet != xno], AC_DEFINE([ENABLE_TESTNET]))
+AS_IF([test x$enable_testnet != xno], AC_SUBST([testnet], [-DENABLE_TESTNET]))
 
 # Inherit --enable-shared option and define BOOST_TEST_DYN_LINK.
 #------------------------------------------------------------------------------

--- a/libbitcoin.pc.in
+++ b/libbitcoin.pc.in
@@ -19,7 +19,7 @@ Version: @PACKAGE_VERSION@
 Requires: libsecp256k1 >= 0.0.1
 
 # Our own include directory and any other compiler flags we require.
-Cflags: -I${includedir} -std=c++11
+Cflags: -I${includedir} -std=c++11 @testnet@
 
 # Our own lib and any we require that do not publish package configuration.
 Libs: -L${libdir} -lbitcoin -lpthread @boost_LIBS@ @rt_LIBS@


### PR DESCRIPTION
Thanks @genjix for the suggestion. This guarantees consistency with dependency builds and simplifies their configure.ac.