### PR TITLE
Fix doc about the branch secp256k1 is built from

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The build script clones, builds and installs two unpackaged repositories, namely
 - [libbitcoin/secp256k1](https://github.com/libbitcoin/secp256k1)
 - [libbitcoin/libbitcoin](https://github.com/libbitcoin/libbitcoin)
 
-The script builds from the head of the `version2` branches. The `master` branch is a staging area for changes. The version branches are considered release quality.
+The script builds from the head of their `version3` and `version2` branches respectively. The `master` branch is a staging area for changes. The version branches are considered release quality.
 
 #### Build Options
 


### PR DESCRIPTION
A minor README.md fix I just bumped into while building libbitcoin. Since [this](https://github.com/libbitcoin/libbitcoin/commit/19b6e4503f00c02984a48a0435bad6ac4947f58b#diff-3fbb47e318cd8802bd325e7da9aaabe8R532) the build script builds from 'version3' branch of secp256k1.