### PR TITLE
Correct default parameter behavior on get_substring

### DIFF
--- a/src/utility/binary.cpp
+++ b/src/utility/binary.cpp
@@ -191,7 +191,7 @@ binary_type binary_type::get_substring(size_type start, size_type length) const
         start = size_;
     }
 
-    if ((start + length) > size_)
+    if ((length == SIZE_MAX) || ((start + length) > size_))
     {
         length = size_ - start;
     }

--- a/test/binary.cpp
+++ b/test/binary.cpp
@@ -22,31 +22,24 @@
 
 using namespace bc;
 
-static void require_equal(binary_type::size_type expected_size,
-    data_chunk& expected_blocks, binary_type& instance)
+static void require_equal(binary_type& expected, binary_type& instance)
 {
-//    BOOST_CHECK_EQUAL_COLLECTIONS(
-//        instance.blocks().begin(), instance.blocks().end(),
-//        expected_blocks.begin(), expected_blocks.end());
-
-    BOOST_REQUIRE(instance.size() == expected_size);
-    BOOST_REQUIRE(instance.blocks().size() == expected_blocks.size());
-
-    for (binary_type::size_type i = 0; i < expected_blocks.size(); i++)
-    {
-        uint8_t value = instance.blocks()[i];
-        uint8_t expected = expected_blocks[i];
-
-        if (value != expected)
-        {
-            // printf("item: %02u\n", i);
-            std::cout << "item: " << i << std::endl;
-            printf("value: 0x%02x\n", value);
-            printf("expected:0x%02x\n", expected);
-        }
-
-        BOOST_REQUIRE(value == expected);
-    }
+//    for (binary_type::size_type i = 0; i < expected.blocks().size(); i++)
+//    {
+//        uint8_t value = instance.blocks()[i];
+//        uint8_t expected_value = expected.blocks()[i];
+//
+//        if (value != expected_value)
+//        {
+//            // printf("item: %02u\n", i);
+//            std::cout << "item: " << i << std::endl;
+//            printf("value: 0x%02x\n", value);
+//            printf("expected:0x%02x\n", expected_value);
+//        }
+//
+//        BOOST_REQUIRE(value == expected_value);
+//    }
+    BOOST_REQUIRE(instance == expected);
 }
 
 BOOST_AUTO_TEST_SUITE(binary_type_tests)
@@ -57,171 +50,121 @@ BOOST_AUTO_TEST_SUITE(binary_type_tests)
 BOOST_AUTO_TEST_CASE(shift_left_by_zero)
 {
     binary_type::size_type distance = 0;
+    binary_type instance(16, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 16;
-
-    data_chunk expected_blocks = { 0xAA, 0xAA };
-    binary_type::size_type expected_size = 16;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(16, data_chunk { 0xAA, 0xAA });
 
     instance.shift_left(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_left_alternate_initial)
 {
     binary_type::size_type distance = 16;
+    binary_type instance(24, data_chunk { 0xAB, 0xCD, 0xEF });
 
-    data_chunk initial_blocks = { 0xAB, 0xCD, 0xEF };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0xEF };
-    binary_type::size_type expected_size = 8;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(8, data_chunk { 0xEF });
 
     instance.shift_left(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_left_by_less_than_byte)
 {
     binary_type::size_type distance = 5;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0x55, 0x55, 0x40};
-    binary_type::size_type expected_size = 19;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(19, data_chunk { 0x55, 0x55, 0x40});
 
     instance.shift_left(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_left_by_less_than_byte_to_byte_align)
 {
     binary_type::size_type distance = 5;
+    binary_type instance(21, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 21;
-
-    data_chunk expected_blocks = { 0x55, 0x55 };
-    binary_type::size_type expected_size = 16;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(16, data_chunk { 0x55, 0x55 });
 
     instance.shift_left(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_left_by_byte_single)
 {
     binary_type::size_type distance = 8;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0xAA, 0xAA };
-    binary_type::size_type expected_size = 16;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(16, data_chunk { 0xAA, 0xAA });
 
     instance.shift_left(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_left_by_greater_than_byte)
 {
     binary_type::size_type distance = 13;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0x55, 0x40 };
-    binary_type::size_type expected_size = 11;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(11, data_chunk { 0x55, 0x40 });
 
     instance.shift_left(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_left_by_greater_than_byte_not_initially_aligned)
 {
     binary_type::size_type distance = 13;
+    binary_type instance(18, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 18;
-
-    data_chunk expected_blocks = { 0x50 };
-    binary_type::size_type expected_size = 5;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(5, data_chunk { 0x50 });
 
     instance.shift_left(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_left_by_byte_multiple)
 {
     binary_type::size_type distance = 16;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0xAA };
-    binary_type::size_type expected_size = 8;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(8, data_chunk { 0xAA });
 
     instance.shift_left(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_left_by_size)
 {
     binary_type::size_type distance = 24;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { };
-    binary_type::size_type expected_size = 0;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(0, data_chunk { });
 
     instance.shift_left(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_left_by_greater_than_size)
 {
     binary_type::size_type distance = 30;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { };
-    binary_type::size_type expected_size = 0;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(0, data_chunk { });
 
     instance.shift_left(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 //
@@ -229,156 +172,110 @@ BOOST_AUTO_TEST_CASE(shift_left_by_greater_than_size)
 //
 BOOST_AUTO_TEST_CASE(shift_right_by_zero)
 {
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 16;
+    binary_type::size_type distance = 0;
+    binary_type instance(16, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk expected_blocks = { 0xAA, 0xAA };
-    binary_type::size_type expected_size = 16;
+    binary_type expected(16, data_chunk { 0xAA, 0xAA });
 
-    bc::binary_type instance(initial_size, initial_blocks);
+    instance.shift_right(distance);
 
-    instance.shift_right(0);
-
-    BOOST_REQUIRE(instance.size() == expected_size);
-    BOOST_REQUIRE(instance.blocks().size() == expected_blocks.size());
-
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_right_by_less_than_byte)
 {
     binary_type::size_type distance = 5;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0x05, 0x55, 0x55, 0x50};
-    binary_type::size_type expected_size = 29;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(29, data_chunk { 0x05, 0x55, 0x55, 0x50});
 
     instance.shift_right(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_right_by_less_than_byte_to_byte_align)
 {
     binary_type::size_type distance = 3;
+    binary_type instance(21, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 21;
-
-    data_chunk expected_blocks = { 0x15, 0x55, 0x55 };
-    binary_type::size_type expected_size = 24;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(24, data_chunk { 0x15, 0x55, 0x55 });
 
     instance.shift_right(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_right_by_byte_single)
 {
     binary_type::size_type distance = 8;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0x00, 0xAA, 0xAA, 0xAA };
-    binary_type::size_type expected_size = 32;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(32, data_chunk { 0x00, 0xAA, 0xAA, 0xAA });
 
     instance.shift_right(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_right_by_greater_than_byte)
 {
     binary_type::size_type distance = 13;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0x00, 0x05, 0x55, 0x55, 0x50 };
-    binary_type::size_type expected_size = 37;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(37, data_chunk { 0x00, 0x05, 0x55, 0x55, 0x50 });
 
     instance.shift_right(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_right_by_greater_than_byte_not_initially_aligned)
 {
     binary_type::size_type distance = 13;
+    binary_type instance(18, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 18;
-
-    data_chunk expected_blocks = { 0x00, 0x05, 0x55, 0x54 };
-    binary_type::size_type expected_size = 31;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(31, data_chunk { 0x00, 0x05, 0x55, 0x54 });
 
     instance.shift_right(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_right_by_byte_multiple)
 {
     binary_type::size_type distance = 16;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0x00, 0x00, 0xAA, 0xAA, 0xAA };
-    binary_type::size_type expected_size = 40;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(40, data_chunk { 0x00, 0x00, 0xAA, 0xAA, 0xAA });
 
     instance.shift_right(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_right_by_size)
 {
     binary_type::size_type distance = 24;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0x00, 0x00, 0x00, 0xAA, 0xAA, 0xAA };
-    binary_type::size_type expected_size = 48;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(48, data_chunk { 0x00, 0x00, 0x00, 0xAA, 0xAA, 0xAA });
 
     instance.shift_right(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(shift_right_by_greater_than_size)
 {
     binary_type::size_type distance = 30;
+    binary_type instance(24, data_chunk { 0xAA, 0xAA, 0xAA });
 
-    data_chunk initial_blocks = { 0xAA, 0xAA, 0xAA };
-    binary_type::size_type initial_size = 24;
-
-    data_chunk expected_blocks = { 0x00, 0x00, 0x00, 0x02, 0xAA, 0xAA, 0xA8 };
-    binary_type::size_type expected_size = 54;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(54, data_chunk { 0x00, 0x00, 0x00, 0x02, 0xAA, 0xAA, 0xA8 });
 
     instance.shift_right(distance);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 //
@@ -386,78 +283,50 @@ BOOST_AUTO_TEST_CASE(shift_right_by_greater_than_size)
 //
 BOOST_AUTO_TEST_CASE(append_to_zero_length)
 {
-    data_chunk initial_blocks = { 0x00 };
-    binary_type::size_type initial_size = 0;
+    binary_type instance(0, data_chunk { 0x00 });
+    binary_type augment(24, data_chunk { 0xAA, 0xBB, 0xCC });
 
-    data_chunk appended_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type appended_size = 24;
-    bc::binary_type augment(appended_size, appended_blocks);
-
-    data_chunk expected_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type expected_size = 24;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(24, data_chunk { 0xAA, 0xBB, 0xCC });
 
     instance.append(augment);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(append_zero_length_to_content)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 24;
+    binary_type instance(24, data_chunk { 0xAA, 0xBB, 0xCC });
+    binary_type augment(0, data_chunk { });
 
-    data_chunk appended_blocks = { };
-    binary_type::size_type appended_size = 0;
-    bc::binary_type augment(appended_size, appended_blocks);
-
-    data_chunk expected_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type expected_size = 24;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(24, data_chunk { 0xAA, 0xBB, 0xCC });
 
     instance.append(augment);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(append_byte_aligned_instances)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 24;
+    binary_type instance(24, data_chunk { 0xAA, 0xBB, 0xCC });
+    binary_type augment(24, data_chunk { 0xDD, 0xEE, 0xFF });
 
-    data_chunk appended_blocks = { 0xDD, 0xEE, 0xFF };
-    binary_type::size_type appended_size = 24;
-    bc::binary_type augment(appended_size, appended_blocks);
-
-    data_chunk expected_blocks = { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
-    binary_type::size_type expected_size = 48;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(48, data_chunk { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF });
 
     instance.append(augment);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(append_byte_nonaligned_instances)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 20;
+    binary_type instance(20, data_chunk { 0xAA, 0xBB, 0xCC });
+    binary_type augment(13, data_chunk { 0xDD, 0xEE });
 
-    data_chunk appended_blocks = { 0xDD, 0xEE };
-    binary_type::size_type appended_size = 13;
-    bc::binary_type augment(appended_size, appended_blocks);
-
-    data_chunk expected_blocks = { 0xAA, 0xBB, 0xCD, 0xDE, 0x80 };
-    binary_type::size_type expected_size = 33;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(33, data_chunk { 0xAA, 0xBB, 0xCD, 0xDE, 0x80 });
 
     instance.append(augment);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 //
@@ -465,78 +334,50 @@ BOOST_AUTO_TEST_CASE(append_byte_nonaligned_instances)
 //
 BOOST_AUTO_TEST_CASE(prepend_to_zero_length)
 {
-    data_chunk initial_blocks = { 0x00 };
-    binary_type::size_type initial_size = 0;
+    binary_type instance(0, data_chunk { 0x00 });
+    binary_type augment(24, data_chunk { 0xAA, 0xBB, 0xCC });
 
-    data_chunk appended_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type appended_size = 24;
-    bc::binary_type augment(appended_size, appended_blocks);
-
-    data_chunk expected_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type expected_size = 24;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(24, data_chunk { 0xAA, 0xBB, 0xCC });
 
     instance.prepend(augment);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(prepend_zero_length_to_content)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 24;
+    binary_type instance(24, data_chunk { 0xAA, 0xBB, 0xCC });
+    binary_type augment(0, data_chunk { });
 
-    data_chunk appended_blocks = { };
-    binary_type::size_type appended_size = 0;
-    bc::binary_type augment(appended_size, appended_blocks);
-
-    data_chunk expected_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type expected_size = 24;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(24, data_chunk { 0xAA, 0xBB, 0xCC });
 
     instance.prepend(augment);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(prepend_byte_aligned_instances)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 24;
+    binary_type instance(24, data_chunk { 0xAA, 0xBB, 0xCC });
+    binary_type augment(24, data_chunk { 0xDD, 0xEE, 0xFF });
 
-    data_chunk appended_blocks = { 0xDD, 0xEE, 0xFF };
-    binary_type::size_type appended_size = 24;
-    bc::binary_type augment(appended_size, appended_blocks);
-
-    data_chunk expected_blocks = { 0xDD, 0xEE, 0xFF, 0xAA, 0xBB, 0xCC };
-    binary_type::size_type expected_size = 48;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(48, data_chunk { 0xDD, 0xEE, 0xFF, 0xAA, 0xBB, 0xCC });
 
     instance.prepend(augment);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 BOOST_AUTO_TEST_CASE(prepend_byte_nonaligned_instances)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 20;
+    binary_type instance(20, data_chunk { 0xAA, 0xBB, 0xCC });
+    binary_type augment(13, data_chunk { 0xDD, 0xEE });
 
-    data_chunk appended_blocks = { 0xDD, 0xEE };
-    binary_type::size_type appended_size = 13;
-    bc::binary_type augment(appended_size, appended_blocks);
-
-    data_chunk expected_blocks = { 0xDD, 0xED, 0x55, 0xDE, 0x00 };
-    binary_type::size_type expected_size = 33;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(33, data_chunk { 0xDD, 0xED, 0x55, 0xDE, 0x00 });
 
     instance.prepend(augment);
 
-    require_equal(expected_size, expected_blocks, instance);
+    require_equal(expected, instance);
 }
 
 //
@@ -544,92 +385,79 @@ BOOST_AUTO_TEST_CASE(prepend_byte_nonaligned_instances)
 //
 BOOST_AUTO_TEST_CASE(get_substring_start_after_end)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 20;
-
+    binary_type instance(20, data_chunk { 0xAA, 0xBB, 0xCC });
     binary_type::size_type start = 21;
     binary_type::size_type length = 10;
 
-    data_chunk expected_blocks = {};
-    binary_type::size_type expected_size = 0;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(0, data_chunk {});
 
     binary_type result = instance.get_substring(start, length);
 
-    require_equal(expected_size, expected_blocks, result);
+    require_equal(expected, result);
 }
 
 BOOST_AUTO_TEST_CASE(get_substring_length_zero)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 20;
-
+    binary_type instance(20, data_chunk { 0xAA, 0xBB, 0xCC });
     binary_type::size_type start = 5;
     binary_type::size_type length = 0;
 
-    data_chunk expected_blocks = {};
-    binary_type::size_type expected_size = 0;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(0, data_chunk {});
 
     binary_type result = instance.get_substring(start, length);
 
-    require_equal(expected_size, expected_blocks, result);
+    require_equal(expected, result);
 }
 
 BOOST_AUTO_TEST_CASE(get_substring_byte_aligned_start)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 20;
-
+    binary_type instance(20, data_chunk { 0xAA, 0xBB, 0xCC });
     binary_type::size_type start = 8;
     binary_type::size_type length = 10;
 
-    data_chunk expected_blocks = { 0xBB, 0xC0 };
-    binary_type::size_type expected_size = 10;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(10, data_chunk { 0xBB, 0xC0 });
 
     binary_type result = instance.get_substring(start, length);
 
-    require_equal(expected_size, expected_blocks, result);
+    require_equal(expected, result);
 }
 
 BOOST_AUTO_TEST_CASE(get_substring_byte_nonaligned_start)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 20;
-
+    binary_type instance(20, data_chunk { 0xAA, 0xBB, 0xCC });
     binary_type::size_type start = 10;
     binary_type::size_type length = 10;
 
-    data_chunk expected_blocks = { 0xEF, 0x00 };
-    binary_type::size_type expected_size = 10;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(10, data_chunk { 0xEF, 0x00 });
 
     binary_type result = instance.get_substring(start, length);
 
-    require_equal(expected_size, expected_blocks, result);
+    require_equal(expected, result);
 }
 
 BOOST_AUTO_TEST_CASE(get_substring_request_exceeds_string)
 {
-    data_chunk initial_blocks = { 0xAA, 0xBB, 0xCC };
-    binary_type::size_type initial_size = 20;
-
+    binary_type instance(20, data_chunk { 0xAA, 0xBB, 0xCC });
     binary_type::size_type start = 10;
     binary_type::size_type length = 15;
 
-    data_chunk expected_blocks = { 0xEF, 0x00 };
-    binary_type::size_type expected_size = 10;
-
-    bc::binary_type instance(initial_size, initial_blocks);
+    binary_type expected(10, data_chunk { 0xEF, 0x00 });
 
     binary_type result = instance.get_substring(start, length);
 
-    require_equal(expected_size, expected_blocks, result);
+    require_equal(expected, result);
+}
+
+BOOST_AUTO_TEST_CASE(get_substring_implicit_length)
+{
+    binary_type instance(20, data_chunk { 0xAA, 0xBB, 0xCC });
+    binary_type::size_type start = 10;
+
+    binary_type expected(10, data_chunk { 0xEF, 0x00 });
+
+    binary_type result = instance.get_substring(start);
+
+    require_equal(expected, result);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Additionally, added test for validation.