### PR TITLE
Factor network files into class-per-file organization.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,7 +74,12 @@ src_libbitcoin_la_SOURCES = \
     src/math/external/sha512.h \
     src/math/external/zeroize.c \
     src/math/external/zeroize.h \
+    src/network/acceptor.cpp \
     src/network/channel.cpp \
+    src/network/channel_proxy.cpp \
+    src/network/channel_stream_loader.cpp \
+    src/network/connect_with_timeout.cpp \
+    src/network/connect_with_timeout.hpp \
     src/network/handshake.cpp \
     src/network/hosts.cpp \
     src/network/network.cpp \
@@ -237,7 +242,11 @@ include_bitcoin_bitcoin_math_HEADERS = \
 
 include_bitcoin_bitcoin_networkdir = ${includedir}/bitcoin/bitcoin/network
 include_bitcoin_bitcoin_network_HEADERS = \
+    include/bitcoin/bitcoin/network/acceptor.hpp \
     include/bitcoin/bitcoin/network/channel.hpp \
+    include/bitcoin/bitcoin/network/channel_loader_module.hpp \
+    include/bitcoin/bitcoin/network/channel_proxy.hpp \
+    include/bitcoin/bitcoin/network/channel_stream_loader.hpp \
     include/bitcoin/bitcoin/network/handshake.hpp \
     include/bitcoin/bitcoin/network/hosts.hpp \
     include/bitcoin/bitcoin/network/network.hpp \

--- a/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj
@@ -97,10 +97,14 @@
     <ClCompile Include="..\..\..\..\src\math\script_number.cpp" />
     <ClCompile Include="..\..\..\..\src\math\secp256k1_initializer.cpp" />
     <ClCompile Include="..\..\..\..\src\math\uint256.cpp" />
+    <ClCompile Include="..\..\..\..\src\network\acceptor.cpp" />
     <ClCompile Include="..\..\..\..\src\network\channel.cpp" />
+    <ClCompile Include="..\..\..\..\src\network\channel_proxy.cpp" />
+    <ClCompile Include="..\..\..\..\src\network\channel_stream_loader.cpp" />
     <ClCompile Include="..\..\..\..\src\network\handshake.cpp" />
     <ClCompile Include="..\..\..\..\src\network\hosts.cpp" />
     <ClCompile Include="..\..\..\..\src\network\network.cpp" />
+    <ClCompile Include="..\..\..\..\src\network\connect_with_timeout.cpp" />
     <ClCompile Include="..\..\..\..\src\network\protocol.cpp" />
     <ClCompile Include="..\..\..\..\src\satoshi_serialize.cpp" />
     <ClCompile Include="..\..\..\..\src\script.cpp" />
@@ -152,7 +156,11 @@
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\math\script_number.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\math\secp256k1_initializer.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\math\uint256.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\acceptor.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\channel.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\channel_loader_module.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\channel_proxy.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\channel_stream_loader.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\handshake.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\hosts.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\network.hpp" />
@@ -209,6 +217,7 @@
     <ClInclude Include="..\..\..\..\src\math\external\sha256.h" />
     <ClInclude Include="..\..\..\..\src\math\external\sha512.h" />
     <ClInclude Include="..\..\..\..\src\math\external\zeroize.h" />
+    <ClInclude Include="..\..\..\..\src\network\connect_with_timeout.hpp" />
     <ClInclude Include="..\..\resource.h" />
   </ItemGroup>
   <ItemGroup>

--- a/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj.filters
@@ -299,6 +299,18 @@
     <ClCompile Include="..\..\..\..\src\utility\thread.cpp">
       <Filter>src\utility</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\network\channel_stream_loader.cpp">
+      <Filter>src\network</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\network\channel_proxy.cpp">
+      <Filter>src\network</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\network\acceptor.cpp">
+      <Filter>src\network</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\network\connect_with_timeout.cpp">
+      <Filter>src\network</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\resource.h">
@@ -540,6 +552,21 @@
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\utility\thread.hpp">
       <Filter>include\bitcoin\utility</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\channel_stream_loader.hpp">
+      <Filter>include\bitcoin\network</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\channel_loader_module.hpp">
+      <Filter>include\bitcoin\network</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\channel_proxy.hpp">
+      <Filter>include\bitcoin\network</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\network\acceptor.hpp">
+      <Filter>include\bitcoin\network</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\network\connect_with_timeout.hpp">
+      <Filter>src\network</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/include/bitcoin/bitcoin.hpp
+++ b/include/bitcoin/bitcoin.hpp
@@ -41,7 +41,11 @@
 #include <bitcoin/bitcoin/math/script_number.hpp>
 #include <bitcoin/bitcoin/math/secp256k1_initializer.hpp>
 #include <bitcoin/bitcoin/math/uint256.hpp>
+#include <bitcoin/bitcoin/network/acceptor.hpp>
 #include <bitcoin/bitcoin/network/channel.hpp>
+#include <bitcoin/bitcoin/network/channel_loader_module.hpp>
+#include <bitcoin/bitcoin/network/channel_proxy.hpp>
+#include <bitcoin/bitcoin/network/channel_stream_loader.hpp>
 #include <bitcoin/bitcoin/network/handshake.hpp>
 #include <bitcoin/bitcoin/network/hosts.hpp>
 #include <bitcoin/bitcoin/network/network.hpp>

--- a/include/bitcoin/bitcoin/network/channel.hpp
+++ b/include/bitcoin/bitcoin/network/channel.hpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
  *
  * This file is part of libbitcoin.
@@ -20,318 +20,70 @@
 #ifndef LIBBITCOIN_CHANNEL_HPP
 #define LIBBITCOIN_CHANNEL_HPP
 
-#include <atomic>
 #include <cstdint>
 #include <memory>
-#include <mutex>
-#include <stack>
-#include <boost/asio.hpp>
-#include <boost/array.hpp>
-#include <boost/utility.hpp>
-#include <boost/asio/streambuf.hpp>
-#include <bitcoin/bitcoin/compat.hpp>
 #include <bitcoin/bitcoin/constants.hpp>
 #include <bitcoin/bitcoin/define.hpp>
-#include <bitcoin/bitcoin/network/network.hpp>
-#include <bitcoin/bitcoin/network/shared_const_buffer.hpp>
-#include <bitcoin/bitcoin/primitives.hpp>
+#include <bitcoin/bitcoin/network/channel_proxy.hpp>
 #include <bitcoin/bitcoin/satoshi_serialize.hpp>
-#include <bitcoin/bitcoin/math/checksum.hpp>
-#include <bitcoin/bitcoin/utility/assert.hpp>
 #include <bitcoin/bitcoin/utility/logger.hpp>
 #include <bitcoin/bitcoin/utility/serializer.hpp>
-#include <bitcoin/bitcoin/utility/subscriber.hpp>
 
 namespace libbitcoin {
 namespace network {
+    
+class channel;
 
-template <typename Message>
-data_chunk create_raw_message(const Message& packet)
-{
-    data_chunk payload(satoshi_raw_size(packet));
-    satoshi_save(packet, payload.begin());
-    // Make the header packet and serialise it
-    header_type head;
-    head.magic = magic_value();
-    head.command = satoshi_command(packet);
-    head.payload_length = static_cast<uint32_t>(payload.size());
-    head.checksum = bitcoin_checksum(payload);
-    data_chunk raw_header(satoshi_raw_size(head));
-    satoshi_save(head, raw_header.begin());
-    // Construct completed packet with header + payload
-    data_chunk whole_message = raw_header;
-    extend_data(whole_message, payload);
-    // Probably not the right place for this
-    // Networking output in an exporter
-    log_debug(LOG_NETWORK) << "s: " << head.command
-        << " (" << payload.size() << " bytes)";
-    return whole_message;
-}
+// TODO: move channel_ptr into channel as public type (interface break).
+typedef std::shared_ptr<channel> channel_ptr;
 
-class channel_loader_module_base
+class BC_API channel
 {
 public:
-    BC_API virtual ~channel_loader_module_base() {}
-    BC_API virtual void attempt_load(const data_chunk& stream) const = 0;
-    BC_API virtual const std::string lookup_symbol() const = 0;
-};
-
-class channel_stream_loader
-{
-public:
-    ~channel_stream_loader();
-    BC_API void add(channel_loader_module_base* module);
-    BC_API void load_lookup(const std::string& symbol,
-        const data_chunk& stream) const;
-private:
-    typedef std::vector<channel_loader_module_base*> module_list;
-
-    module_list modules_;
-};
-
-class channel_proxy
-  : public std::enable_shared_from_this<channel_proxy>
-{
-public:
-    typedef std::function<void (const std::error_code&)> send_handler;
-
-    typedef std::function<void (const std::error_code&,
-        const version_type&)> receive_version_handler;
-
-    typedef std::function<void (const std::error_code&,
-        const verack_type&)> receive_verack_handler;
-
-    typedef std::function<void (const std::error_code&,
-        const address_type&)> receive_address_handler;
-
-    typedef std::function<void (const std::error_code&,
-        const get_address_type&)> receive_get_address_handler;
-
-    typedef std::function<void (const std::error_code&,
-        const inventory_type&)> receive_inventory_handler;
-
-    typedef std::function<void (const std::error_code&,
-        const get_data_type&)> receive_get_data_handler;
-
-    typedef std::function<void (const std::error_code&,
-        const get_blocks_type&)> receive_get_blocks_handler;
-
-    typedef std::function<void (const std::error_code&,
-        const transaction_type&)> receive_transaction_handler;
-
-    typedef std::function<void (const std::error_code&,
-        const block_type&)> receive_block_handler;
-
-    typedef std::function<void (const std::error_code&,
-        const header_type&, const data_chunk&)> receive_raw_handler;
-
-    typedef std::function<void (const std::error_code&)> stop_handler;
-
-    BC_API channel_proxy(threadpool& pool, socket_ptr socket);
-    BC_API ~channel_proxy();
-
-    BC_API channel_proxy(const channel_proxy&) = delete;
-    BC_API void operator=(const channel_proxy&) = delete;
-
-    BC_API void start();
-    BC_API void stop();
-    BC_API bool stopped() const;
-
-    // List of bitcoin messages
-    // version
-    // verack
-    // addr
-    // getaddr
-    // inv
-    // getdata
-    // getblocks
-    // tx
-    // block
-    // getheaders   [unused]
-    // headers      [unused]
-    // checkorder   [deprecated]
-    // submitorder  [deprecated]
-    // reply        [deprecated]
-    // ping         [internal]
-    // alert        [not supported]
-
-    template <typename Message>
-    void send(const Message& packet, send_handler handle_send)
-    {
-        send_common(create_raw_message(packet), handle_send);
-    }
-
-    BC_API void send_raw(const header_type& packet_header,
-        const data_chunk& payload, send_handler handle_send);
-
-    BC_API void send_common(const data_chunk& whole_message,
-        send_handler handle_send);
-
-    BC_API void subscribe_version(receive_version_handler handle_receive);
-    BC_API void subscribe_verack(receive_verack_handler handle_receive);
-    BC_API void subscribe_address(receive_address_handler handle_receive);
-    BC_API void subscribe_get_address(
-        receive_get_address_handler handle_receive);
-    BC_API void subscribe_inventory(receive_inventory_handler handle_receive);
-    BC_API void subscribe_get_data(receive_get_data_handler handle_receive);
-    BC_API void subscribe_get_blocks(
-        receive_get_blocks_handler handle_receive);
-    BC_API void subscribe_transaction(
-        receive_transaction_handler handle_receive);
-    BC_API void subscribe_block(receive_block_handler handle_receive);
-    BC_API void subscribe_raw(receive_raw_handler handle_receive);
-
-    BC_API void subscribe_stop(stop_handler handle_stop);
-
-private:
-    typedef subscriber<const std::error_code&, const version_type&>
-        version_subscriber_type;
-    typedef subscriber<const std::error_code&, const verack_type&>
-        verack_subscriber_type;
-    typedef subscriber<const std::error_code&, const address_type&>
-        address_subscriber_type;
-    typedef subscriber<const std::error_code&, const get_address_type&>
-        get_address_subscriber_type;
-    typedef subscriber<const std::error_code&, const inventory_type&>
-        inventory_subscriber_type;
-    typedef subscriber<const std::error_code&, const get_data_type&>
-        get_data_subscriber_type;
-    typedef subscriber<const std::error_code&, const get_blocks_type&>
-        get_blocks_subscriber_type;
-    typedef subscriber<const std::error_code&, const transaction_type&>
-        transaction_subscriber_type;
-    typedef subscriber<const std::error_code&, const block_type&>
-        block_subscriber_type;
-
-    typedef subscriber<const std::error_code&,
-        const header_type&, const data_chunk&> raw_subscriber_type;
-    typedef subscriber<const std::error_code&> stop_subscriber_type;
-
-    void do_send_raw(const header_type& packet_header,
-        const data_chunk& payload, send_handler handle_send);
-    void do_send_common(const data_chunk& whole_message,
-        send_handler handle_send);
-
-    template <typename Message, typename Callback, typename SubscriberPtr>
-    void generic_subscribe(Callback handle_message,
-        SubscriberPtr message_subscribe)
-    {
-        // Subscribing must be immediate. We cannot switch thread contexts
-        if (stopped_)
-            handle_message(error::service_stopped, Message());
-        else
-            message_subscribe->subscribe(handle_message);
-    }
-
-    void read_header();
-    void read_checksum(const header_type& header_msg);
-    void read_payload(const header_type& header_msg);
-
-    void handle_read_header(const boost::system::error_code& ec,
-        size_t bytes_transferred);
-    void handle_read_checksum(const boost::system::error_code& ec,
-        size_t bytes_transferred, header_type& header_msg);
-    void handle_read_payload(const boost::system::error_code& ec,
-        size_t bytes_transferred, const header_type& header_msg);
-
-    // Calls the send handler after a successful send, translating
-    // the boost error_code to std::error_code
-    void call_handle_send(const boost::system::error_code& ec,
-        send_handler handle_send);
-
-    void handle_timeout(const boost::system::error_code& ec);
-    void handle_heartbeat(const boost::system::error_code& ec);
-
-    void set_timeout(const boost::posix_time::time_duration timeout);
-    void set_heartbeat(const boost::posix_time::time_duration timeout);
-    void reset_timers();
-
-    bool problems_check(const boost::system::error_code& ec);
-    void stop_impl();
-    void clear_subscriptions();
-
-    async_strand strand_;
-    socket_ptr socket_;
-    // We keep the service alive for lifetime rules
-    boost::asio::deadline_timer timeout_, heartbeat_;
-    std::atomic<bool> stopped_;
-
-    channel_stream_loader loader_;
-
-    // Header minus checksum is 4 + 12 + 4 = 20 bytes
-    static BC_CONSTEXPR size_t header_chunk_size = 20;
-    // Checksum size is 4 bytes
-    static BC_CONSTEXPR size_t header_checksum_size = 4;
-
-    // boost1.54/linux/clang/libstdc++-4.8 error if std::array
-    // could not match 'boost::array' against 'std::array'
-    boost::array<uint8_t, header_chunk_size> inbound_header_;
-    boost::array<uint8_t, header_checksum_size> inbound_checksum_;
-
-    std::vector<uint8_t> inbound_payload_;
-
-    // We should be using variadic templates for these
-    version_subscriber_type::ptr version_subscriber_;
-    verack_subscriber_type::ptr verack_subscriber_;
-    address_subscriber_type::ptr address_subscriber_;
-    get_address_subscriber_type::ptr get_address_subscriber_;
-    inventory_subscriber_type::ptr inventory_subscriber_;
-    get_data_subscriber_type::ptr get_data_subscriber_;
-    get_blocks_subscriber_type::ptr get_blocks_subscriber_;
-    transaction_subscriber_type::ptr transaction_subscriber_;
-    block_subscriber_type::ptr block_subscriber_;
-
-    raw_subscriber_type::ptr raw_subscriber_;
-    stop_subscriber_type::ptr stop_subscriber_;
-};
-
-class channel
-{
-public:
+    // TODO: move into channel_proxy (interface break).
     typedef std::shared_ptr<channel_proxy> channel_proxy_ptr;
 
-    BC_API channel(channel_proxy_ptr proxy);
-    BC_API ~channel();
+    channel(channel_proxy_ptr proxy);
+    ~channel();
 
-    BC_API void stop();
-    BC_API bool stopped() const;
+    void stop();
+    bool stopped() const;
 
     template <typename Message>
-    void send(const Message& packet,
-        channel_proxy::send_handler handle_send)
+    void send(const Message& packet, channel_proxy::send_handler handle_send)
     {
-        channel_proxy_ptr proxy = weak_proxy_.lock();
+        const auto proxy = weak_proxy_.lock();
         if (!proxy)
             handle_send(error::service_stopped);
         else
             proxy->send(packet, handle_send);
     }
 
-    BC_API void send_raw(const header_type& packet_header,
+    void send_raw(const header_type& packet_header,
         const data_chunk& payload, channel_proxy::send_handler handle_send);
 
-    BC_API void subscribe_version(
+    void subscribe_version(
         channel_proxy::receive_version_handler handle_receive);
-    BC_API void subscribe_verack(
+    void subscribe_verack(
         channel_proxy::receive_verack_handler handle_receive);
-    BC_API void subscribe_address(
+    void subscribe_address(
         channel_proxy::receive_address_handler handle_receive);
-    BC_API void subscribe_get_address(
+    void subscribe_get_address(
         channel_proxy::receive_get_address_handler handle_receive);
-    BC_API void subscribe_inventory(
+    void subscribe_inventory(
         channel_proxy::receive_inventory_handler handle_receive);
-    BC_API void subscribe_get_data(
+    void subscribe_get_data(
         channel_proxy::receive_get_data_handler handle_receive);
-    BC_API void subscribe_get_blocks(
+    void subscribe_get_blocks(
         channel_proxy::receive_get_blocks_handler handle_receive);
-    BC_API void subscribe_transaction(
+    void subscribe_transaction(
         channel_proxy::receive_transaction_handler handle_receive);
-    BC_API void subscribe_block(
+    void subscribe_block(
         channel_proxy::receive_block_handler handle_receive);
-    BC_API void subscribe_raw(
+    void subscribe_raw(
         channel_proxy::receive_raw_handler handle_receive);
 
-    BC_API void subscribe_stop(
+    void subscribe_stop(
         channel_proxy::stop_handler handle_stop);
 
 private:

--- a/include/bitcoin/bitcoin/network/channel_loader_module.hpp
+++ b/include/bitcoin/bitcoin/network/channel_loader_module.hpp
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_CHANNEL_LOADER_MODULE_HPP
+#define LIBBITCOIN_CHANNEL_LOADER_MODULE_HPP
+
+#include <functional>
+#include <string>
+#include <system_error>
+#include <bitcoin/bitcoin/define.hpp>
+#include <bitcoin/bitcoin/error.hpp>
+#include <bitcoin/bitcoin/satoshi_serialize.hpp>
+#include <bitcoin/bitcoin/utility/data.hpp>
+
+namespace libbitcoin {
+namespace network {
+
+class BC_API channel_loader_module_base
+{
+public:
+    virtual ~channel_loader_module_base() {}
+    virtual void attempt_load(const bc::data_chunk& stream) const = 0;
+    virtual const std::string lookup_symbol() const = 0;
+};
+
+// TODO: split to impl.
+template <typename Message>
+class channel_loader_module
+  : public channel_loader_module_base
+{
+public:
+    typedef std::function<
+        void(const std::error_code&, const Message&)> load_handler;
+
+    channel_loader_module(load_handler handle_load)
+      : handle_load_(handle_load)
+    {
+    }
+
+    void attempt_load(const bc::data_chunk& stream) const
+    {
+        Message result;
+        try
+        {
+            satoshi_load(stream.begin(), stream.end(), result);
+            handle_load_(std::error_code(), result);
+        }
+        catch (bc::end_of_stream)
+        {
+            handle_load_(bc::error::bad_stream, Message());
+        }
+    }
+
+    const std::string lookup_symbol() const
+    {
+        return satoshi_command(Message());
+    }
+
+private:
+    load_handler handle_load_;
+};
+
+} // namespace network
+} // namespace libbitcoin
+
+#endif
+

--- a/include/bitcoin/bitcoin/network/channel_proxy.hpp
+++ b/include/bitcoin/bitcoin/network/channel_proxy.hpp
@@ -34,6 +34,7 @@
 #include <bitcoin/bitcoin/network/channel_stream_loader.hpp>
 #include <bitcoin/bitcoin/primitives.hpp>
 #include <bitcoin/bitcoin/utility/data.hpp>
+#include <bitcoin/bitcoin/utility/logger.hpp>
 #include <bitcoin/bitcoin/utility/threadpool.hpp>
 #include <bitcoin/bitcoin/utility/subscriber.hpp>
 

--- a/include/bitcoin/bitcoin/network/channel_proxy.hpp
+++ b/include/bitcoin/bitcoin/network/channel_proxy.hpp
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_CHANNEL_PROXY_HPP
+#define LIBBITCOIN_CHANNEL_PROXY_HPP
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <system_error>
+#include <boost/array.hpp>
+#include <boost/asio.hpp>
+#include <boost/date_time.hpp>
+#include <bitcoin/bitcoin/compat.hpp>
+#include <bitcoin/bitcoin/define.hpp>
+#include <bitcoin/bitcoin/math/checksum.hpp>
+#include <bitcoin/bitcoin/network/channel_stream_loader.hpp>
+#include <bitcoin/bitcoin/primitives.hpp>
+#include <bitcoin/bitcoin/utility/data.hpp>
+#include <bitcoin/bitcoin/utility/threadpool.hpp>
+#include <bitcoin/bitcoin/utility/subscriber.hpp>
+
+namespace libbitcoin {
+namespace network {
+
+// List of bitcoin messages
+// version
+// verack
+// addr
+// getaddr
+// inv
+// getdata
+// getblocks
+// tx
+// block
+// getheaders   [unused]
+// headers      [unused]
+// checkorder   [deprecated]
+// submitorder  [deprecated]
+// reply        [deprecated]
+// ping         [internal]
+// alert        [not supported]
+
+// Defined here because of the central position in the dependency graph.
+typedef std::shared_ptr<boost::asio::ip::tcp::socket> socket_ptr;
+
+// TODO: move to serializer|misc|message.hpp/ipp.
+template <typename Message>
+data_chunk create_raw_message(const Message& packet)
+{
+    data_chunk payload(satoshi_raw_size(packet));
+    satoshi_save(packet, payload.begin());
+
+    // Make the header packet and serialise it
+    header_type head;
+    head.magic = magic_value();
+    head.command = satoshi_command(packet);
+    head.payload_length = static_cast<uint32_t>(payload.size());
+    head.checksum = bitcoin_checksum(payload);
+    data_chunk raw_header(satoshi_raw_size(head));
+    satoshi_save(head, raw_header.begin());
+
+    // Construct completed packet with header + payload
+    data_chunk whole_message = raw_header;
+    extend_data(whole_message, payload);
+
+    // Probably not the right place for this
+    // Networking output in an exporter
+    log_debug(LOG_NETWORK) << "s: " << head.command
+        << " (" << payload.size() << " bytes)";
+    return whole_message;
+}
+
+class BC_API channel_proxy
+  : public std::enable_shared_from_this<channel_proxy>
+{
+public:
+    typedef std::function<void (const std::error_code&)> send_handler;
+
+    typedef std::function<void (const std::error_code&,
+        const version_type&)> receive_version_handler;
+
+    typedef std::function<void (const std::error_code&,
+        const verack_type&)> receive_verack_handler;
+
+    typedef std::function<void (const std::error_code&,
+        const address_type&)> receive_address_handler;
+
+    typedef std::function<void (const std::error_code&,
+        const get_address_type&)> receive_get_address_handler;
+
+    typedef std::function<void (const std::error_code&,
+        const inventory_type&)> receive_inventory_handler;
+
+    typedef std::function<void (const std::error_code&,
+        const get_data_type&)> receive_get_data_handler;
+
+    typedef std::function<void (const std::error_code&,
+        const get_blocks_type&)> receive_get_blocks_handler;
+
+    typedef std::function<void (const std::error_code&,
+        const transaction_type&)> receive_transaction_handler;
+
+    typedef std::function<void (const std::error_code&,
+        const block_type&)> receive_block_handler;
+
+    typedef std::function<void (const std::error_code&,
+        const header_type&, const data_chunk&)> receive_raw_handler;
+
+    typedef std::function<void (const std::error_code&)> stop_handler;
+
+    channel_proxy(threadpool& pool, socket_ptr socket);
+    ~channel_proxy();
+
+    channel_proxy(const channel_proxy&) = delete;
+    void operator=(const channel_proxy&) = delete;
+
+    void start();
+    void stop();
+    bool stopped() const;
+
+    template <typename Message>
+    void send(const Message& packet, send_handler handle_send)
+    {
+        send_common(create_raw_message(packet), handle_send);
+    }
+
+    void send_raw(const header_type& packet_header,
+        const data_chunk& payload, send_handler handle_send);
+
+    void send_common(const data_chunk& whole_message,
+        send_handler handle_send);
+
+    void subscribe_version(receive_version_handler handle_receive);
+    void subscribe_verack(receive_verack_handler handle_receive);
+    void subscribe_address(receive_address_handler handle_receive);
+    void subscribe_get_address(
+        receive_get_address_handler handle_receive);
+    void subscribe_inventory(receive_inventory_handler handle_receive);
+    void subscribe_get_data(receive_get_data_handler handle_receive);
+    void subscribe_get_blocks(
+        receive_get_blocks_handler handle_receive);
+    void subscribe_transaction(
+        receive_transaction_handler handle_receive);
+    void subscribe_block(receive_block_handler handle_receive);
+    void subscribe_raw(receive_raw_handler handle_receive);
+
+    void subscribe_stop(stop_handler handle_stop);
+
+private:
+    typedef subscriber<const std::error_code&, const version_type&>
+        version_subscriber_type;
+    typedef subscriber<const std::error_code&, const verack_type&>
+        verack_subscriber_type;
+    typedef subscriber<const std::error_code&, const address_type&>
+        address_subscriber_type;
+    typedef subscriber<const std::error_code&, const get_address_type&>
+        get_address_subscriber_type;
+    typedef subscriber<const std::error_code&, const inventory_type&>
+        inventory_subscriber_type;
+    typedef subscriber<const std::error_code&, const get_data_type&>
+        get_data_subscriber_type;
+    typedef subscriber<const std::error_code&, const get_blocks_type&>
+        get_blocks_subscriber_type;
+    typedef subscriber<const std::error_code&, const transaction_type&>
+        transaction_subscriber_type;
+    typedef subscriber<const std::error_code&, const block_type&>
+        block_subscriber_type;
+
+    typedef subscriber<const std::error_code&,
+        const header_type&, const data_chunk&> raw_subscriber_type;
+    typedef subscriber<const std::error_code&> stop_subscriber_type;
+
+    void do_send_raw(const header_type& packet_header,
+        const data_chunk& payload, send_handler handle_send);
+    void do_send_common(const data_chunk& whole_message,
+        send_handler handle_send);
+
+    template <typename Message, typename Callback, typename SubscriberPtr>
+    void generic_subscribe(Callback handle_message,
+        SubscriberPtr message_subscribe)
+    {
+        // Subscribing must be immediate. We cannot switch thread contexts
+        if (stopped_)
+            handle_message(error::service_stopped, Message());
+        else
+            message_subscribe->subscribe(handle_message);
+    }
+
+    void read_header();
+    void read_checksum(const header_type& header_msg);
+    void read_payload(const header_type& header_msg);
+
+    void handle_read_header(const boost::system::error_code& ec,
+        size_t bytes_transferred);
+    void handle_read_checksum(const boost::system::error_code& ec,
+        size_t bytes_transferred, header_type& header_msg);
+    void handle_read_payload(const boost::system::error_code& ec,
+        size_t bytes_transferred, const header_type& header_msg);
+
+    // Calls the send handler after a successful send, translating
+    // the boost error_code to std::error_code
+    void call_handle_send(const boost::system::error_code& ec,
+        send_handler handle_send);
+
+    void handle_timeout(const boost::system::error_code& ec);
+    void handle_heartbeat(const boost::system::error_code& ec);
+
+    void set_timeout(const boost::posix_time::time_duration timeout);
+    void set_heartbeat(const boost::posix_time::time_duration timeout);
+    void reset_timers();
+
+    bool problems_check(const boost::system::error_code& ec);
+    void stop_impl();
+    void clear_subscriptions();
+
+    async_strand strand_;
+    socket_ptr socket_;
+
+    // We keep the service alive for lifetime rules
+    boost::asio::deadline_timer timeout_, heartbeat_;
+    std::atomic<bool> stopped_;
+
+    channel_stream_loader loader_;
+
+    // Header minus checksum is 4 + 12 + 4 = 20 bytes
+    static BC_CONSTEXPR size_t header_chunk_size = 20;
+    static BC_CONSTEXPR size_t header_checksum_size = 4;
+
+    // boost1.54/linux/clang/libstdc++-4.8 error if std::array
+    // could not match 'boost::array' against 'std::array'
+    boost::array<uint8_t, header_chunk_size> inbound_header_;
+    boost::array<uint8_t, header_checksum_size> inbound_checksum_;
+
+    std::vector<uint8_t> inbound_payload_;
+
+    // We should be using variadic templates for these
+    version_subscriber_type::ptr version_subscriber_;
+    verack_subscriber_type::ptr verack_subscriber_;
+    address_subscriber_type::ptr address_subscriber_;
+    get_address_subscriber_type::ptr get_address_subscriber_;
+    inventory_subscriber_type::ptr inventory_subscriber_;
+    get_data_subscriber_type::ptr get_data_subscriber_;
+    get_blocks_subscriber_type::ptr get_blocks_subscriber_;
+    transaction_subscriber_type::ptr transaction_subscriber_;
+    block_subscriber_type::ptr block_subscriber_;
+
+    raw_subscriber_type::ptr raw_subscriber_;
+    stop_subscriber_type::ptr stop_subscriber_;
+};
+
+} // namespace network
+} // namespace libbitcoin
+
+#endif
+

--- a/include/bitcoin/bitcoin/network/channel_stream_loader.hpp
+++ b/include/bitcoin/bitcoin/network/channel_stream_loader.hpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
  *
  * This file is part of libbitcoin.
@@ -17,45 +17,30 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef LIBBITCOIN_SHARED_CONST_BUFFER_HPP
-#define LIBBITCOIN_SHARED_CONST_BUFFER_HPP
+#ifndef LIBBITCOIN_CHANNEL_STREAM_LOADER_HPP
+#define LIBBITCOIN_CHANNEL_STREAM_LOADER_HPP
 
-#include <memory>
-#include <boost/asio.hpp>
+#include <string>
+#include <vector>
+#include <bitcoin/bitcoin/define.hpp>
+#include <bitcoin/bitcoin/network/channel_loader_module.hpp>
 #include <bitcoin/bitcoin/utility/data.hpp>
 
 namespace libbitcoin {
 namespace network {
 
-// A reference-counted non-modifiable buffer class.
-class BC_API shared_const_buffer
+class BC_API channel_stream_loader
 {
 public:
-     // Construct from a stream object.
-     explicit shared_const_buffer(const data_chunk& user_data)
-     : data_(std::make_shared<data_chunk>(
-            std::begin(user_data), std::end(user_data))),
-        buffer_(boost::asio::buffer(*data_))
-    {
-    }
-
-    // Implement the ConstBufferSequence requirements.
-    typedef boost::asio::const_buffer value_type;
-    typedef const value_type* const_iterator;
-
-    const_iterator begin() const
-    {
-        return &buffer_;
-    }
-
-    const_iterator end() const
-    {
-        return &buffer_ + 1;
-    }
+    ~channel_stream_loader();
+    void add(bc::network::channel_loader_module_base* module);
+    void load_lookup(const std::string& symbol,
+        const bc::data_chunk& stream) const;
 
 private:
-    std::shared_ptr<data_chunk> data_;
-    value_type buffer_;
+    typedef std::vector<channel_loader_module_base*> module_list;
+
+    module_list modules_;
 };
 
 } // namespace network

--- a/include/bitcoin/bitcoin/network/handshake.hpp
+++ b/include/bitcoin/bitcoin/network/handshake.hpp
@@ -20,17 +20,19 @@
 #ifndef LIBBITCOIN_HANDSHAKE_HPP
 #define LIBBITCOIN_HANDSHAKE_HPP
 
-#include <atomic>
+#include <cstdint>
+#include <string>
+#include <system_error>
+#include <boost/asio.hpp>
 #include <bitcoin/bitcoin/define.hpp>
-#include <bitcoin/bitcoin/primitives.hpp>
 #include <bitcoin/bitcoin/network/network.hpp>
-#include <bitcoin/bitcoin/utility/async_parallel.hpp>
+#include <bitcoin/bitcoin/primitives.hpp>
 #include <bitcoin/bitcoin/utility/threadpool.hpp>
 
 namespace libbitcoin {
 namespace network {
 
-class handshake
+class BC_API handshake
 {
 public:
     typedef std::function<void (const std::error_code&)> start_handler;
@@ -47,35 +49,29 @@ public:
 
     typedef std::function<void (const std::error_code&)> setter_handler;
 
-    BC_API handshake(threadpool& pool);
+    handshake(threadpool& pool);
 
     handshake(const handshake&) = delete;
     void operator=(const handshake&) = delete;
 
-    BC_API void start(start_handler handle_start);
-
-    BC_API void ready(channel_ptr node, handshake_handler handle_handshake);
-
-    BC_API void discover_external_ip(discover_ip_handler handle_discover);
-    BC_API void fetch_network_address(
-        fetch_network_address_handler handle_fetch);
-    BC_API void set_port(uint16_t port, setter_handler handle_set);
-    BC_API void set_user_agent(const std::string& user_agent,
+    void start(start_handler handle_start);
+    void ready(channel_ptr node, handshake_handler handle_handshake);
+    void discover_external_ip(discover_ip_handler handle_discover);
+    void fetch_network_address(fetch_network_address_handler handle_fetch);
+    void set_port(uint16_t port, setter_handler handle_set);
+    void set_user_agent(const std::string& user_agent,
         setter_handler handle_set);
-    BC_API void set_start_height(uint32_t height, setter_handler handle_set);
+    void set_start_height(uint32_t height, setter_handler handle_set);
 
 private:
     void handle_connect(const std::error_code& ec,
         channel_ptr node, network::connect_handler handle_connect);
-
     void handle_message_sent(const std::error_code& ec,
-        handshake::handshake_handler completion_callback);
-
+        handshake_handler completion_callback);
     void receive_version(const std::error_code& ec, const version_type&,
         channel_ptr node, handshake::handshake_handler completion_callback);
-
     void receive_verack(const std::error_code& ec, const verack_type&,
-        handshake::handshake_handler completion_callback);
+        handshake_handler completion_callback);
 
     ip_address_type localhost_ip();
     void do_discover_external_ip(discover_ip_handler handler_discover);

--- a/include/bitcoin/bitcoin/network/hosts.hpp
+++ b/include/bitcoin/bitcoin/network/hosts.hpp
@@ -20,6 +20,8 @@
 #ifndef LIBBITCOIN_HOSTS_HPP
 #define LIBBITCOIN_HOSTS_HPP
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <functional>
 #include <system_error>
@@ -32,7 +34,7 @@
 namespace libbitcoin {
 namespace network {
 
-class hosts
+class BC_API hosts
 {
 public:
     typedef std::function<void (const std::error_code&)> load_handler;
@@ -47,27 +49,26 @@ public:
     typedef std::function<void (const std::error_code&, size_t)>
         fetch_count_handler;
 
-    BC_API hosts(threadpool& pool, const std::string& path, 
-        size_t capacity=1000);
-    BC_API ~hosts();
+    hosts(threadpool& pool, const std::string& path, size_t capacity=1000);
+    ~hosts();
 
     hosts(const hosts&) = delete;
     void operator=(const hosts&) = delete;
 
-    BC_API void load(load_handler handle_load);
-    BC_API void save(save_handler handle_save);
+    void load(load_handler handle_load);
+    void save(save_handler handle_save);
 
-    BC_API void store(const network_address_type& address,
+    void store(const network_address_type& address,
         store_handler handle_store);
-    BC_API void remove(const network_address_type& address,
+    void remove(const network_address_type& address,
         remove_handler handle_remove);
-    BC_API void fetch_address(fetch_address_handler handle_fetch);
-    BC_API void fetch_count(fetch_count_handler handle_fetch);
+    void fetch_address(fetch_address_handler handle_fetch);
+    void fetch_count(fetch_count_handler handle_fetch);
 
     /// Deprecated, set hosts path on construct.
-    BC_API hosts(threadpool& pool, size_t capacity=1000);
-    BC_API void load(const std::string& path, load_handler handle_load);
-    BC_API void save(const std::string& path, save_handler handle_save);
+    hosts(threadpool& pool, size_t capacity=1000);
+    void load(const std::string& path, load_handler handle_load);
+    void save(const std::string& path, save_handler handle_save);
 
 private:
     struct hosts_field

--- a/include/bitcoin/bitcoin/utility/data.hpp
+++ b/include/bitcoin/bitcoin/utility/data.hpp
@@ -21,6 +21,7 @@
 #define LIBBITCOIN_DATA_HPP
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <initializer_list>
 #include <vector>

--- a/src/network/acceptor.cpp
+++ b/src/network/acceptor.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <bitcoin/bitcoin/network/acceptor.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include <system_error>
+#include <boost/asio.hpp>
+#include <bitcoin/bitcoin/network/channel.hpp>
+
+namespace libbitcoin {
+namespace network {
+
+using std::placeholders::_1;
+using boost::asio::ip::tcp;
+
+acceptor::acceptor(threadpool& pool, tcp_acceptor_ptr tcp_accept)
+  : pool_(pool), tcp_accept_(tcp_accept)
+{
+}
+
+void acceptor::accept(accept_handler handle_accept)
+{
+    socket_ptr socket = std::make_shared<tcp::socket>(pool_.service());
+    tcp_accept_->async_accept(*socket,
+        std::bind(&acceptor::call_handle_accept, shared_from_this(),
+            _1, socket, handle_accept));
+}
+
+void acceptor::call_handle_accept(const boost::system::error_code& ec,
+    socket_ptr socket, accept_handler handle_accept)
+{
+    if (ec)
+    {
+        handle_accept(error::accept_failed, nullptr);
+        return;
+    }
+
+    auto proxy = std::make_shared<channel_proxy>(pool_, socket);
+    proxy->start();
+    channel_ptr channel_object = std::make_shared<channel>(proxy);
+    handle_accept(std::error_code(), channel_object);
+}
+
+} // namespace network
+} // namespace libbitcoin

--- a/src/network/channel.cpp
+++ b/src/network/channel.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
  *
  * This file is part of libbitcoin.
@@ -19,455 +19,11 @@
  */
 #include <bitcoin/bitcoin/network/channel.hpp>
 
-#include <bitcoin/bitcoin/constants.hpp>
+#include <bitcoin/bitcoin/network/channel_proxy.hpp>
 #include <bitcoin/bitcoin/primitives.hpp>
-#include <bitcoin/bitcoin/utility/endian.hpp>
 
 namespace libbitcoin {
 namespace network {
-
-using std::placeholders::_1;
-using std::placeholders::_2;
-using boost::asio::buffer;
-using boost::asio::io_service;
-using boost::asio::ip::tcp;
-using boost::posix_time::minutes;
-using boost::posix_time::seconds;
-using boost::posix_time::time_duration;
-
-// Connection timeouts (these can be safely adjusted by accessors at runtime).
-const time_duration initial_timeout = seconds(0) + minutes(1);
-const time_duration disconnect_timeout = seconds(0) + minutes(90);
-const time_duration heartbeat_time = seconds(0) + minutes(30);
-
-template <typename Message>
-class channel_loader_module
-  : public channel_loader_module_base
-{
-public:
-    typedef std::function<
-        void (const std::error_code&, const Message&)> load_handler;
-
-    channel_loader_module(load_handler handle_load)
-      : handle_load_(handle_load) {}
-
-    void attempt_load(const data_chunk& stream) const
-    {
-        Message result;
-        try
-        {
-            satoshi_load(stream.begin(), stream.end(), result);
-            handle_load_(std::error_code(), result);
-        }
-        catch (end_of_stream)
-        {
-            handle_load_(error::bad_stream, Message());
-        }
-    }
-
-    const std::string lookup_symbol() const
-    {
-        return satoshi_command(Message());
-    }
-private:
-    load_handler handle_load_;
-};
-
-channel_stream_loader::~channel_stream_loader()
-{
-    for (channel_loader_module_base* module: modules_)
-        delete module;
-}
-
-void channel_stream_loader::add(channel_loader_module_base* module)
-{
-    modules_.push_back(module);
-}
-
-void channel_stream_loader::load_lookup(const std::string& symbol,
-    const data_chunk& stream) const
-{
-    for (channel_loader_module_base* module: modules_)
-        if (module->lookup_symbol() == symbol)
-            module->attempt_load(stream);
-}
-
-channel_proxy::channel_proxy(threadpool& pool, socket_ptr socket)
-  : strand_(pool), socket_(socket),
-    timeout_(pool.service()), heartbeat_(pool.service()), stopped_(false)
-{
-#define CHANNEL_TRANSPORT_MECHANISM(MESSAGE_TYPE) \
-    MESSAGE_TYPE##_subscriber_ = \
-        std::make_shared<MESSAGE_TYPE##_subscriber_type>(pool); \
-    loader_.add(new channel_loader_module<MESSAGE_TYPE##_type>( \
-        std::bind(&MESSAGE_TYPE##_subscriber_type::relay, \
-            MESSAGE_TYPE##_subscriber_, _1, _2)));
-
-    CHANNEL_TRANSPORT_MECHANISM(version);
-    CHANNEL_TRANSPORT_MECHANISM(verack);
-    CHANNEL_TRANSPORT_MECHANISM(address);
-    CHANNEL_TRANSPORT_MECHANISM(get_address);
-    CHANNEL_TRANSPORT_MECHANISM(inventory);
-    CHANNEL_TRANSPORT_MECHANISM(get_data);
-    CHANNEL_TRANSPORT_MECHANISM(get_blocks);
-    CHANNEL_TRANSPORT_MECHANISM(transaction);
-    CHANNEL_TRANSPORT_MECHANISM(block);
-
-#undef CHANNEL_TRANSPORT_MECHANISM
-
-    raw_subscriber_ = std::make_shared<raw_subscriber_type>(pool);
-    stop_subscriber_ = std::make_shared<stop_subscriber_type>(pool);
-}
-
-channel_proxy::~channel_proxy()
-{
-    stop_impl();
-    stop_subscriber_->relay(error::service_stopped);
-}
-
-void channel_proxy::start()
-{
-    read_header();
-    set_timeout(initial_timeout);
-    set_heartbeat(heartbeat_time);
-}
-
-void channel_proxy::stop()
-{
-    auto this_ptr = shared_from_this();
-    auto do_stop = [this, this_ptr]()
-    {
-        stop_impl();
-        stop_subscriber_->relay(error::service_stopped);
-    };
-    strand_.queue(do_stop);
-}
-void channel_proxy::stop_impl()
-{
-    if (stopped_)
-        return;
-    // We need this because the timeout timer shares this code with stop()
-    // But sends a different error_code
-    stopped_ = true;
-    // Ignore the error_code. We don't really care at this point.
-    boost::system::error_code ret_ec;
-    timeout_.cancel(ret_ec);
-    heartbeat_.cancel(ret_ec);
-    // Force the socket closed
-    // Should we do something with these error_codes?
-    socket_->shutdown(boost::asio::ip::tcp::socket::shutdown_both, ret_ec);
-    socket_->close(ret_ec);
-    clear_subscriptions();
-}
-
-void channel_proxy::clear_subscriptions()
-{
-#define CHANNEL_CLEAR_SUBSCRIPTION(MESSAGE_TYPE) \
-    MESSAGE_TYPE##_subscriber_->relay(error::service_stopped, \
-        MESSAGE_TYPE##_type());
-
-    CHANNEL_CLEAR_SUBSCRIPTION(version);
-    CHANNEL_CLEAR_SUBSCRIPTION(verack);
-    CHANNEL_CLEAR_SUBSCRIPTION(address);
-    CHANNEL_CLEAR_SUBSCRIPTION(get_address);
-    CHANNEL_CLEAR_SUBSCRIPTION(inventory);
-    CHANNEL_CLEAR_SUBSCRIPTION(get_data);
-    CHANNEL_CLEAR_SUBSCRIPTION(get_blocks);
-    CHANNEL_CLEAR_SUBSCRIPTION(transaction);
-    CHANNEL_CLEAR_SUBSCRIPTION(block);
-
-#undef CHANNEL_CLEAR_SUBSCRIPTION
-
-    raw_subscriber_->relay(error::service_stopped,
-        header_type(), data_chunk());
-}
-
-bool channel_proxy::stopped() const
-{
-    return stopped_;
-}
-
-bool timer_errors(const boost::system::error_code& ec, bool stopped)
-{
-    if (ec == boost::asio::error::operation_aborted)
-        return true;
-    else if (ec)
-    {
-        log_error(LOG_NETWORK) << ec.message();
-        return true;
-    }
-    else if (stopped)
-        return true;
-    return false;
-}
-
-void channel_proxy::handle_timeout(const boost::system::error_code& ec)
-{
-    if (timer_errors(ec, stopped_))
-        return;
-    log_debug(LOG_NETWORK) << "Forcing disconnect due to timeout.";
-    // No response for a while so disconnect
-    boost::system::error_code ret_ec;
-    tcp::endpoint remote_endpoint = socket_->remote_endpoint(ret_ec);
-    if (!ret_ec)
-        log_debug(LOG_NETWORK) << "Closing channel "
-            << remote_endpoint.address().to_string();
-    stop_impl();
-    stop_subscriber_->relay(error::channel_timeout);
-}
-
-void handle_ping(const std::error_code&)
-{
-    // if there's a problem sending then this channel will be stopped
-}
-void channel_proxy::handle_heartbeat(const boost::system::error_code& ec)
-{
-    if (timer_errors(ec, stopped_))
-        return;
-    send(ping_type(), handle_ping);
-}
-
-void channel_proxy::set_timeout(const time_duration timeout)
-{
-    timeout_.cancel();
-    timeout_.expires_from_now(timeout);
-    timeout_.async_wait(strand_.wrap(
-        &channel_proxy::handle_timeout, shared_from_this(), _1));
-}
-void channel_proxy::set_heartbeat(const time_duration timeout)
-{
-    heartbeat_.cancel();
-    heartbeat_.expires_from_now(timeout);
-    heartbeat_.async_wait(std::bind(
-        &channel_proxy::handle_heartbeat, shared_from_this(), _1));
-}
-void channel_proxy::reset_timers()
-{
-    set_timeout(disconnect_timeout);
-    set_heartbeat(heartbeat_time);
-}
-
-bool channel_proxy::problems_check(const boost::system::error_code& ec)
-{
-    if (stopped_)
-        return true;
-    else if (!ec)
-        return false;
-    stop();
-    return true;
-}
-
-void channel_proxy::read_header()
-{
-    async_read(*socket_, buffer(inbound_header_),
-        strand_.wrap(&channel_proxy::handle_read_header,
-            shared_from_this(), _1, _2));
-}
-
-void channel_proxy::read_checksum(const header_type& header_msg)
-{
-    async_read(*socket_, buffer(inbound_checksum_),
-        strand_.wrap(&channel_proxy::handle_read_checksum,
-            shared_from_this(), _1, _2, header_msg));
-}
-
-void channel_proxy::read_payload(const header_type& header_msg)
-{
-    inbound_payload_.resize(header_msg.payload_length);
-    async_read(*socket_, buffer(inbound_payload_, header_msg.payload_length),
-        strand_.wrap(&channel_proxy::handle_read_payload,
-            shared_from_this(), _1, _2, header_msg));
-}
-
-void channel_proxy::handle_read_header(const boost::system::error_code& ec,
-    size_t DEBUG_ONLY(bytes_transferred))
-{
-    if (problems_check(ec))
-        return;
-    BITCOIN_ASSERT(bytes_transferred == header_chunk_size);
-    data_slice header_stream(inbound_header_);
-    header_type header_msg;
-    satoshi_load(header_stream.begin(), header_stream.end(), header_msg);
-
-    if (header_msg.magic != magic_value())
-    {
-        log_debug(LOG_NETWORK) << "Bad header received.";
-        stop();
-        return;
-    }
-
-    log_debug(LOG_NETWORK) << "r: " << header_msg.command
-            << " (" << header_msg.payload_length << " bytes)";
-    read_checksum(header_msg);
-    reset_timers();
-}
-
-void channel_proxy::handle_read_checksum(const boost::system::error_code& ec,
-    size_t DEBUG_ONLY(bytes_transferred), header_type& header_msg)
-{
-    if (problems_check(ec))
-        return;
-    BITCOIN_ASSERT(bytes_transferred == header_checksum_size);
-    header_msg.checksum =
-        from_little_endian<uint32_t>(
-            inbound_checksum_.begin(), inbound_checksum_.end());
-    read_payload(header_msg);
-    reset_timers();
-}
-
-void channel_proxy::handle_read_payload(const boost::system::error_code& ec,
-    size_t DEBUG_ONLY(bytes_transferred), const header_type& header_msg)
-{
-    if (problems_check(ec))
-        return;
-    BITCOIN_ASSERT(bytes_transferred == header_msg.payload_length);
-    data_chunk payload_stream = data_chunk(
-        inbound_payload_.begin(), inbound_payload_.end());
-    BITCOIN_ASSERT(payload_stream.size() == header_msg.payload_length);
-    if (header_msg.checksum != bitcoin_checksum(payload_stream))
-    {
-        log_warning(LOG_NETWORK) << "Bad checksum!";
-        raw_subscriber_->relay(error::bad_stream,
-            header_type(), data_chunk());
-        stop();
-        return;
-    }
-    raw_subscriber_->relay(std::error_code(),
-        header_msg, inbound_payload_);
-
-    // This must happen before calling subscribe notification handlers
-    // In case user tries to stop() this channel.
-    read_header();
-    reset_timers();
-
-    loader_.load_lookup(header_msg.command, payload_stream);
-}
-
-void channel_proxy::call_handle_send(const boost::system::error_code& ec,
-    send_handler handle_send)
-{
-    if (problems_check(ec))
-        handle_send(error::service_stopped);
-    else
-        handle_send(std::error_code());
-}
-
-void channel_proxy::subscribe_version(receive_version_handler handle_receive)
-{
-    generic_subscribe<version_type>(
-        handle_receive, version_subscriber_);
-}
-void channel_proxy::subscribe_verack(receive_verack_handler handle_receive)
-{
-    generic_subscribe<verack_type>(
-        handle_receive, verack_subscriber_);
-}
-void channel_proxy::subscribe_address(receive_address_handler handle_receive)
-{
-    generic_subscribe<address_type>(
-        handle_receive, address_subscriber_);
-}
-void channel_proxy::subscribe_inventory(
-    receive_inventory_handler handle_receive)
-{
-    generic_subscribe<inventory_type>(
-        handle_receive, inventory_subscriber_);
-}
-void channel_proxy::subscribe_get_data(
-    receive_get_data_handler handle_receive)
-{
-    generic_subscribe<get_data_type>(
-        handle_receive, get_data_subscriber_);
-}
-void channel_proxy::subscribe_get_blocks(
-    receive_get_blocks_handler handle_receive)
-{
-    generic_subscribe<get_blocks_type>(
-        handle_receive, get_blocks_subscriber_);
-}
-void channel_proxy::subscribe_transaction(
-    receive_transaction_handler handle_receive)
-{
-    generic_subscribe<transaction_type>(
-        handle_receive, transaction_subscriber_);
-}
-void channel_proxy::subscribe_block(receive_block_handler handle_receive)
-{
-    generic_subscribe<block_type>(
-        handle_receive, block_subscriber_);
-}
-void channel_proxy::subscribe_get_address(
-    receive_get_address_handler handle_receive)
-{
-    generic_subscribe<get_address_type>(
-        handle_receive, get_address_subscriber_);
-}
-void channel_proxy::subscribe_raw(receive_raw_handler handle_receive)
-{
-    if (stopped_)
-        handle_receive(error::service_stopped,
-            header_type(), data_chunk());
-    else
-        raw_subscriber_->subscribe(handle_receive);
-}
-
-void channel_proxy::subscribe_stop(stop_handler handle_stop)
-{
-    if (stopped_)
-        handle_stop(error::service_stopped);
-    else
-        stop_subscriber_->subscribe(handle_stop);
-}
-
-void channel_proxy::send_raw(const header_type& packet_header,
-    const data_chunk& payload, send_handler handle_send)
-{
-    if (stopped_)
-        handle_send(error::service_stopped);
-    else
-        strand_.queue(&channel_proxy::do_send_raw,
-            shared_from_this(), packet_header, payload, handle_send);
-}
-
-void channel_proxy::do_send_raw(const header_type& packet_header,
-    const data_chunk& payload, send_handler handle_send)
-{
-    data_chunk raw_header(satoshi_raw_size(packet_header));
-    satoshi_save(packet_header, raw_header.begin());
-    // Construct completed packet with header + payload
-    data_chunk whole_message = raw_header;
-    extend_data(whole_message, payload);
-    do_send_common(whole_message, handle_send);
-}
-
-void channel_proxy::send_common(const data_chunk& whole_message,
-    send_handler handle_send)
-{
-    if (stopped_)
-    {
-        handle_send(error::service_stopped);
-    }
-    else
-    {
-        auto this_ptr = shared_from_this();
-        strand_.queue(
-            [this, this_ptr, whole_message, handle_send]
-            {
-                do_send_common(whole_message, handle_send);
-            });
-    }
-}
-
-void channel_proxy::do_send_common(const data_chunk& whole_message,
-    send_handler handle_send)
-{
-    shared_const_buffer buffer(whole_message);
-    async_write(*socket_, buffer,
-        std::bind(&channel_proxy::call_handle_send, shared_from_this(),
-            std::placeholders::_1, handle_send));
-}
-
-// channel
 
 channel::channel(channel_proxy_ptr proxy)
 {
@@ -478,27 +34,26 @@ channel::~channel()
     stop();
 }
 
+// Slowly shutdown
 void channel::stop()
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
-    // Slowly shutdown
+    const auto proxy = weak_proxy_.lock();
     if (proxy)
         proxy->stop();
 }
 bool channel::stopped() const
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
-    // Slowly shutdown
-    if (!proxy)
-        return true;
-    else
+    const auto proxy = weak_proxy_.lock();
+    if (proxy)
         return proxy->stopped();
+
+    return true;
 }
 
 void channel::send_raw(const header_type& packet_header,
     const data_chunk& payload, channel_proxy::send_handler handle_send)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_send(error::service_stopped);
     else
@@ -508,7 +63,7 @@ void channel::send_raw(const header_type& packet_header,
 void channel::subscribe_version(
     channel_proxy::receive_version_handler handle_receive)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_receive(error::service_stopped, version_type());
     else
@@ -517,7 +72,7 @@ void channel::subscribe_version(
 void channel::subscribe_verack(
     channel_proxy::receive_verack_handler handle_receive)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_receive(error::service_stopped, verack_type());
     else
@@ -526,7 +81,7 @@ void channel::subscribe_verack(
 void channel::subscribe_address(
     channel_proxy::receive_address_handler handle_receive)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_receive(error::service_stopped, address_type());
     else
@@ -535,7 +90,7 @@ void channel::subscribe_address(
 void channel::subscribe_get_address(
     channel_proxy::receive_get_address_handler handle_receive)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_receive(error::service_stopped, get_address_type());
     else
@@ -544,7 +99,7 @@ void channel::subscribe_get_address(
 void channel::subscribe_inventory(
     channel_proxy::receive_inventory_handler handle_receive)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_receive(error::service_stopped, inventory_type());
     else
@@ -553,7 +108,7 @@ void channel::subscribe_inventory(
 void channel::subscribe_get_data(
     channel_proxy::receive_get_data_handler handle_receive)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_receive(error::service_stopped, get_data_type());
     else
@@ -562,7 +117,7 @@ void channel::subscribe_get_data(
 void channel::subscribe_get_blocks(
     channel_proxy::receive_get_blocks_handler handle_receive)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_receive(error::service_stopped, get_blocks_type());
     else
@@ -580,7 +135,7 @@ void channel::subscribe_transaction(
 void channel::subscribe_block(
     channel_proxy::receive_block_handler handle_receive)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_receive(error::service_stopped, block_type());
     else
@@ -589,7 +144,7 @@ void channel::subscribe_block(
 void channel::subscribe_raw(
     channel_proxy::receive_raw_handler handle_receive)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_receive(error::service_stopped,
             header_type(), data_chunk());
@@ -600,7 +155,7 @@ void channel::subscribe_raw(
 void channel::subscribe_stop(
     channel_proxy::stop_handler handle_stop)
 {
-    channel_proxy_ptr proxy = weak_proxy_.lock();
+    const auto proxy = weak_proxy_.lock();
     if (!proxy)
         handle_stop(error::service_stopped);
     else

--- a/src/network/channel_proxy.cpp
+++ b/src/network/channel_proxy.cpp
@@ -1,0 +1,442 @@
+/**
+ * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <bitcoin/bitcoin/network/channel_proxy.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <system_error>
+#include <boost/asio.hpp>
+#include <boost/date_time.hpp>
+#include <bitcoin/bitcoin/math/checksum.hpp>
+#include <bitcoin/bitcoin/network/channel_loader_module.hpp>
+#include <bitcoin/bitcoin/network/shared_const_buffer.hpp>
+#include <bitcoin/bitcoin/primitives.hpp>
+#include <bitcoin/bitcoin/satoshi_serialize.hpp>
+#include <bitcoin/bitcoin/utility/assert.hpp>
+#include <bitcoin/bitcoin/utility/data.hpp>
+#include <bitcoin/bitcoin/utility/endian.hpp>
+#include <bitcoin/bitcoin/utility/logger.hpp>
+#include <bitcoin/bitcoin/utility/serializer.hpp>
+
+namespace libbitcoin {
+namespace network {
+
+using std::placeholders::_1;
+using std::placeholders::_2;
+using boost::asio::buffer;
+using boost::asio::io_service;
+using boost::asio::ip::tcp;
+using boost::posix_time::minutes;
+using boost::posix_time::seconds;
+using boost::posix_time::time_duration;
+
+// Connection timeout (these could be safely adjusted by accessors at runtime).
+static const auto initial_timeout = seconds(0) + minutes(1);
+static const auto disconnect_timeout = seconds(0) + minutes(90);
+static const auto heartbeat_time = seconds(0) + minutes(30);
+
+channel_proxy::channel_proxy(threadpool& pool, socket_ptr socket)
+  : strand_(pool), socket_(socket), timeout_(pool.service()), 
+    heartbeat_(pool.service()), stopped_(false)
+{
+#define CHANNEL_TRANSPORT_MECHANISM(MESSAGE_TYPE) \
+    MESSAGE_TYPE##_subscriber_ = \
+        std::make_shared<MESSAGE_TYPE##_subscriber_type>(pool); \
+    loader_.add(new channel_loader_module<MESSAGE_TYPE##_type>( \
+        std::bind(&MESSAGE_TYPE##_subscriber_type::relay, \
+            MESSAGE_TYPE##_subscriber_, _1, _2)));
+
+    CHANNEL_TRANSPORT_MECHANISM(version);
+    CHANNEL_TRANSPORT_MECHANISM(verack);
+    CHANNEL_TRANSPORT_MECHANISM(address);
+    CHANNEL_TRANSPORT_MECHANISM(get_address);
+    CHANNEL_TRANSPORT_MECHANISM(inventory);
+    CHANNEL_TRANSPORT_MECHANISM(get_data);
+    CHANNEL_TRANSPORT_MECHANISM(get_blocks);
+    CHANNEL_TRANSPORT_MECHANISM(transaction);
+    CHANNEL_TRANSPORT_MECHANISM(block);
+
+#undef CHANNEL_TRANSPORT_MECHANISM
+
+    raw_subscriber_ = std::make_shared<raw_subscriber_type>(pool);
+    stop_subscriber_ = std::make_shared<stop_subscriber_type>(pool);
+}
+
+channel_proxy::~channel_proxy()
+{
+    stop_impl();
+    stop_subscriber_->relay(error::service_stopped);
+}
+
+void channel_proxy::start()
+{
+    read_header();
+    set_timeout(initial_timeout);
+    set_heartbeat(heartbeat_time);
+}
+
+void channel_proxy::stop()
+{
+    auto this_ptr = shared_from_this();
+    auto do_stop = [this, this_ptr]()
+    {
+        stop_impl();
+        stop_subscriber_->relay(error::service_stopped);
+    };
+    strand_.queue(do_stop);
+}
+void channel_proxy::stop_impl()
+{
+    if (stopped_)
+        return;
+
+    // We need this because the timeout timer shares this code with stop()
+    // But sends a different error_code
+    stopped_ = true;
+
+    // Ignore the error_code. We don't really care at this point.
+    boost::system::error_code ret_ec;
+    timeout_.cancel(ret_ec);
+    heartbeat_.cancel(ret_ec);
+
+    // Force the socket closed
+    // Should we do something with these error_codes?
+    socket_->shutdown(boost::asio::ip::tcp::socket::shutdown_both, ret_ec);
+    socket_->close(ret_ec);
+    clear_subscriptions();
+}
+
+void channel_proxy::clear_subscriptions()
+{
+#define CHANNEL_CLEAR_SUBSCRIPTION(MESSAGE_TYPE) \
+    MESSAGE_TYPE##_subscriber_->relay(error::service_stopped, \
+        MESSAGE_TYPE##_type());
+
+    CHANNEL_CLEAR_SUBSCRIPTION(version);
+    CHANNEL_CLEAR_SUBSCRIPTION(verack);
+    CHANNEL_CLEAR_SUBSCRIPTION(address);
+    CHANNEL_CLEAR_SUBSCRIPTION(get_address);
+    CHANNEL_CLEAR_SUBSCRIPTION(inventory);
+    CHANNEL_CLEAR_SUBSCRIPTION(get_data);
+    CHANNEL_CLEAR_SUBSCRIPTION(get_blocks);
+    CHANNEL_CLEAR_SUBSCRIPTION(transaction);
+    CHANNEL_CLEAR_SUBSCRIPTION(block);
+
+#undef CHANNEL_CLEAR_SUBSCRIPTION
+
+    raw_subscriber_->relay(error::service_stopped,
+        header_type(), data_chunk());
+}
+
+bool channel_proxy::stopped() const
+{
+    return stopped_;
+}
+
+bool timer_errors(const boost::system::error_code& ec, bool stopped)
+{
+    if (ec == boost::asio::error::operation_aborted)
+        return true;
+
+    if (ec)
+    {
+        log_error(LOG_NETWORK) << ec.message();
+        return true;
+    }
+
+    return stopped;
+}
+
+void channel_proxy::handle_timeout(const boost::system::error_code& ec)
+{
+    if (timer_errors(ec, stopped_))
+        return;
+
+    log_debug(LOG_NETWORK) << "Forcing disconnect due to timeout.";
+
+    // No response for a while so disconnect
+    boost::system::error_code ret_ec;
+    const auto remote_endpoint = socket_->remote_endpoint(ret_ec);
+    if (!ret_ec)
+        log_debug(LOG_NETWORK) << "Closing channel "
+            << remote_endpoint.address().to_string();
+
+    stop_impl();
+    stop_subscriber_->relay(error::channel_timeout);
+}
+
+void handle_ping(const std::error_code&)
+{
+    // if there's a problem sending then this channel will be stopped
+}
+void channel_proxy::handle_heartbeat(const boost::system::error_code& ec)
+{
+    if (timer_errors(ec, stopped_))
+        return;
+
+    send(ping_type(), handle_ping);
+}
+
+void channel_proxy::set_timeout(const time_duration timeout)
+{
+    timeout_.cancel();
+    timeout_.expires_from_now(timeout);
+    timeout_.async_wait(strand_.wrap(
+        &channel_proxy::handle_timeout, shared_from_this(), _1));
+}
+void channel_proxy::set_heartbeat(const time_duration timeout)
+{
+    heartbeat_.cancel();
+    heartbeat_.expires_from_now(timeout);
+    heartbeat_.async_wait(std::bind(
+        &channel_proxy::handle_heartbeat, shared_from_this(), _1));
+}
+void channel_proxy::reset_timers()
+{
+    set_timeout(disconnect_timeout);
+    set_heartbeat(heartbeat_time);
+}
+
+bool channel_proxy::problems_check(const boost::system::error_code& ec)
+{
+    if (stopped_)
+        return true;
+
+    if (!ec)
+        return false;
+
+    stop();
+    return true;
+}
+
+void channel_proxy::read_header()
+{
+    async_read(*socket_, buffer(inbound_header_),
+        strand_.wrap(&channel_proxy::handle_read_header,
+            shared_from_this(), _1, _2));
+}
+
+void channel_proxy::read_checksum(const header_type& header_msg)
+{
+    async_read(*socket_, buffer(inbound_checksum_),
+        strand_.wrap(&channel_proxy::handle_read_checksum,
+            shared_from_this(), _1, _2, header_msg));
+}
+
+void channel_proxy::read_payload(const header_type& header_msg)
+{
+    inbound_payload_.resize(header_msg.payload_length);
+    async_read(*socket_, buffer(inbound_payload_, header_msg.payload_length),
+        strand_.wrap(&channel_proxy::handle_read_payload,
+            shared_from_this(), _1, _2, header_msg));
+}
+
+void channel_proxy::handle_read_header(const boost::system::error_code& ec,
+    size_t DEBUG_ONLY(bytes_transferred))
+{
+    if (problems_check(ec))
+        return;
+
+    BITCOIN_ASSERT(bytes_transferred == header_chunk_size);
+    header_type header_msg;
+    data_slice header_stream(inbound_header_);
+    satoshi_load(header_stream.begin(), header_stream.end(), header_msg);
+    if (header_msg.magic != magic_value())
+    {
+        log_debug(LOG_NETWORK) << "Bad header received.";
+        stop();
+        return;
+    }
+
+    log_debug(LOG_NETWORK) << "r: " << header_msg.command
+            << " (" << header_msg.payload_length << " bytes)";
+    read_checksum(header_msg);
+    reset_timers();
+}
+
+void channel_proxy::handle_read_checksum(const boost::system::error_code& ec,
+    size_t DEBUG_ONLY(bytes_transferred), header_type& header_msg)
+{
+    if (problems_check(ec))
+        return;
+
+    BITCOIN_ASSERT(bytes_transferred == header_checksum_size);
+    header_msg.checksum =
+        from_little_endian<uint32_t>(
+            inbound_checksum_.begin(), inbound_checksum_.end());
+
+    read_payload(header_msg);
+    reset_timers();
+}
+
+void channel_proxy::handle_read_payload(const boost::system::error_code& ec,
+    size_t DEBUG_ONLY(bytes_transferred), const header_type& header_msg)
+{
+    if (problems_check(ec))
+        return;
+
+    BITCOIN_ASSERT(bytes_transferred == header_msg.payload_length);
+    const auto payload_stream = data_chunk(
+        inbound_payload_.begin(), inbound_payload_.end());
+
+    BITCOIN_ASSERT(payload_stream.size() == header_msg.payload_length);
+    if (header_msg.checksum != bitcoin_checksum(payload_stream))
+    {
+        log_warning(LOG_NETWORK) << "Bad checksum!";
+        raw_subscriber_->relay(error::bad_stream, header_type(), data_chunk());
+        stop();
+        return;
+    }
+
+    raw_subscriber_->relay(std::error_code(), header_msg, inbound_payload_);
+
+    // This must happen before calling subscribe notification handlers
+    // In case user tries to stop() this channel.
+    read_header();
+    reset_timers();
+
+    loader_.load_lookup(header_msg.command, payload_stream);
+}
+
+void channel_proxy::call_handle_send(const boost::system::error_code& ec,
+    send_handler handle_send)
+{
+    if (problems_check(ec))
+        handle_send(error::service_stopped);
+    else
+        handle_send(std::error_code());
+}
+
+void channel_proxy::subscribe_version(receive_version_handler handle_receive)
+{
+    generic_subscribe<version_type>(
+        handle_receive, version_subscriber_);
+}
+void channel_proxy::subscribe_verack(receive_verack_handler handle_receive)
+{
+    generic_subscribe<verack_type>(
+        handle_receive, verack_subscriber_);
+}
+void channel_proxy::subscribe_address(receive_address_handler handle_receive)
+{
+    generic_subscribe<address_type>(
+        handle_receive, address_subscriber_);
+}
+void channel_proxy::subscribe_inventory(
+    receive_inventory_handler handle_receive)
+{
+    generic_subscribe<inventory_type>(
+        handle_receive, inventory_subscriber_);
+}
+void channel_proxy::subscribe_get_data(
+    receive_get_data_handler handle_receive)
+{
+    generic_subscribe<get_data_type>(
+        handle_receive, get_data_subscriber_);
+}
+void channel_proxy::subscribe_get_blocks(
+    receive_get_blocks_handler handle_receive)
+{
+    generic_subscribe<get_blocks_type>(
+        handle_receive, get_blocks_subscriber_);
+}
+void channel_proxy::subscribe_transaction(
+    receive_transaction_handler handle_receive)
+{
+    generic_subscribe<transaction_type>(
+        handle_receive, transaction_subscriber_);
+}
+void channel_proxy::subscribe_block(receive_block_handler handle_receive)
+{
+    generic_subscribe<block_type>(
+        handle_receive, block_subscriber_);
+}
+void channel_proxy::subscribe_get_address(
+    receive_get_address_handler handle_receive)
+{
+    generic_subscribe<get_address_type>(
+        handle_receive, get_address_subscriber_);
+}
+void channel_proxy::subscribe_raw(receive_raw_handler handle_receive)
+{
+    if (stopped_)
+        handle_receive(error::service_stopped, header_type(), data_chunk());
+    else
+        raw_subscriber_->subscribe(handle_receive);
+}
+
+void channel_proxy::subscribe_stop(stop_handler handle_stop)
+{
+    if (stopped_)
+        handle_stop(error::service_stopped);
+    else
+        stop_subscriber_->subscribe(handle_stop);
+}
+
+void channel_proxy::send_raw(const header_type& packet_header,
+    const data_chunk& payload, send_handler handle_send)
+{
+    if (stopped_)
+        handle_send(error::service_stopped);
+    else
+        strand_.queue(&channel_proxy::do_send_raw,
+            shared_from_this(), packet_header, payload, handle_send);
+}
+
+void channel_proxy::do_send_raw(const header_type& packet_header,
+    const data_chunk& payload, send_handler handle_send)
+{
+    data_chunk raw_header(satoshi_raw_size(packet_header));
+    satoshi_save(packet_header, raw_header.begin());
+
+    // Construct completed packet with header + payload
+    data_chunk whole_message = raw_header;
+    extend_data(whole_message, payload);
+    do_send_common(whole_message, handle_send);
+}
+
+void channel_proxy::send_common(const data_chunk& whole_message,
+    send_handler handle_send)
+{
+    if (stopped_)
+    {
+        handle_send(error::service_stopped);
+        return;
+    }
+
+    auto this_ptr = shared_from_this();
+    strand_.queue([this, this_ptr, whole_message, handle_send]
+    {
+        do_send_common(whole_message, handle_send);
+    });
+}
+
+void channel_proxy::do_send_common(const data_chunk& whole_message,
+    send_handler handle_send)
+{
+    shared_const_buffer buffer(whole_message);
+    async_write(*socket_, buffer,
+        std::bind(&channel_proxy::call_handle_send, shared_from_this(),
+            std::placeholders::_1, handle_send));
+}
+
+} // namespace network
+} // namespace libbitcoin

--- a/src/network/connect_with_timeout.cpp
+++ b/src/network/connect_with_timeout.cpp
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "connect_with_timeout.hpp"
+
+#include <functional>
+#include <memory>
+#include <boost/asio.hpp>
+#include <boost/date_time.hpp>
+#include <bitcoin/bitcoin/utility/assert.hpp>
+#include <bitcoin/bitcoin/network/channel.hpp>
+#include <bitcoin/bitcoin/network/channel_proxy.hpp>
+#include <bitcoin/bitcoin/network/network.hpp>
+#include <bitcoin/bitcoin/utility/threadpool.hpp>
+
+namespace libbitcoin {
+namespace network {
+
+using std::placeholders::_1;
+using std::placeholders::_2;
+using boost::asio::ip::tcp;
+using boost::posix_time::time_duration;
+
+connect_with_timeout::connect_with_timeout(threadpool& pool)
+  : timer_(pool.service()),
+    socket_(std::make_shared<tcp::socket>(pool.service())),
+    proxy_(std::make_shared<channel_proxy>(pool, socket_))
+{
+}
+
+void connect_with_timeout::start(tcp::resolver::iterator endpoint_iterator,
+    time_duration timeout, network::connect_handler handle_connect)
+{
+    timer_.expires_from_now(timeout);
+    timer_.async_wait(std::bind(
+        &connect_with_timeout::close, shared_from_this(), _1));
+
+    boost::asio::async_connect(*socket_, endpoint_iterator,
+        std::bind(&connect_with_timeout::call_connect_handler,
+            shared_from_this(), _1, _2, handle_connect));
+}
+
+
+void connect_with_timeout::call_connect_handler(
+    const boost::system::error_code& ec, tcp::resolver::iterator, 
+    network::connect_handler handle_connect)
+{
+    if (ec)
+    {
+        handle_connect(error::network_unreachable, nullptr);
+        return;
+    }
+
+    timer_.cancel();
+    proxy_->start();
+    channel_ptr channel_object = std::make_shared<channel>(proxy_);
+    handle_connect(std::error_code(), channel_object);
+}
+
+void connect_with_timeout::close(const boost::system::error_code& ec)
+{
+    // ec should be boost::asio::error::operation_aborted or nothing.
+    BITCOIN_ASSERT(!ec || ec == boost::asio::error::operation_aborted);
+    if (!ec)
+        proxy_->stop();
+}
+
+} // namespace network
+} // namespace libbitcoin

--- a/src/network/connect_with_timeout.hpp
+++ b/src/network/connect_with_timeout.hpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2011-2013 libbitcoin developers (see AUTHORS)
  *
  * This file is part of libbitcoin.
@@ -17,49 +17,38 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef LIBBITCOIN_SHARED_CONST_BUFFER_HPP
-#define LIBBITCOIN_SHARED_CONST_BUFFER_HPP
-
 #include <memory>
 #include <boost/asio.hpp>
-#include <bitcoin/bitcoin/utility/data.hpp>
+#include <boost/date_time.hpp>
+#include <bitcoin/bitcoin/network/channel.hpp>
+#include <bitcoin/bitcoin/network/channel_proxy.hpp>
+#include <bitcoin/bitcoin/network/network.hpp>
 
 namespace libbitcoin {
 namespace network {
 
-// A reference-counted non-modifiable buffer class.
-class BC_API shared_const_buffer
+using boost::asio::ip::tcp;
+using boost::posix_time::time_duration;
+
+class connect_with_timeout
+  : public std::enable_shared_from_this<connect_with_timeout>
 {
 public:
-     // Construct from a stream object.
-     explicit shared_const_buffer(const data_chunk& user_data)
-     : data_(std::make_shared<data_chunk>(
-            std::begin(user_data), std::end(user_data))),
-        buffer_(boost::asio::buffer(*data_))
-    {
-    }
+    connect_with_timeout(threadpool& pool);
 
-    // Implement the ConstBufferSequence requirements.
-    typedef boost::asio::const_buffer value_type;
-    typedef const value_type* const_iterator;
-
-    const_iterator begin() const
-    {
-        return &buffer_;
-    }
-
-    const_iterator end() const
-    {
-        return &buffer_ + 1;
-    }
+    void start(tcp::resolver::iterator endpoint_iterator,
+        time_duration timeout, network::connect_handler handle_connect);
 
 private:
-    std::shared_ptr<data_chunk> data_;
-    value_type buffer_;
+    void call_connect_handler(const boost::system::error_code& ec,
+        tcp::resolver::iterator, network::connect_handler handle_connect);
+
+    void close(const boost::system::error_code& ec);
+
+    socket_ptr socket_;
+    channel::channel_proxy_ptr proxy_;
+    boost::asio::deadline_timer timer_;
 };
 
 } // namespace network
 } // namespace libbitcoin
-
-#endif
-

--- a/src/network/handshake.cpp
+++ b/src/network/handshake.cpp
@@ -26,6 +26,7 @@
 #include <bitcoin/bitcoin/define.hpp>
 #include <bitcoin/bitcoin/network/channel.hpp>
 #include <bitcoin/bitcoin/network/network.hpp>
+#include <bitcoin/bitcoin/utility/async_parallel.hpp>
 #include <bitcoin/bitcoin/version.hpp>
 namespace libbitcoin {
 namespace network {

--- a/src/network/hosts.cpp
+++ b/src/network/hosts.cpp
@@ -99,6 +99,7 @@ void hosts::do_load(const path& path, load_handler handle_load)
                 buffer_.push_back(field);
             });
     }
+
     handle_load(std::error_code());
 }
 
@@ -163,6 +164,7 @@ void hosts::do_remove(const network_address_type& address,
         handle_remove(error::not_found);
         return;
     }
+
     buffer_.erase(it);
     handle_remove(std::error_code());
 }
@@ -180,6 +182,7 @@ void hosts::do_fetch_address(fetch_address_handler handle_fetch)
         handle_fetch(error::not_found, network_address_type());
         return;
     }
+
     size_t index = rand() % buffer_.size();
     network_address_type address;
     address.timestamp = 0;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -22,8 +22,11 @@
 #include <algorithm>
 #include <functional>
 #include <iostream>
+#include <boost/asio.hpp>
+#include <boost/date_time.hpp>
 #include <bitcoin/bitcoin/network/channel.hpp>
 #include <bitcoin/bitcoin/utility/logger.hpp>
+#include "connect_with_timeout.hpp"
 
 namespace libbitcoin {
 namespace network {
@@ -34,84 +37,8 @@ using boost::asio::ip::tcp;
 using boost::posix_time::seconds;
 using boost::posix_time::time_duration;
 
-const time_duration connect_timeout = seconds(5);
-
-acceptor::acceptor(threadpool& pool, tcp_acceptor_ptr tcp_accept)
-  : pool_(pool), tcp_accept_(tcp_accept)
-{
-}
-void acceptor::accept(accept_handler handle_accept)
-{
-    socket_ptr socket =
-        std::make_shared<tcp::socket>(pool_.service());
-    tcp_accept_->async_accept(*socket,
-        std::bind(&acceptor::call_handle_accept, shared_from_this(),
-            _1, socket, handle_accept));
-}
-void acceptor::call_handle_accept(const boost::system::error_code& ec,
-    socket_ptr socket, accept_handler handle_accept)
-{
-    if (ec)
-    {
-        handle_accept(error::accept_failed, nullptr);
-        return;
-    }
-    auto proxy = std::make_shared<channel_proxy>(pool_, socket);
-    proxy->start();
-    channel_ptr channel_object = std::make_shared<channel>(proxy);
-    handle_accept(std::error_code(), channel_object);
-}
-
-class perform_connect_with_timeout
-  : public std::enable_shared_from_this<perform_connect_with_timeout>
-{
-public:
-    perform_connect_with_timeout(threadpool& pool)
-      : timer_(pool.service())
-    {
-        socket_ = std::make_shared<tcp::socket>(pool.service());
-        proxy_ = std::make_shared<channel_proxy>(pool, socket_);
-    }
-
-    void start(tcp::resolver::iterator endpoint_iterator,
-        time_duration timeout, network::connect_handler handle_connect)
-    {
-        timer_.expires_from_now(timeout);
-        timer_.async_wait(std::bind(
-            &perform_connect_with_timeout::close, shared_from_this(), _1));
-
-        boost::asio::async_connect(*socket_, endpoint_iterator,
-            std::bind(&perform_connect_with_timeout::call_connect_handler,
-                shared_from_this(), _1, _2, handle_connect));
-    }
-
-private:
-    void call_connect_handler(const boost::system::error_code& ec,
-        tcp::resolver::iterator, network::connect_handler handle_connect)
-    {
-        if (ec)
-        {
-            handle_connect(error::network_unreachable, nullptr);
-            return;
-        }
-        timer_.cancel();
-        proxy_->start();
-        channel_ptr channel_object = std::make_shared<channel>(proxy_);
-        handle_connect(std::error_code(), channel_object);
-    }
-
-    void close(const boost::system::error_code& ec)
-    {
-        // ec should be boost::asio::error::operation_aborted or nothing.
-        BITCOIN_ASSERT(!ec || ec == boost::asio::error::operation_aborted);
-        if (!ec)
-            proxy_->stop();
-    }
-
-    socket_ptr socket_;
-    channel::channel_proxy_ptr proxy_;
-    boost::asio::deadline_timer timer_;
-};
+// TODO: parameterize for config access.
+static const auto connect_timeout = seconds(5);
 
 network::network(threadpool& pool)
   : pool_(pool)
@@ -127,24 +54,23 @@ void network::resolve_handler(const boost::system::error_code& ec,
         handle_connect(error::resolve_failed, nullptr);
         return;
     }
-    auto connect =
-        std::make_shared<perform_connect_with_timeout>(pool_);
+
+    const auto connect = std::make_shared<connect_with_timeout>(pool_);
     connect->start(endpoint_iterator, connect_timeout, handle_connect);
 }
 
 void network::connect(const std::string& hostname, uint16_t port,
     connect_handler handle_connect)
 {
-    resolver_ptr resolver =
-        std::make_shared<tcp::resolver>(pool_.service());
-    query_ptr query =
-        std::make_shared<tcp::resolver::query>(hostname, std::to_string(port));
+    const auto resolver = std::make_shared<tcp::resolver>(pool_.service());
+    const auto  query = std::make_shared<tcp::resolver::query>(
+        hostname, std::to_string(port));
     resolver->async_resolve(*query,
         std::bind(&network::resolve_handler,
             this, _1, _2, handle_connect, resolver, query));
 }
 
-// I personally don't like how exceptions mess with the program flow
+// I personally don't like how exceptions mess with the program flow.
 bool listen_error(const boost::system::error_code& ec,
     network::listen_handler handle_listen)
 {
@@ -153,38 +79,41 @@ bool listen_error(const boost::system::error_code& ec,
         handle_listen(error::address_in_use, nullptr);
         return true;
     }
-    else if (ec)
+
+    if (ec)
     {
         handle_listen(error::listen_failed, nullptr);
         return true;
     }
+
     return false;
 }
 void network::listen(uint16_t port, listen_handler handle_listen)
 {
     tcp::endpoint endpoint(tcp::v4(), port);
-    acceptor::tcp_acceptor_ptr tcp_accept =
-        std::make_shared<tcp::acceptor>(pool_.service());
+    const auto tcp_accept =std::make_shared<tcp::acceptor>(pool_.service());
+
     // Need to check error codes for functions
     boost::system::error_code ec;
     tcp_accept->open(endpoint.protocol(), ec);
     if (listen_error(ec, handle_listen))
         return;
+
     tcp_accept->set_option(tcp::acceptor::reuse_address(true), ec);
     if (listen_error(ec, handle_listen))
         return;
+
     tcp_accept->bind(endpoint, ec);
     if (listen_error(ec, handle_listen))
         return;
+
     tcp_accept->listen(boost::asio::socket_base::max_connections, ec);
     if (listen_error(ec, handle_listen))
         return;
 
-    acceptor_ptr accept =
-        std::make_shared<acceptor>(pool_, tcp_accept);
+    const auto  accept = std::make_shared<acceptor>(pool_, tcp_accept);
     handle_listen(std::error_code(), accept);
 }
 
 } // namespace network
 } // namespace libbitcoin
-


### PR DESCRIPTION
We have been moving the libraries towards a "one class per file" organization. I've applied this to the network namespace in order to make that layer easier to traverse, as we troubleshoot network/chain/node blocking issues.