### PR TITLE
Add base85 (Z85) format for client/server certificates.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,7 +80,8 @@ bitcoin_bitcoin_formats_include_HEADERS = \
     include/bitcoin/bitcoin/formats/base10.hpp \
     include/bitcoin/bitcoin/formats/base16.hpp \
     include/bitcoin/bitcoin/formats/base58.hpp \
-    include/bitcoin/bitcoin/formats/base64.hpp
+    include/bitcoin/bitcoin/formats/base64.hpp \
+    include/bitcoin/bitcoin/formats/base85.hpp
 
 bitcoin_bitcoin_impl_formats_includedir = ${includedir}/bitcoin/bitcoin/impl/formats
 bitcoin_bitcoin_impl_formats_include_HEADERS = \
@@ -169,6 +170,7 @@ src_libbitcoin_la_SOURCES = \
     src/formats/base16.cpp \
     src/formats/base58.cpp \
     src/formats/base64.cpp \
+    src/formats/base85.cpp \
     src/math/checksum.cpp \
     src/math/ec_keys.cpp \
     src/math/external/hmac_sha256.c \
@@ -227,6 +229,7 @@ test_libbitcoin_test_SOURCES = \
     test/base16.cpp \
     test/base58.cpp \
     test/base64.cpp \
+    test/base85.cpp \
     test/big_number.cpp \
     test/checksum.cpp \
     test/config.cpp \

--- a/builds/msvc/vs2013/libbitcoin-test/libbitcoin-test.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin-test/libbitcoin-test.vcxproj
@@ -73,6 +73,7 @@
     <ClCompile Include="..\..\..\..\test\base16.cpp" />
     <ClCompile Include="..\..\..\..\test\base58.cpp" />
     <ClCompile Include="..\..\..\..\test\base64.cpp" />
+    <ClCompile Include="..\..\..\..\test\base85.cpp" />
     <ClCompile Include="..\..\..\..\test\big_number.cpp" />
     <ClCompile Include="..\..\..\..\test\checksum.cpp" />
     <ClCompile Include="..\..\..\..\test\config.cpp" />

--- a/builds/msvc/vs2013/libbitcoin-test/libbitcoin-test.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin-test/libbitcoin-test.vcxproj.filters
@@ -73,6 +73,9 @@
     <ClCompile Include="..\..\..\..\test\config.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\test\base85.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="src">

--- a/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile Include="..\..\..\..\src\formats\base16.cpp" />
     <ClCompile Include="..\..\..\..\src\formats\base58.cpp" />
     <ClCompile Include="..\..\..\..\src\formats\base64.cpp" />
+    <ClCompile Include="..\..\..\..\src\formats\base85.cpp" />
     <ClCompile Include="..\..\..\..\src\math\checksum.cpp" />
     <ClCompile Include="..\..\..\..\src\math\ec_keys.cpp" />
     <ClCompile Include="..\..\..\..\src\math\external\hmac_sha256.c" />
@@ -126,6 +127,7 @@
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\formats\base16.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\formats\base58.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\formats\base64.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\formats\base85.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\math\checksum.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\math\ec_keys.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\math\external\hmac_sha256.h" />

--- a/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj.filters
@@ -227,6 +227,9 @@
     <ClCompile Include="..\..\..\..\src\utility\general.cpp">
       <Filter>src\utility</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\formats\base85.cpp">
+      <Filter>src\formats</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\resource.h">
@@ -408,6 +411,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\version.hpp">
       <Filter>include\bitcoin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\formats\base85.hpp">
+      <Filter>include\bitcoin\formats</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/include/bitcoin/bitcoin.hpp
+++ b/include/bitcoin/bitcoin.hpp
@@ -128,6 +128,8 @@
  * - @link libbitcoin::decode_base58 decode_base58 @endlink
  * - @link libbitcoin::encode_base64 encode_base64 @endlink
  * - @link libbitcoin::decode_base64 decode_base64 @endlink
+ * - @link libbitcoin::encode_base85 encode_base85 @endlink
+ * - @link libbitcoin::decode_base85 decode_base85 @endlink
  * - @link libbitcoin::decode_hash decode_hash @endlink
  * - @link libbitcoin::extend_data extend_data @endlink
  * - @link libbitcoin::to_little_endian to_little_endian @endlink
@@ -177,6 +179,7 @@
 #include <bitcoin/bitcoin/formats/base16.hpp>
 #include <bitcoin/bitcoin/formats/base58.hpp>
 #include <bitcoin/bitcoin/formats/base64.hpp>
+#include <bitcoin/bitcoin/formats/base85.hpp>
 #include <bitcoin/bitcoin/math/checksum.hpp>
 #include <bitcoin/bitcoin/math/ec_keys.hpp>
 #include <bitcoin/bitcoin/math/hash.hpp>

--- a/include/bitcoin/bitcoin/formats/base64.hpp
+++ b/include/bitcoin/bitcoin/formats/base64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
+ * Copyright (c) 2011-2014 libbitcoin developers (see AUTHORS)
  *
  * This file is part of libbitcoin.
  *
@@ -27,14 +27,14 @@
 namespace libbitcoin {
 
 /**
- * Encode data as base58.
- * @return the base58 encoded string.
+ * Encode data as base64.
+ * @return the base64 encoded string.
  */
 BC_API std::string encode_base64(data_slice unencoded);
 
 /**
- * Attempt to decode base58 data.
- * @return false if the input contains non-base58 characters.
+ * Attempt to decode base64 data.
+ * @return false if the input contains non-base64 characters.
  */
 BC_API bool decode_base64(data_chunk& out, const std::string& in);
 

--- a/include/bitcoin/bitcoin/formats/base85.hpp
+++ b/include/bitcoin/bitcoin/formats/base85.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-2015 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_BASE85_HPP
+#define LIBBITCOIN_BASE85_HPP
+
+#include <string>
+#include <bitcoin/bitcoin/define.hpp>
+#include <bitcoin/bitcoin/utility/data.hpp>
+
+namespace libbitcoin {
+
+/**
+ * Encode data as base85 (Z85).
+ * @return false if the input is not of base85 size (% 4).
+ */
+BC_API bool encode_base85(std::string& out, data_slice in);
+
+/**
+ * Attempt to decode base85 (Z85) data.
+ * @return false if the input contains non-base85 characters or length (% 5).
+ */
+BC_API bool decode_base85(data_chunk& out, const std::string& in);
+
+} // namespace libbitcoin
+
+#endif

--- a/src/formats/base64.cpp
+++ b/src/formats/base64.cpp
@@ -36,7 +36,7 @@ const static char table[] =
 std::string encode_base64(data_slice unencoded)
 {
     std::string encoded;
-    auto size = unencoded.size();
+    const auto size = unencoded.size();
     encoded.reserve(((size / 3) + (size % 3 > 0)) * 4);
 
     uint32_t value;
@@ -83,7 +83,7 @@ bool decode_base64(data_chunk& out, const std::string& in)
 {
     const static uint32_t mask = 0x000000FF;
 
-    auto length = in.length();
+    const auto length = in.length();
     if ((length % 4) != 0)
         return false;
 

--- a/src/formats/base64.cpp
+++ b/src/formats/base64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
+ * Copyright (c) 2011-2014 libbitcoin developers (see AUTHORS)
  *
  * This file is part of libbitcoin.
  *
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#include <bitcoin/bitcoin/formats/base58.hpp>
+#include <bitcoin/bitcoin/formats/base64.hpp>
 
 #include <cstdint>
 #include <string>

--- a/src/formats/base64.cpp
+++ b/src/formats/base64.cpp
@@ -21,7 +21,6 @@
 
 #include <cstdint>
 #include <string>
-#include <bitcoin/bitcoin/define.hpp>
 #include <bitcoin/bitcoin/utility/data.hpp>
 
 // This implementation derived from public domain:
@@ -34,7 +33,7 @@ const static char pad = '=';
 const static char table[] = 
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-BC_API std::string encode_base64(data_slice unencoded)
+std::string encode_base64(data_slice unencoded)
 {
     std::string encoded;
     auto size = unencoded.size();

--- a/src/formats/base85.cpp
+++ b/src/formats/base85.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2011-2015 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// This implementation is based on:
+//  --------------------------------------------------------------------------
+//  Reference implementation for rfc.zeromq.org/spec:32/Z85
+//
+//  This implementation provides a Z85 codec as an easy-to-reuse C class 
+//  designed to be easy to port into other languages.
+
+//  --------------------------------------------------------------------------
+//  Copyright (c) 2010-2013 iMatix Corporation and Contributors
+//  
+//  Permission is hereby granted, free of charge, to any person obtaining a 
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation 
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+//  and/or sell copies of the Software, and to permit persons to whom the 
+//  Software is furnished to do so, subject to the following conditions:
+//  
+//  The above copyright notice and this permission notice shall be included in 
+//  all copies or substantial portions of the Software.
+//  
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//  DEALINGS IN THE SOFTWARE.
+//  --------------------------------------------------------------------------
+
+#include <bitcoin/bitcoin/formats/base85.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <bitcoin/bitcoin/utility/assert.hpp>
+#include <bitcoin/bitcoin/utility/data.hpp>
+
+namespace libbitcoin {
+    
+// Maps binary to base 85.
+static char encoder[85 + 1] =
+{
+    "0123456789"
+    "abcdefghij"
+    "klmnopqrst"
+    "uvwxyzABCD"
+    "EFGHIJKLMN"
+    "OPQRSTUVWX"
+    "YZ.-:+=^!/"
+    "*?&<>()[]{"
+    "}@%$#"
+};
+
+// Maps base 85 to binary.
+static uint8_t decoder[96] =
+{
+    0x00, 0x44, 0x00, 0x54, 0x53, 0x52, 0x48, 0x00,
+    0x4B, 0x4C, 0x46, 0x41, 0x00, 0x3F, 0x3E, 0x45,
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x40, 0x00, 0x49, 0x42, 0x4A, 0x47,
+    0x51, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A,
+    0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32,
+    0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A,
+    0x3B, 0x3C, 0x3D, 0x4D, 0x00, 0x4E, 0x43, 0x00,
+    0x00, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20,
+    0x21, 0x22, 0x23, 0x4F, 0x00, 0x50, 0x00, 0x00
+};
+
+// Accepts only byte arrays bounded to 4 bytes.
+bool encode_base85(std::string& out, data_slice in)
+{
+    const size_t size = in.size();
+    if (size % 4 != 0)
+        return false;
+
+    const size_t encoded_size = size * 5 / 4;
+    std::string encoded;
+    encoded.reserve(encoded_size + 1);
+    size_t byte_index = 0;
+    uint32_t accumulator = 0;
+
+    for (const uint8_t unencoded_byte: in)
+    {
+        accumulator = accumulator * 256 + unencoded_byte;
+        if (++byte_index % 4 == 0)
+        {
+            for (uint32_t divise = 85 * 85 * 85 * 85; divise > 0; divise /= 85)
+                encoded.push_back(encoder[accumulator / divise % 85]);
+
+            accumulator = 0;
+        }
+    }
+
+    out.assign(encoded.begin(), encoded.end());
+    BITCOIN_ASSERT(out.size() == encoded_size);
+    return true;
+}
+
+// Accepts only strings bounded to 5 characters.
+bool decode_base85(data_chunk& out, const std::string& in)
+{
+    const size_t length = in.size();
+    if (length % 5 != 0)
+        return false;
+
+    constexpr uint8_t shift = 32;
+    const size_t decoded_size = length * 4 / 5;
+    data_chunk decoded;
+    decoded.reserve(decoded_size);
+    size_t char_index = 0;
+    uint32_t accumulator = 0;
+
+    for (const uint8_t encoded_character: in)
+    {
+        const auto position = encoded_character - shift;
+        if (position < 0 || position > sizeof(decoder))
+            return false;
+
+        accumulator = accumulator * 85 + decoder[position];
+        if (++char_index % 5 == 0)
+        {
+            for (uint32_t divise = 256 * 256 * 256; divise > 0; divise /= 256)
+                decoded.push_back(accumulator / divise % 256);
+
+            accumulator = 0;
+        }
+    }
+
+    out.assign(decoded.begin(), decoded.end());
+    BITCOIN_ASSERT(out.size() == decoded_size);
+    return true;
+}
+
+} // namespace libbitcoin

--- a/src/formats/base85.cpp
+++ b/src/formats/base85.cpp
@@ -125,7 +125,6 @@ bool decode_base85(data_chunk& out, const std::string& in)
     if (length % 5 != 0)
         return false;
 
-    constexpr uint8_t shift = 32;
     const size_t decoded_size = length * 4 / 5;
     data_chunk decoded;
     decoded.reserve(decoded_size);
@@ -134,8 +133,8 @@ bool decode_base85(data_chunk& out, const std::string& in)
 
     for (const uint8_t encoded_character: in)
     {
-        const auto position = encoded_character - shift;
-        if (position < 0 || position > sizeof(decoder))
+        const auto position = encoded_character - 32;
+        if (position < 0 || position > 96)
             return false;
 
         accumulator = accumulator * 85 + decoder[position];

--- a/test/base85.cpp
+++ b/test/base85.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2011-2014 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin-client.
+ *
+ * libbitcoin-client is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test_suite.hpp>
+#include <bitcoin/bitcoin.hpp>
+
+using namespace bc;
+
+BOOST_AUTO_TEST_SUITE(base85_tests)
+
+#define BASE85_ENCODED "HelloWorld"
+#define BASE85_DECODED \
+{ \
+    0x86, 0x4F, 0xD2, 0x6F, 0xB5, 0x59, 0xF7, 0x5B \
+}
+
+#define BASE85_ENCODED_INVALID_CHAR "Test\n"
+#define BASE85_ENCODED_INVALID_LENGTH "Hello World"
+#define BASE85_DECODED_INVALID \
+{ \
+    0x86, 0x4F, 0xD2, 0x6F, 0xB5, 0x59, 0xF7, 0x5B, 0x42 \
+}
+
+BOOST_AUTO_TEST_CASE(encode_base85_empty_test)
+{
+    std::string encoded;
+    BOOST_REQUIRE(encode_base85(encoded, data_chunk()));
+    BOOST_REQUIRE(encoded.empty());
+}
+
+BOOST_AUTO_TEST_CASE(decode_base85_empty_test)
+{
+    data_chunk result;
+    BOOST_REQUIRE(decode_base85(result, ""));
+    BOOST_REQUIRE(result.empty());
+}
+
+BOOST_AUTO_TEST_CASE(encode_base85_valid_test)
+{
+    std::string encoded;
+    data_chunk decoded(BASE85_DECODED);
+    BOOST_REQUIRE(encode_base85(encoded, decoded));
+    BOOST_REQUIRE_EQUAL(encoded, BASE85_ENCODED);
+}
+
+BOOST_AUTO_TEST_CASE(encode_base85_invalid_test)
+{
+    std::string encoded;
+    data_chunk decoded(BASE85_DECODED_INVALID);
+    BOOST_REQUIRE(!encode_base85(encoded, decoded));
+    BOOST_REQUIRE(encoded.empty());
+}
+
+BOOST_AUTO_TEST_CASE(decode_base85_valid_test)
+{
+    data_chunk result;
+    BOOST_REQUIRE(decode_base85(result, BASE85_ENCODED));
+    BOOST_REQUIRE(result == data_chunk(BASE85_DECODED));
+}
+
+BOOST_AUTO_TEST_CASE(decode_base85_invalid_char_test)
+{
+    data_chunk result;
+    BOOST_REQUIRE(!decode_base85(result, BASE85_ENCODED_INVALID_CHAR));
+    BOOST_REQUIRE(result.empty());
+}
+
+BOOST_AUTO_TEST_CASE(decode_base85_invalid_length_test)
+{
+    data_chunk result;
+    BOOST_REQUIRE(!decode_base85(result, BASE85_ENCODED_INVALID_LENGTH));
+    BOOST_REQUIRE(result.empty());
+}
+
+// The semicolon is not in the Z85 alphabet, and such characters are treated as
+// valid but with zero value in the reference implementation.
+BOOST_AUTO_TEST_CASE(decode_base85_outside_alphabet_test)
+{
+    data_chunk result;
+    BOOST_REQUIRE(decode_base85(result, ";;;;;"));
+    BOOST_REQUIRE(result == data_chunk({ 0, 0, 0, 0 }));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is the native format for CurveZMQ certificates, which we use in server and bx.