### PR TITLE
Mnemonic clean-up, second try

### DIFF
--- a/include/bitcoin/bitcoin/math/hash.hpp
+++ b/include/bitcoin/bitcoin/math/hash.hpp
@@ -101,8 +101,8 @@ BC_API long_hash hmac_sha512_hash(data_slice data, data_slice key);
  *
  * pkcs5_pbkdf2_hmac_sha512(passphrase, salt, iterations)
  */
-BC_API bool pkcs5_pbkdf2_hmac_sha512(const std::string& passphrase,
-    data_slice salt, size_t iterations, long_hash& long_hash);
+BC_API long_hash pkcs5_pbkdf2_hmac_sha512(data_slice passphrase,
+    data_slice salt, size_t iterations);
 
 /**
  * Generate a typical bitcoin hash. This is the most widely used

--- a/include/bitcoin/bitcoin/wallet/dictionary.hpp
+++ b/include/bitcoin/bitcoin/wallet/dictionary.hpp
@@ -25,7 +25,6 @@
 #include <bitcoin/bitcoin/compat.hpp>
 
 namespace libbitcoin {
-namespace bip39 {
 
 /**
  * A valid mnemonic wordlist has exactly this many words.
@@ -57,7 +56,6 @@ namespace language
     extern const wordlist_list all;
 }
 
-} // namespace bip39
 } // namespace libbitcoin
 
 #endif

--- a/include/bitcoin/bitcoin/wallet/dictionary.hpp
+++ b/include/bitcoin/bitcoin/wallet/dictionary.hpp
@@ -27,33 +27,34 @@
 namespace libbitcoin {
 
 /**
- * A valid mnemonic wordlist has exactly this many words.
+ * A valid mnemonic dictionary has exactly this many words.
  */
-BC_CONSTEXPR size_t wordlist_size = 2048;
+BC_CONSTEXPR size_t dictionary_size = 2048;
 
 /**
- * A "wordlist" for creating mnemonics, as defined in bip39.
+ * A dictionary for creating mnemonics.
+ * The bip39 spec calls this a "wordlist".
  * This is a POD type, which means the compiler can write it directly
  * to static memory with no run-time overhead.
  */
-typedef std::array<const char*, wordlist_size> wordlist;
+typedef std::array<const char*, dictionary_size> dictionary;
 
 /**
- * A collection of candidate wordlists for mnemonic validation.
+ * A collection of candidate dictionaries for mnemonic validation.
  */
-typedef std::vector<const wordlist*> wordlist_list;
+typedef std::vector<const dictionary*> dictionary_list;
 
 namespace language
 {
     // Individual built-in languages:
-    extern const wordlist en;
-    extern const wordlist es;
-    extern const wordlist ja;
-    extern const wordlist zh_Hans;
-    extern const wordlist zh_Hant;
+    extern const dictionary en;
+    extern const dictionary es;
+    extern const dictionary ja;
+    extern const dictionary zh_Hans;
+    extern const dictionary zh_Hant;
 
     // All built-in languages:
-    extern const wordlist_list all;
+    extern const dictionary_list all;
 }
 
 } // namespace libbitcoin

--- a/include/bitcoin/bitcoin/wallet/dictionary.hpp
+++ b/include/bitcoin/bitcoin/wallet/dictionary.hpp
@@ -21,7 +21,7 @@
 #define LIBBITCOIN_DICTIONARY_HPP
 
 #include <array>
-#include <map>
+#include <vector>
 #include <bitcoin/bitcoin/compat.hpp>
 
 namespace libbitcoin {
@@ -35,34 +35,27 @@ BC_CONSTEXPR size_t wordlist_size = 2048;
 /**
  * A "wordlist" for creating mnemonics, as defined in bip39.
  * This is a POD type, which means the compiler can write it directly
- * to static memory no run-time overhead.
+ * to static memory with no run-time overhead.
  */
 typedef std::array<const char*, wordlist_size> wordlist;
 
 /**
- * Dictionary languages.
+ * A collection of candidate wordlists for mnemonic validation.
  */
-enum class language
+typedef std::vector<const wordlist*> wordlist_list;
+
+namespace language
 {
-    en,
-    es,
-    ja,
-    zh_Hans,
-    zh_Hant,
-    unknown
-};
+    // Individual built-in languages:
+    extern const wordlist en;
+    extern const wordlist es;
+    extern const wordlist ja;
+    extern const wordlist zh_Hans;
+    extern const wordlist zh_Hant;
 
-/**
- * Multilingual word dictionary type.
- * It references the wordlists by pointer,
- * allowing them to live in static memory.
- */
-typedef std::map<language, const wordlist*> dictionary_type;
-
-/**
- * Multilingual word dictionary.
- */
-extern const dictionary_type dictionary;
+    // All built-in languages:
+    extern const wordlist_list all;
+}
 
 } // namespace bip39
 } // namespace libbitcoin

--- a/include/bitcoin/bitcoin/wallet/mnemonic.hpp
+++ b/include/bitcoin/bitcoin/wallet/mnemonic.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <bitcoin/bitcoin/compat.hpp>
 #include <bitcoin/bitcoin/define.hpp>
+#include <bitcoin/bitcoin/math/hash.hpp>
 #include <bitcoin/bitcoin/utility/data.hpp>
 #include <bitcoin/bitcoin/wallet/dictionary.hpp>
 
@@ -64,13 +65,19 @@ BC_API string_list create_mnemonic(data_slice entropy,
     bip39::language language=bip39::language::en);
 
 /**
- * Convert a mnemonic and optional passphrase to a seed for use in seeding
- * wallet creation. The words must have been created using mnemonic encoding.
+ * Checks a mnemonic against a list of languages to determine if the
+ * words are spelled correctly and the checksum matches.
+ * The words must have been created using mnemonic encoding.
+ */
+BC_API bool validate_mnemonic(const string_list& mnemonic,
+    bip39::language language=bip39::language::unknown);
+
+/**
+ * Convert a mnemonic and optional passphrase to a wallet-generation seed.
  * Any passphrase can be used and will change the resulting seed.
  */
-BC_API data_chunk decode_mnemonic(const string_list& mnemonic,
-    const std::string& passphrase="",
-    bip39::language language=bip39::language::unknown);
+BC_API long_hash decode_mnemonic(const string_list& mnemonic,
+    const std::string& passphrase="");
 
 } // namespace bip39
 } // namespace libbitcoin

--- a/include/bitcoin/bitcoin/wallet/mnemonic.hpp
+++ b/include/bitcoin/bitcoin/wallet/mnemonic.hpp
@@ -50,21 +50,21 @@ typedef std::vector<std::string> string_list;
  * creation. Entropy byte count must be evenly divisible by 4.
  */
 BC_API string_list create_mnemonic(data_slice entropy,
-    const wordlist &dictionary=language::en);
+    const dictionary &lexicon=language::en);
 
 /**
- * Checks a mnemonic against a wordlist to determine if the
+ * Checks a mnemonic against a dictionary to determine if the
  * words are spelled correctly and the checksum matches.
  * The words must have been created using mnemonic encoding.
  */
 BC_API bool validate_mnemonic(const string_list& mnemonic,
-    const wordlist &dictionary);
+    const dictionary &lexicon);
 
 /**
  * Checks that a mnemonic is valid in at least one of the provided languages.
  */
 BC_API bool validate_mnemonic(const string_list& mnemonic,
-    const wordlist_list& dictionaries=language::all);
+    const dictionary_list& lexicons=language::all);
 
 /**
  * Convert a mnemonic and optional passphrase to a wallet-generation seed.

--- a/include/bitcoin/bitcoin/wallet/mnemonic.hpp
+++ b/include/bitcoin/bitcoin/wallet/mnemonic.hpp
@@ -28,17 +28,16 @@
 #include <bitcoin/bitcoin/wallet/dictionary.hpp>
 
 namespace libbitcoin {
-namespace bip39 {
 
 /**
  * A valid mnemonic word count is evenly divisible by this number.
  */
-BC_CONSTEXPR size_t word_multiple = 3;
+BC_CONSTEXPR size_t mnemonic_word_multiple = 3;
 
 /**
  * A valid seed byte count is evenly divisible by this number.
  */
-BC_CONSTEXPR size_t seed_multiple = 4;
+BC_CONSTEXPR size_t mnemonic_seed_multiple = 4;
 
 /**
  * Represents a mnemonic.
@@ -74,7 +73,6 @@ BC_API bool validate_mnemonic(const string_list& mnemonic,
 BC_API long_hash decode_mnemonic(const string_list& mnemonic,
     const std::string& passphrase="");
 
-} // namespace bip39
 } // namespace libbitcoin
 
 #endif

--- a/include/bitcoin/bitcoin/wallet/mnemonic.hpp
+++ b/include/bitcoin/bitcoin/wallet/mnemonic.hpp
@@ -21,7 +21,6 @@
 #define LIBBITCOIN_MNEMONIC_HPP
 
 #include <string>
-#include <vector>
 #include <bitcoin/bitcoin/compat.hpp>
 #include <bitcoin/bitcoin/define.hpp>
 #include <bitcoin/bitcoin/math/hash.hpp>
@@ -52,15 +51,21 @@ typedef std::vector<std::string> string_list;
  * creation. Entropy byte count must be evenly divisible by 4.
  */
 BC_API string_list create_mnemonic(data_slice entropy,
-    bip39::language language=bip39::language::en);
+    const wordlist &dictionary=language::en);
 
 /**
- * Checks a mnemonic against a list of languages to determine if the
+ * Checks a mnemonic against a wordlist to determine if the
  * words are spelled correctly and the checksum matches.
  * The words must have been created using mnemonic encoding.
  */
 BC_API bool validate_mnemonic(const string_list& mnemonic,
-    bip39::language language=bip39::language::unknown);
+    const wordlist &dictionary);
+
+/**
+ * Checks that a mnemonic is valid in at least one of the provided languages.
+ */
+BC_API bool validate_mnemonic(const string_list& mnemonic,
+    const wordlist_list& dictionaries=language::all);
 
 /**
  * Convert a mnemonic and optional passphrase to a wallet-generation seed.

--- a/include/bitcoin/bitcoin/wallet/mnemonic.hpp
+++ b/include/bitcoin/bitcoin/wallet/mnemonic.hpp
@@ -42,16 +42,6 @@ BC_CONSTEXPR size_t word_multiple = 3;
 BC_CONSTEXPR size_t seed_multiple = 4;
 
 /**
- * A valid mnemonic has at least this many words.
- */
-BC_CONSTEXPR size_t min_word_count = 12;
-
-/**
- * A valid mnemonic has no more than this many words.
- */
-BC_CONSTEXPR size_t max_word_count = 128;
-
-/**
  * Represents a mnemonic.
  */
 typedef std::vector<std::string> string_list;
@@ -59,7 +49,7 @@ typedef std::vector<std::string> string_list;
 /**
  * Create a new mnenomic (list of words) from provided entropy and a dictionary
  * selection. The mnemonic can later be converted to a seed for use in wallet
- * creation. Entropy byte count must be evenly divisible by 3.
+ * creation. Entropy byte count must be evenly divisible by 4.
  */
 BC_API string_list create_mnemonic(data_slice entropy,
     bip39::language language=bip39::language::en);

--- a/src/math/external/pkcs5_pbkdf2.c
+++ b/src/math/external/pkcs5_pbkdf2.c
@@ -34,12 +34,12 @@ int pkcs5_pbkdf2(const uint8_t* passphrase, size_t passphrase_length,
     uint8_t digest1[HMACSHA512_DIGEST_LENGTH];
     uint8_t digest2[HMACSHA512_DIGEST_LENGTH];
 
-    if (iterations == 0 || key_length == 0)
-        return -1;
+    /* An iteration count of 0 is equivalent to a count of 1. */
+    /* A key_length of 0 is a no-op. */
+    /* A salt_length of 0 is perfectly valid. */
 
-    if (salt_length == 0 || salt_length > SIZE_MAX - 4)
+    if (salt_length > SIZE_MAX - 4)
         return -1;
-
     asalt_size = salt_length + 4;
     asalt = malloc(asalt_size);
     if (asalt == NULL)

--- a/src/math/external/pkcs5_pbkdf2.h
+++ b/src/math/external/pkcs5_pbkdf2.h
@@ -22,7 +22,7 @@
 #include "pkcs5_pbkdf2.h"
 
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 {
 #endif
 

--- a/src/math/hash.cpp
+++ b/src/math/hash.cpp
@@ -20,6 +20,7 @@
 #include <bitcoin/bitcoin/math/hash.hpp>
 
 #include <algorithm>
+#include <new>
 #include "../math/external/hmac_sha256.h"
 #include "../math/external/hmac_sha512.h"
 #include "../math/external/pkcs5_pbkdf2.h"
@@ -87,13 +88,14 @@ long_hash hmac_sha512_hash(data_slice data, data_slice key)
     return hash;
 }
 
-bool pkcs5_pbkdf2_hmac_sha512(const std::string& passphrase, 
-    data_slice salt, size_t iterations, long_hash& long_hash)
+long_hash pkcs5_pbkdf2_hmac_sha512(data_slice passphrase,
+    data_slice salt, size_t iterations)
 {
-    const auto passphrase_bytes = to_data_chunk(passphrase);
-    return pkcs5_pbkdf2(&passphrase_bytes[0], passphrase_bytes.size(),
-        salt.data(), salt.size(), long_hash.data(), sizeof(long_hash),
-        iterations) == 0;
+    long_hash hash;
+    if (pkcs5_pbkdf2(passphrase.data(), passphrase.size(),
+        salt.data(), salt.size(), hash.data(), hash.size(), iterations))
+        throw std::bad_alloc();
+    return hash;
 }
 
 hash_digest bitcoin_hash(data_slice data)

--- a/src/wallet/dictionary.cpp
+++ b/src/wallet/dictionary.cpp
@@ -21,8 +21,9 @@
 
 namespace libbitcoin {
 namespace bip39 {
+namespace language {
 
-static const wordlist wordlist_en =
+const wordlist en =
 {
     {
         "abandon",
@@ -2076,7 +2077,7 @@ static const wordlist wordlist_en =
     }
 };
 
-static const wordlist wordlist_es =
+const wordlist es =
 {
     {
         "ábaco",
@@ -4130,7 +4131,7 @@ static const wordlist wordlist_es =
     }
 };
 
-static const wordlist wordlist_ja =
+const wordlist ja =
 {
     {
         "あいこくしん",
@@ -6184,7 +6185,7 @@ static const wordlist wordlist_ja =
     }
 };
 
-static const wordlist wordlist_zh_Hans =
+const wordlist zh_Hans =
 {
     {
         "的",
@@ -8238,7 +8239,7 @@ static const wordlist wordlist_zh_Hans =
     }
 };
 
-static const wordlist wordlist_zh_Hant =
+const wordlist zh_Hant =
 {
     {
         "的",
@@ -10294,24 +10295,15 @@ static const wordlist wordlist_zh_Hant =
 
 // Word lists from:
 // github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md
-const dictionary_type dictionary
+const wordlist_list all
 {
-    {
-        {language::en}, &wordlist_en
-    },
-    {
-        {language::es}, &wordlist_es
-    },
-    {
-        {language::ja}, &wordlist_ja
-    },
-    {
-        {language::zh_Hans}, &wordlist_zh_Hans
-    },
-    {
-        {language::zh_Hant}, &wordlist_zh_Hant
-    }
+    &en,
+    &es,
+    &ja,
+    &zh_Hans,
+    &zh_Hant,
 };
 
+} // namespace language
 } // namespace bip39
 } // namespace libbitcoin

--- a/src/wallet/dictionary.cpp
+++ b/src/wallet/dictionary.cpp
@@ -20,7 +20,6 @@
 #include <bitcoin/bitcoin/wallet/dictionary.hpp>
 
 namespace libbitcoin {
-namespace bip39 {
 namespace language {
 
 const wordlist en =
@@ -10305,5 +10304,4 @@ const wordlist_list all
 };
 
 } // namespace language
-} // namespace bip39
 } // namespace libbitcoin

--- a/src/wallet/dictionary.cpp
+++ b/src/wallet/dictionary.cpp
@@ -22,7 +22,7 @@
 namespace libbitcoin {
 namespace language {
 
-const wordlist en =
+const dictionary en =
 {
     {
         "abandon",
@@ -2076,7 +2076,7 @@ const wordlist en =
     }
 };
 
-const wordlist es =
+const dictionary es =
 {
     {
         "ábaco",
@@ -4130,7 +4130,7 @@ const wordlist es =
     }
 };
 
-const wordlist ja =
+const dictionary ja =
 {
     {
         "あいこくしん",
@@ -6184,7 +6184,7 @@ const wordlist ja =
     }
 };
 
-const wordlist zh_Hans =
+const dictionary zh_Hans =
 {
     {
         "的",
@@ -8238,7 +8238,7 @@ const wordlist zh_Hans =
     }
 };
 
-const wordlist zh_Hant =
+const dictionary zh_Hant =
 {
     {
         "的",
@@ -10294,7 +10294,7 @@ const wordlist zh_Hant =
 
 // Word lists from:
 // github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md
-const wordlist_list all
+const dictionary_list all
 {
     &en,
     &es,

--- a/src/wallet/mnemonic.cpp
+++ b/src/wallet/mnemonic.cpp
@@ -151,13 +151,9 @@ data_chunk decode_mnemonic(const string_list& mnemonic,
 
     const auto sentence = join(mnemonic);
     const auto salt = normalize_nfkd("mnemonic" + passphrase);
-    const auto salt_chunk = to_data_chunk(salt);
 
-    long_hash hash;
-    if (pkcs5_pbkdf2_hmac_sha512(sentence, salt_chunk, hmac_iterations, hash))
-        return to_data_chunk(hash);
-
-    return data_chunk();
+    return to_data_chunk(pkcs5_pbkdf2_hmac_sha512(
+        to_data_chunk(sentence), to_data_chunk(salt), hmac_iterations));
 }
 
 string_list create_mnemonic(data_slice entropy, bip39::language language)

--- a/src/wallet/mnemonic.cpp
+++ b/src/wallet/mnemonic.cpp
@@ -49,7 +49,7 @@ static std::string normalize_nfkd(const std::string& value)
     return normalize(value, norm_type::norm_nfkd, locale("UTF-8"));
 }
 
-bool validate_mnemonic(const string_list& words, const wordlist& dictionary)
+bool validate_mnemonic(const string_list& words, const dictionary& lexicon)
 {
     const auto word_count = words.size();
     if ((word_count % mnemonic_word_multiple) != 0)
@@ -66,7 +66,7 @@ bool validate_mnemonic(const string_list& words, const wordlist& dictionary)
 
     for (const auto& word: words)
     {
-        const auto position = find_position(dictionary, word);
+        const auto position = find_position(lexicon, word);
         if (position == -1)
             return false;
 
@@ -82,11 +82,11 @@ bool validate_mnemonic(const string_list& words, const wordlist& dictionary)
 
     data.resize(entropy_bits / byte_bits);
 
-    const auto mnemonic = create_mnemonic(data, dictionary);
+    const auto mnemonic = create_mnemonic(data, lexicon);
     return std::equal(mnemonic.begin(), mnemonic.end(), words.begin());
 }
 
-string_list create_mnemonic(data_slice entropy, const wordlist &dictionary)
+string_list create_mnemonic(data_slice entropy, const dictionary &lexicon)
 {
     if ((entropy.size() % mnemonic_seed_multiple) != 0)
         return string_list();
@@ -118,8 +118,8 @@ string_list create_mnemonic(data_slice entropy, const wordlist &dictionary)
                 position++;
         }
 
-        BITCOIN_ASSERT(position < wordlist_size);
-        words.push_back(dictionary[position]);
+        BITCOIN_ASSERT(position < dictionary_size);
+        words.push_back(lexicon[position]);
     }
 
     BITCOIN_ASSERT(words.size() == ((bit + 1) / bits_per_word));
@@ -127,9 +127,9 @@ string_list create_mnemonic(data_slice entropy, const wordlist &dictionary)
 }
 
 bool validate_mnemonic(const string_list& mnemonic,
-    const wordlist_list& dictionaries)
+    const dictionary_list& lexicons)
 {
-    for (const auto& i: dictionaries)
+    for (const auto& i: lexicons)
     {
         if (validate_mnemonic(mnemonic, *i))
             return true;

--- a/src/wallet/mnemonic.cpp
+++ b/src/wallet/mnemonic.cpp
@@ -31,7 +31,6 @@
 #include "../math/external/pkcs5_pbkdf2.h"
 
 namespace libbitcoin {
-namespace bip39 {
 
 // BIP-39 private constants.
 constexpr size_t bits_per_word = 11;
@@ -53,7 +52,7 @@ static std::string normalize_nfkd(const std::string& value)
 bool validate_mnemonic(const string_list& words, const wordlist& dictionary)
 {
     const auto word_count = words.size();
-    if ((word_count % word_multiple) != 0)
+    if ((word_count % mnemonic_word_multiple) != 0)
         return false;
 
     const auto total_bits = bits_per_word * word_count;
@@ -89,7 +88,7 @@ bool validate_mnemonic(const string_list& words, const wordlist& dictionary)
 
 string_list create_mnemonic(data_slice entropy, const wordlist &dictionary)
 {
-    if ((entropy.size() % seed_multiple) != 0)
+    if ((entropy.size() % mnemonic_seed_multiple) != 0)
         return string_list();
 
     const size_t entropy_bits = (entropy.size() * byte_bits);
@@ -98,7 +97,7 @@ string_list create_mnemonic(data_slice entropy, const wordlist &dictionary)
     const size_t word_count = (total_bits / bits_per_word);
 
     BITCOIN_ASSERT((total_bits % bits_per_word) == 0);
-    BITCOIN_ASSERT((word_count % word_multiple) == 0);
+    BITCOIN_ASSERT((word_count % mnemonic_word_multiple) == 0);
 
     const auto data = build_data({entropy, sha256_hash(entropy)});
 
@@ -148,6 +147,5 @@ long_hash decode_mnemonic(const string_list& mnemonic,
         to_data_chunk(sentence), to_data_chunk(salt), hmac_iterations);
 }
 
-} // namespace bip39
 } // namespace libbitcoin
 

--- a/test/hash.cpp
+++ b/test/hash.cpp
@@ -112,9 +112,9 @@ BOOST_AUTO_TEST_CASE(pkcs5_pbkdf2_hmac_sha512_test)
     for (const pkcs5_pbkdf2_hmac_sha512_result& result:
              pkcs5_pbkdf2_hmac_sha512_tests)
     {
-        long_hash hash;
-        BOOST_REQUIRE(pkcs5_pbkdf2_hmac_sha512(result.passphrase,
-            to_data_chunk(result.salt), result.iterations, hash));
+        auto hash = pkcs5_pbkdf2_hmac_sha512(
+            to_data_chunk(result.passphrase), to_data_chunk(result.salt),
+            result.iterations);
         BOOST_REQUIRE_EQUAL(encode_base16(hash), result.result);
     }
 }

--- a/test/mnemonic.cpp
+++ b/test/mnemonic.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(entropy_to_en_mnemonic)
     {
         data_chunk entropy;
         decode_base16(entropy, result.entropy);
-        const auto mnemonic = create_mnemonic(entropy, bip39::language::en);
+        const auto mnemonic = create_mnemonic(entropy, language::en);
         BOOST_REQUIRE(mnemonic.size() > 0);
         BOOST_REQUIRE_EQUAL(join(mnemonic), result.mnemonic);
         BOOST_REQUIRE(validate_mnemonic(mnemonic));
@@ -79,8 +79,8 @@ BOOST_AUTO_TEST_CASE(invalid_mnemonics)
 
 BOOST_AUTO_TEST_CASE(ensure_en_es_disjointness)
 {
-    const auto& english = *dictionary.at(language::en);
-    const auto& spanish = *dictionary.at(language::es);
+    const auto& english = language::en;
+    const auto& spanish = language::es;
     size_t intersection = 0;
     for (const auto es: spanish)
     {
@@ -95,8 +95,8 @@ BOOST_AUTO_TEST_CASE(ensure_en_es_disjointness)
 
 BOOST_AUTO_TEST_CASE(ensure_zh_Hans_Hant_intersection)
 {
-    const auto& simplified = *dictionary.at(language::zh_Hans);
-    const auto& traditional = *dictionary.at(language::zh_Hant);
+    const auto& simplified = language::zh_Hans;
+    const auto& traditional = language::zh_Hant;
     size_t intersection = 0;
     for (const auto hant: traditional)
     {

--- a/test/mnemonic.cpp
+++ b/test/mnemonic.cpp
@@ -36,6 +36,7 @@ BOOST_AUTO_TEST_CASE(entropy_to_en_mnemonic)
         const auto mnemonic = create_mnemonic(entropy, bip39::language::en);
         BOOST_REQUIRE(mnemonic.size() > 0);
         BOOST_REQUIRE_EQUAL(join(mnemonic), result.mnemonic);
+        BOOST_REQUIRE(validate_mnemonic(mnemonic));
     }
 }
 
@@ -45,8 +46,8 @@ BOOST_AUTO_TEST_CASE(en_mnemonic_to_seed)
     for (const mnemonic_result& result: mnemonic_bip39_vectors)
     {
         const auto words = split(result.mnemonic);
+        BOOST_REQUIRE(validate_mnemonic(words));
         const auto seed = decode_mnemonic(words, passphrase);
-        BOOST_REQUIRE(!seed.empty());
         BOOST_REQUIRE_EQUAL(encode_base16(seed), result.seed);
     }
 }

--- a/test/mnemonic.cpp
+++ b/test/mnemonic.cpp
@@ -23,7 +23,6 @@
 #include <bitcoin/bitcoin.hpp>
 
 using namespace bc;
-using namespace bc::bip39;
 
 BOOST_AUTO_TEST_SUITE(mnemonic_tests)
 

--- a/test/mnemonic.cpp
+++ b/test/mnemonic.cpp
@@ -52,6 +52,31 @@ BOOST_AUTO_TEST_CASE(en_mnemonic_to_seed)
     }
 }
 
+BOOST_AUTO_TEST_CASE(tiny_mnemonic)
+{
+    const data_chunk entropy(4, 0xa9);
+    const auto mnemonic = create_mnemonic(entropy);
+    BOOST_REQUIRE_EQUAL(mnemonic.size(), 3u);
+    BOOST_REQUIRE(validate_mnemonic(mnemonic));
+}
+
+BOOST_AUTO_TEST_CASE(giant_mnemonic)
+{
+    const data_chunk entropy(1024, 0xa9);
+    const auto mnemonic = create_mnemonic(entropy);
+    BOOST_REQUIRE_EQUAL(mnemonic.size(), 768u);
+    BOOST_REQUIRE(validate_mnemonic(mnemonic));
+}
+
+BOOST_AUTO_TEST_CASE(invalid_mnemonics)
+{
+    for (const auto& mnemonic: invalid_mnemonic_tests)
+    {
+        const auto words = split(mnemonic);
+        BOOST_REQUIRE(!validate_mnemonic(words));
+    }
+}
+
 BOOST_AUTO_TEST_CASE(ensure_en_es_disjointness)
 {
     const auto& english = *dictionary.at(language::en);

--- a/test/mnemonic.cpp
+++ b/test/mnemonic.cpp
@@ -29,25 +29,25 @@ BOOST_AUTO_TEST_SUITE(mnemonic_tests)
 
 BOOST_AUTO_TEST_CASE(entropy_to_en_mnemonic)
 {
-    for (const mnemonic_result& result: entropy_to_mnemonic_en)
+    for (const mnemonic_result& result: mnemonic_bip39_vectors)
     {
         data_chunk entropy;
-        decode_base16(entropy, result.input);
+        decode_base16(entropy, result.entropy);
         const auto mnemonic = create_mnemonic(entropy, bip39::language::en);
         BOOST_REQUIRE(mnemonic.size() > 0);
-        BOOST_REQUIRE_EQUAL(join(mnemonic), result.expectation);
+        BOOST_REQUIRE_EQUAL(join(mnemonic), result.mnemonic);
     }
 }
 
 BOOST_AUTO_TEST_CASE(en_mnemonic_to_seed)
 {
     const auto& passphrase = "TREZOR";
-    for (const mnemonic_result& result: mnemonic_to_seed_en)
+    for (const mnemonic_result& result: mnemonic_bip39_vectors)
     {
-        const auto words = split(result.input);
+        const auto words = split(result.mnemonic);
         const auto seed = decode_mnemonic(words, passphrase);
         BOOST_REQUIRE(!seed.empty());
-        BOOST_REQUIRE_EQUAL(encode_base16(seed), result.expectation);
+        BOOST_REQUIRE_EQUAL(encode_base16(seed), result.seed);
     }
 }
 

--- a/test/mnemonic.hpp
+++ b/test/mnemonic.hpp
@@ -25,111 +25,137 @@
 
 struct mnemonic_result
 {
-    std::string input, expectation;
+    std::string entropy;
+    std::string mnemonic;
+    std::string seed;
 };
 
 typedef std::vector<mnemonic_result> mnemonic_result_list;
 
-mnemonic_result_list entropy_to_mnemonic_en{{
-    {"00000000000000000000000000000000",
-     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"},
-    {"7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
-     "legal winner thank year wave sausage worth useful legal winner thank yellow"},
-    {"80808080808080808080808080808080",
-     "letter advice cage absurd amount doctor acoustic avoid letter advice cage above"},
-    {"ffffffffffffffffffffffffffffffff",
-     "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong"},
-    {"000000000000000000000000000000000000000000000000",
-     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent"},
-    {"7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
-     "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will"},
-    {"808080808080808080808080808080808080808080808080",
-     "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always"},
-    {"ffffffffffffffffffffffffffffffffffffffffffffffff",
-     "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when"},
-    {"0000000000000000000000000000000000000000000000000000000000000000",
-     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"},
-    {"7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
-     "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title"},
-    {"8080808080808080808080808080808080808080808080808080808080808080",
-     "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless"},
-    {"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-     "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote"},
-    {"77c2b00716cec7213839159e404db50d",
-     "jelly better achieve collect unaware mountain thought cargo oxygen act hood bridge"},
-    {"b63a9c59a6e641f288ebc103017f1da9f8290b3da6bdef7b",
-     "renew stay biology evidence goat welcome casual join adapt armor shuffle fault little machine walk stumble urge swap"},
-    {"3e141609b97933b66a060dcddc71fad1d91677db872031e85f4c015c5e7e8982",
-     "dignity pass list indicate nasty swamp pool script soccer toe leaf photo multiply desk host tomato cradle drill spread actor shine dismiss champion exotic"},
-    {"0460ef47585604c5660618db2e6a7e7f",
-     "afford alter spike radar gate glance object seek swamp infant panel yellow"},
-    {"72f60ebac5dd8add8d2a25a797102c3ce21bc029c200076f",
-     "indicate race push merry suffer human cruise dwarf pole review arch keep canvas theme poem divorce alter left"},
-    {"2c85efc7f24ee4573d2b81a6ec66cee209b2dcbd09d8eddc51e0215b0b68e416",
-     "clutch control vehicle tonight unusual clog visa ice plunge glimpse recipe series open hour vintage deposit universe tip job dress radar refuse motion taste"},
-    {"eaebabb2383351fd31d703840b32e9e2",
-     "turtle front uncle idea crush write shrug there lottery flower risk shell"},
-    {"7ac45cfe7722ee6c7ba84fbc2d5bd61b45cb2fe5eb65aa78",
-     "kiss carry display unusual confirm curtain upgrade antique rotate hello void custom frequent obey nut hole price segment"},
-    {"4fa1a8bc3e6d80ee1316050e862c1812031493212b7ec3f3bb1b08f168cabeef",
-     "exile ask congress lamp submit jacket era scheme attend cousin alcohol catch course end lucky hurt sentence oven short ball bird grab wing top"},
-    {"18ab19a9f54a9274f03e5209a2ac8a91",
-     "board flee heavy tunnel powder denial science ski answer betray cargo cat"},
-    {"18a2e1d81b8ecfb2a333adcb0c17a5b9eb76cc5d05db91a4",
-     "board blade invite damage undo sun mimic interest slam gaze truly inherit resist great inject rocket museum chief"},
-    {"15da872c95a13dd738fbf50e427583ad61f18fd99f628c417a61cf8343c90419",
-     "beyond stage sleep clip because twist token leaf atom beauty genius food business side grid unable middle armed observe pair crouch tonight away coconut"}
-}};
-
-mnemonic_result_list mnemonic_to_seed_en{{
-    {"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-     "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04"},
-    {"legal winner thank year wave sausage worth useful legal winner thank yellow",
-     "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607"},
-    {"letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
-     "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8"},
-    {"zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
-     "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069"},
-    {"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
-     "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa"},
-    {"legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
-     "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd"},
-    {"letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
-     "107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65"},
-    {"zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
-     "0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528"},
-    {"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
-     "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8"},
-    {"legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
-     "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87"},
-    {"letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
-     "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f"},
-    {"zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
-     "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad"},
-    {"jelly better achieve collect unaware mountain thought cargo oxygen act hood bridge",
-     "b5b6d0127db1a9d2226af0c3346031d77af31e918dba64287a1b44b8ebf63cdd52676f672a290aae502472cf2d602c051f3e6f18055e84e4c43897fc4e51a6ff"},
-    {"renew stay biology evidence goat welcome casual join adapt armor shuffle fault little machine walk stumble urge swap",
-     "9248d83e06f4cd98debf5b6f010542760df925ce46cf38a1bdb4e4de7d21f5c39366941c69e1bdbf2966e0f6e6dbece898a0e2f0a4c2b3e640953dfe8b7bbdc5"},
-    {"dignity pass list indicate nasty swamp pool script soccer toe leaf photo multiply desk host tomato cradle drill spread actor shine dismiss champion exotic",
-     "ff7f3184df8696d8bef94b6c03114dbee0ef89ff938712301d27ed8336ca89ef9635da20af07d4175f2bf5f3de130f39c9d9e8dd0472489c19b1a020a940da67"},
-    {"afford alter spike radar gate glance object seek swamp infant panel yellow",
-     "65f93a9f36b6c85cbe634ffc1f99f2b82cbb10b31edc7f087b4f6cb9e976e9faf76ff41f8f27c99afdf38f7a303ba1136ee48a4c1e7fcd3dba7aa876113a36e4"},
-    {"indicate race push merry suffer human cruise dwarf pole review arch keep canvas theme poem divorce alter left",
-     "3bbf9daa0dfad8229786ace5ddb4e00fa98a044ae4c4975ffd5e094dba9e0bb289349dbe2091761f30f382d4e35c4a670ee8ab50758d2c55881be69e327117ba"},
-    {"clutch control vehicle tonight unusual clog visa ice plunge glimpse recipe series open hour vintage deposit universe tip job dress radar refuse motion taste",
-     "fe908f96f46668b2d5b37d82f558c77ed0d69dd0e7e043a5b0511c48c2f1064694a956f86360c93dd04052a8899497ce9e985ebe0c8c52b955e6ae86d4ff4449"},
-    {"turtle front uncle idea crush write shrug there lottery flower risk shell",
-     "bdfb76a0759f301b0b899a1e3985227e53b3f51e67e3f2a65363caedf3e32fde42a66c404f18d7b05818c95ef3ca1e5146646856c461c073169467511680876c"},
-    {"kiss carry display unusual confirm curtain upgrade antique rotate hello void custom frequent obey nut hole price segment",
-     "ed56ff6c833c07982eb7119a8f48fd363c4a9b1601cd2de736b01045c5eb8ab4f57b079403485d1c4924f0790dc10a971763337cb9f9c62226f64fff26397c79"},
-    {"exile ask congress lamp submit jacket era scheme attend cousin alcohol catch course end lucky hurt sentence oven short ball bird grab wing top",
-     "095ee6f817b4c2cb30a5a797360a81a40ab0f9a4e25ecd672a3f58a0b5ba0687c096a6b14d2c0deb3bdefce4f61d01ae07417d502429352e27695163f7447a8c"},
-    {"board flee heavy tunnel powder denial science ski answer betray cargo cat",
-     "6eff1bb21562918509c73cb990260db07c0ce34ff0e3cc4a8cb3276129fbcb300bddfe005831350efd633909f476c45c88253276d9fd0df6ef48609e8bb7dca8"},
-    {"board blade invite damage undo sun mimic interest slam gaze truly inherit resist great inject rocket museum chief",
-     "f84521c777a13b61564234bf8f8b62b3afce27fc4062b51bb5e62bdfecb23864ee6ecf07c1d5a97c0834307c5c852d8ceb88e7c97923c0a3b496bedd4e5f88a9"},
-    {"beyond stage sleep clip because twist token leaf atom beauty genius food business side grid unable middle armed observe pair crouch tonight away coconut",
-     "b15509eaa2d09d3efd3e006ef42151b30367dc6e3aa5e44caba3fe4d3e352e65101fbdb86a96776b91946ff06f8eac594dc6ee1d3e82a42dfe1b40fef6bcc3fd"}
-}};
+mnemonic_result_list mnemonic_bip39_vectors
+{
+    {
+        {
+            "00000000000000000000000000000000",
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04"
+        },
+        {
+            "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+            "legal winner thank year wave sausage worth useful legal winner thank yellow",
+            "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607"
+        },
+        {
+            "80808080808080808080808080808080",
+            "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+            "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8"
+        },
+        {
+            "ffffffffffffffffffffffffffffffff",
+            "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+            "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069"
+        },
+        {
+            "000000000000000000000000000000000000000000000000",
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+            "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa"
+        },
+        {
+            "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+            "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+            "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd"
+        },
+        {
+            "808080808080808080808080808080808080808080808080",
+            "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+            "107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65"
+        },
+        {
+            "ffffffffffffffffffffffffffffffffffffffffffffffff",
+            "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+            "0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528"
+        },
+        {
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+            "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8"
+        },
+        {
+            "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+            "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+            "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87"
+        },
+        {
+            "8080808080808080808080808080808080808080808080808080808080808080",
+            "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+            "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f"
+        },
+        {
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+            "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad"
+        },
+        {
+            "77c2b00716cec7213839159e404db50d",
+            "jelly better achieve collect unaware mountain thought cargo oxygen act hood bridge",
+            "b5b6d0127db1a9d2226af0c3346031d77af31e918dba64287a1b44b8ebf63cdd52676f672a290aae502472cf2d602c051f3e6f18055e84e4c43897fc4e51a6ff"
+        },
+        {
+            "b63a9c59a6e641f288ebc103017f1da9f8290b3da6bdef7b",
+            "renew stay biology evidence goat welcome casual join adapt armor shuffle fault little machine walk stumble urge swap",
+            "9248d83e06f4cd98debf5b6f010542760df925ce46cf38a1bdb4e4de7d21f5c39366941c69e1bdbf2966e0f6e6dbece898a0e2f0a4c2b3e640953dfe8b7bbdc5"
+        },
+        {
+            "3e141609b97933b66a060dcddc71fad1d91677db872031e85f4c015c5e7e8982",
+            "dignity pass list indicate nasty swamp pool script soccer toe leaf photo multiply desk host tomato cradle drill spread actor shine dismiss champion exotic",
+            "ff7f3184df8696d8bef94b6c03114dbee0ef89ff938712301d27ed8336ca89ef9635da20af07d4175f2bf5f3de130f39c9d9e8dd0472489c19b1a020a940da67"
+        },
+        {
+            "0460ef47585604c5660618db2e6a7e7f",
+            "afford alter spike radar gate glance object seek swamp infant panel yellow",
+            "65f93a9f36b6c85cbe634ffc1f99f2b82cbb10b31edc7f087b4f6cb9e976e9faf76ff41f8f27c99afdf38f7a303ba1136ee48a4c1e7fcd3dba7aa876113a36e4"
+        },
+        {
+            "72f60ebac5dd8add8d2a25a797102c3ce21bc029c200076f",
+            "indicate race push merry suffer human cruise dwarf pole review arch keep canvas theme poem divorce alter left",
+            "3bbf9daa0dfad8229786ace5ddb4e00fa98a044ae4c4975ffd5e094dba9e0bb289349dbe2091761f30f382d4e35c4a670ee8ab50758d2c55881be69e327117ba"
+        },
+        {
+            "2c85efc7f24ee4573d2b81a6ec66cee209b2dcbd09d8eddc51e0215b0b68e416",
+            "clutch control vehicle tonight unusual clog visa ice plunge glimpse recipe series open hour vintage deposit universe tip job dress radar refuse motion taste",
+            "fe908f96f46668b2d5b37d82f558c77ed0d69dd0e7e043a5b0511c48c2f1064694a956f86360c93dd04052a8899497ce9e985ebe0c8c52b955e6ae86d4ff4449"
+        },
+        {
+            "eaebabb2383351fd31d703840b32e9e2",
+            "turtle front uncle idea crush write shrug there lottery flower risk shell",
+            "bdfb76a0759f301b0b899a1e3985227e53b3f51e67e3f2a65363caedf3e32fde42a66c404f18d7b05818c95ef3ca1e5146646856c461c073169467511680876c"
+        },
+        {
+            "7ac45cfe7722ee6c7ba84fbc2d5bd61b45cb2fe5eb65aa78",
+            "kiss carry display unusual confirm curtain upgrade antique rotate hello void custom frequent obey nut hole price segment",
+            "ed56ff6c833c07982eb7119a8f48fd363c4a9b1601cd2de736b01045c5eb8ab4f57b079403485d1c4924f0790dc10a971763337cb9f9c62226f64fff26397c79"
+        },
+        {
+            "4fa1a8bc3e6d80ee1316050e862c1812031493212b7ec3f3bb1b08f168cabeef",
+            "exile ask congress lamp submit jacket era scheme attend cousin alcohol catch course end lucky hurt sentence oven short ball bird grab wing top",
+            "095ee6f817b4c2cb30a5a797360a81a40ab0f9a4e25ecd672a3f58a0b5ba0687c096a6b14d2c0deb3bdefce4f61d01ae07417d502429352e27695163f7447a8c"
+        },
+        {
+            "18ab19a9f54a9274f03e5209a2ac8a91",
+            "board flee heavy tunnel powder denial science ski answer betray cargo cat",
+            "6eff1bb21562918509c73cb990260db07c0ce34ff0e3cc4a8cb3276129fbcb300bddfe005831350efd633909f476c45c88253276d9fd0df6ef48609e8bb7dca8"
+        },
+        {
+            "18a2e1d81b8ecfb2a333adcb0c17a5b9eb76cc5d05db91a4",
+            "board blade invite damage undo sun mimic interest slam gaze truly inherit resist great inject rocket museum chief",
+            "f84521c777a13b61564234bf8f8b62b3afce27fc4062b51bb5e62bdfecb23864ee6ecf07c1d5a97c0834307c5c852d8ceb88e7c97923c0a3b496bedd4e5f88a9"
+        },
+        {
+            "15da872c95a13dd738fbf50e427583ad61f18fd99f628c417a61cf8343c90419",
+            "beyond stage sleep clip because twist token leaf atom beauty genius food business side grid unable middle armed observe pair crouch tonight away coconut",
+            "b15509eaa2d09d3efd3e006ef42151b30367dc6e3aa5e44caba3fe4d3e352e65101fbdb86a96776b91946ff06f8eac594dc6ee1d3e82a42dfe1b40fef6bcc3fd"
+        }
+    }
+};
 
 #endif

--- a/test/mnemonic.hpp
+++ b/test/mnemonic.hpp
@@ -158,4 +158,20 @@ mnemonic_result_list mnemonic_bip39_vectors
     }
 };
 
+typedef std::vector<std::string> string_list;
+
+string_list invalid_mnemonic_tests
+{
+    // Spelling error:
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon aboot",
+
+    // Bad lengths:
+    "one",
+    "one two",
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon",
+
+    // Bad checksum:
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon one",
+};
+
 #endif


### PR DESCRIPTION
This is an update on pull request #234. Here are the fixes:

* Remove the unnecessary pbkdf2 assertions.
* Expose the built-in dictionaries as a std::map for run-time string-based lookup.
* Rename `wordlist` to `dictionary`, as requested.

I expose the built-in dictionaries two ways, once as plain C++ variables and again through a string-based std::map. If a developer knows which language they want at compile-time, they can simply refer to the plain variables. This removes the indirection of an enum, and makes the compile-time language lookup a lot simpler. Its main users are default parameters and unit tests, so I would be willing to privatize this capability if necessary.

For run-time language lookup, the developer can examine the map to determine which languages are available. The libbitcoin/libbitcoin-explorer#231 pull request makes use of this to eliminate the need for switch statements.