### PR TITLE
Networking fixes and enhancements.

### DIFF
--- a/include/bitcoin/bitcoin/constants.hpp
+++ b/include/bitcoin/bitcoin/constants.hpp
@@ -53,7 +53,7 @@ BC_CONSTEXPR uint8_t byte_bits = 8;
 BC_CONSTEXPR uint32_t protocol_version = 70001;
 
 //TODO:  We haven't yet established a minimum required peer version.
-BC_CONSTEXPR uint32_t peer_minimum_version = 0;
+BC_CONSTEXPR uint32_t peer_minimum_version = 1;
 
 // Consensus constants.
 BC_CONSTEXPR uint32_t reward_interval = 210000;

--- a/include/bitcoin/bitcoin/error.hpp
+++ b/include/bitcoin/bitcoin/error.hpp
@@ -46,11 +46,14 @@ namespace error {
         // network errors (more)
         resolve_failed,
         network_unreachable,
+        address_blocked,
         address_in_use,
         listen_failed,
         accept_failed,
         bad_stream,
         channel_timeout,
+        connection_limit,
+        connection_to_self,
 
         // transaction pool
         blockchain_reorganized,

--- a/include/bitcoin/bitcoin/network/channel.hpp
+++ b/include/bitcoin/bitcoin/network/channel.hpp
@@ -50,8 +50,8 @@ public:
     /// This class is not copyable.
     channel(const channel&) = delete;
     void operator=(const channel&) = delete;
-
-    void stop() const;
+    
+    void stop(const std::error_code& ec=error::service_stopped);
     bool stopped() const;
 
     config::authority address() const;

--- a/include/bitcoin/bitcoin/network/channel.hpp
+++ b/include/bitcoin/bitcoin/network/channel.hpp
@@ -53,9 +53,12 @@ public:
 
     void stop() const;
     bool stopped() const;
+
     config::authority address() const;
-    void reset_revival();
+    uint64_t nonce() const;
     void set_nonce(uint64_t nonce);
+
+    void reset_revival();
     void set_revival_handler(channel_proxy::revival_handler handler);
 
     template <typename Message>
@@ -99,6 +102,7 @@ public:
 
 private:
     std::weak_ptr<channel_proxy> weak_proxy_;
+    uint64_t nonce_;
 };
 
 } // namespace network

--- a/include/bitcoin/bitcoin/network/channel_loader_module.hpp
+++ b/include/bitcoin/bitcoin/network/channel_loader_module.hpp
@@ -39,7 +39,6 @@ public:
     virtual const std::string lookup_symbol() const = 0;
 };
 
-// TODO: split to impl.
 template <typename Message>
 class channel_loader_module
   : public channel_loader_module_base
@@ -67,7 +66,6 @@ public:
         }
         catch (bc::end_of_stream)
         {
-            // This doesn't invalidate the channel (unlike the invalid header).
             handle_load_(bc::error::bad_stream, Message());
         }
     }

--- a/include/bitcoin/bitcoin/network/channel_proxy.hpp
+++ b/include/bitcoin/bitcoin/network/channel_proxy.hpp
@@ -213,10 +213,11 @@ private:
     void do_stop(const std::error_code& ec=error::service_stopped);
 
     template<typename Message, class Subscriber>
-    void subscribe(Subscriber& subscriber);
-
+    void relay(Subscriber& subscriber);
     template <typename Message, class Subscriber, typename Callback>
     void subscribe(Subscriber& subscriber, Callback handler) const;
+    template <typename Message, class Subscriber>
+    void unsubscribe(Subscriber& subscriber) const;
 
     void reset_timers();
     void stop_impl();
@@ -280,10 +281,8 @@ private:
     // could not match 'boost::array' against 'std::array'
     boost::array<uint8_t, header_chunk_size> inbound_header_;
     boost::array<uint8_t, header_checksum_size> inbound_checksum_;
-
     data_chunk inbound_payload_;
 
-    // We should be using variadic templates for these
     version_subscriber version_subscriber_;
     verack_subscriber verack_subscriber_;
     address_subscriber address_subscriber_;
@@ -295,7 +294,6 @@ private:
     block_subscriber block_subscriber_;
     ping_subscriber ping_subscriber_;
     pong_subscriber pong_subscriber_;
-
     raw_subscriber raw_subscriber_;
     stop_subscriber stop_subscriber_;
 };

--- a/include/bitcoin/bitcoin/network/channel_proxy.hpp
+++ b/include/bitcoin/bitcoin/network/channel_proxy.hpp
@@ -244,9 +244,9 @@ private:
     void handle_read_payload(const boost::system::error_code& ec,
         size_t bytes_transferred, const header_type& header);
 
-    void handle_ping_message(const std::error_code& ec,
+    void handle_receive_ping(const std::error_code& ec,
         const ping_type& ping);
-    void handle_pong_message(const std::error_code& ec,
+    void handle_receive_pong(const std::error_code& ec,
         const pong_type& pong, uint64_t nonce);
 
     void call_handle_send(const boost::system::error_code& ec,

--- a/include/bitcoin/bitcoin/network/channel_proxy.hpp
+++ b/include/bitcoin/bitcoin/network/channel_proxy.hpp
@@ -184,44 +184,39 @@ public:
 
 private:
     typedef subscriber<const std::error_code&, const version_type&>
-        version_subscriber_type;
+        version_subscriber;
     typedef subscriber<const std::error_code&, const verack_type&>
-        verack_subscriber_type;
+        verack_subscriber;
     typedef subscriber<const std::error_code&, const address_type&>
-        address_subscriber_type;
+        address_subscriber;
     typedef subscriber<const std::error_code&, const get_address_type&>
-        get_address_subscriber_type;
+        get_address_subscriber;
     typedef subscriber<const std::error_code&, const inventory_type&>
-        inventory_subscriber_type;
+        inventory_subscriber;
     typedef subscriber<const std::error_code&, const get_data_type&>
-        get_data_subscriber_type;
+        get_data_subscriber;
     typedef subscriber<const std::error_code&, const get_blocks_type&>
-        get_blocks_subscriber_type;
+        get_blocks_subscriber;
     typedef subscriber<const std::error_code&, const transaction_type&>
-        transaction_subscriber_type;
+        transaction_subscriber;
     typedef subscriber<const std::error_code&, const block_type&>
-        block_subscriber_type;
+        block_subscriber;
     typedef subscriber<const std::error_code&, const ping_type&>
-        ping_subscriber_type;
+        ping_subscriber;
     typedef subscriber<const std::error_code&, const pong_type&>
-        pong_subscriber_type;
+        pong_subscriber;
     typedef subscriber<const std::error_code&, const header_type&,
-        const data_chunk&> raw_subscriber_type;
-    typedef subscriber<const std::error_code&> stop_subscriber_type;
+        const data_chunk&> raw_subscriber;
+    typedef subscriber<const std::error_code&> stop_subscriber;
 
     void stop(const boost::system::error_code& ec);
     void do_stop(const std::error_code& ec=error::service_stopped);
 
-    template <typename Message, typename Callback, typename SubscriberPtr>
-    void generic_subscribe(Callback handle_message,
-        SubscriberPtr message_subscribe)
-    {
-        // Subscribing must be immediate, we cannot switch thread contexts.
-        if (stopped())
-            handle_message(error::service_stopped, Message());
-        else
-            message_subscribe->subscribe(handle_message);
-    }
+    template<typename Message, class Subscriber>
+    void subscribe(Subscriber& subscriber);
+
+    template <typename Message, class Subscriber, typename Callback>
+    void subscribe(Subscriber& subscriber, Callback handler) const;
 
     void reset_timers();
     void stop_impl();
@@ -289,20 +284,20 @@ private:
     data_chunk inbound_payload_;
 
     // We should be using variadic templates for these
-    version_subscriber_type::ptr version_subscriber_;
-    verack_subscriber_type::ptr verack_subscriber_;
-    address_subscriber_type::ptr address_subscriber_;
-    get_address_subscriber_type::ptr get_address_subscriber_;
-    inventory_subscriber_type::ptr inventory_subscriber_;
-    get_data_subscriber_type::ptr get_data_subscriber_;
-    get_blocks_subscriber_type::ptr get_blocks_subscriber_;
-    transaction_subscriber_type::ptr transaction_subscriber_;
-    block_subscriber_type::ptr block_subscriber_;
-    ping_subscriber_type::ptr ping_subscriber_;
-    pong_subscriber_type::ptr pong_subscriber_;
+    version_subscriber version_subscriber_;
+    verack_subscriber verack_subscriber_;
+    address_subscriber address_subscriber_;
+    get_address_subscriber get_address_subscriber_;
+    inventory_subscriber inventory_subscriber_;
+    get_data_subscriber get_data_subscriber_;
+    get_blocks_subscriber get_blocks_subscriber_;
+    transaction_subscriber transaction_subscriber_;
+    block_subscriber block_subscriber_;
+    ping_subscriber ping_subscriber_;
+    pong_subscriber pong_subscriber_;
 
-    raw_subscriber_type::ptr raw_subscriber_;
-    stop_subscriber_type::ptr stop_subscriber_;
+    raw_subscriber raw_subscriber_;
+    stop_subscriber stop_subscriber_;
 };
 
 } // namespace network

--- a/include/bitcoin/bitcoin/network/channel_stream_loader.hpp
+++ b/include/bitcoin/bitcoin/network/channel_stream_loader.hpp
@@ -20,8 +20,8 @@
 #ifndef LIBBITCOIN_CHANNEL_STREAM_LOADER_HPP
 #define LIBBITCOIN_CHANNEL_STREAM_LOADER_HPP
 
+#include <map>
 #include <string>
-#include <vector>
 #include <bitcoin/bitcoin/define.hpp>
 #include <bitcoin/bitcoin/network/channel_loader_module.hpp>
 #include <bitcoin/bitcoin/utility/data.hpp>
@@ -39,12 +39,18 @@ public:
     channel_stream_loader(const channel_stream_loader&) = delete;
     void operator=(const channel_stream_loader&) = delete;
 
-    void add(bc::network::channel_loader_module_base* module);
-    void load_lookup(const std::string& symbol,
-        const bc::data_chunk& stream) const;
+    template <typename Message>
+    void add(typename channel_loader_module<Message>::load_handler handler)
+    {
+        // channel_loader_module isn't copyable, so we use pointers here.
+        auto module = new channel_loader_module<Message>(handler);
+        modules_[module->lookup_symbol()] = module;
+    }
+
+    void load(const std::string& symbol, const bc::data_chunk& stream) const;
 
 private:
-    typedef std::vector<channel_loader_module_base*> module_list;
+    typedef std::map<std::string, channel_loader_module_base*> module_list;
 
     module_list modules_;
 };

--- a/include/bitcoin/bitcoin/network/protocol.hpp
+++ b/include/bitcoin/bitcoin/network/protocol.hpp
@@ -49,7 +49,8 @@ namespace network {
 class BC_API protocol
 {
 public:
-    typedef std::function<void (const std::error_code&)> completion_handler;
+    typedef std::function<void (const std::error_code&)>
+        completion_handler;
     typedef std::function<void (const std::error_code&, size_t)>
         fetch_connection_count_handler;
     typedef std::function<void (const std::error_code&, channel_ptr)>
@@ -174,8 +175,7 @@ private:
     typedef size_t slot_index;
     typedef std::vector<channel_ptr> channel_ptr_list;
     typedef std::vector<connect_state> connect_state_list;
-    typedef subscriber<const std::error_code&, channel_ptr>
-        channel_subscriber_type;
+    typedef subscriber<const std::error_code&, channel_ptr> channel_subscriber;
 
     void handle_hosts_load(const std::error_code& ec,
         completion_handler handle_complete);
@@ -273,6 +273,7 @@ private:
     handshake& handshake_;
     network& network_;
     seeder seeder_;
+    channel_subscriber channel_subscriber_;
 
     // Manual connections created via configuration or user input.
     channel_ptr_list manual_connections_;
@@ -288,14 +289,11 @@ private:
     channel_ptr_list outbound_connections_;
 
     // Used to enforce correct state transition behaviour for maintaining connections.
+    // Timer prevents too many connection attempts from exhausting resources.
     connect_state_list connect_states_;
-
-    // Used to prevent too many connection attempts from exhausting resources.
-    // The sweep is refreshed every interval.
     boost::asio::deadline_timer sweep_timer_;
     size_t sweep_count_;
 
-    channel_subscriber_type::ptr channel_subscribe_;
     boost::filesystem::path hosts_path_;
 };
 

--- a/include/bitcoin/bitcoin/network/settings.hpp
+++ b/include/bitcoin/bitcoin/network/settings.hpp
@@ -40,7 +40,7 @@ struct BC_API settings
     uint32_t channel_expiration_minutes;
     uint32_t channel_timeout_minutes;
     uint32_t channel_heartbeat_minutes;
-    uint32_t channel_startup_minutes;
+    uint32_t channel_handshake_minutes;
     uint32_t channel_revival_minutes;
     uint32_t host_pool_capacity;
     boost::filesystem::path hosts_file;

--- a/include/bitcoin/bitcoin/network/settings.hpp
+++ b/include/bitcoin/bitcoin/network/settings.hpp
@@ -43,6 +43,7 @@ struct BC_API settings
     uint32_t channel_handshake_minutes;
     uint32_t channel_revival_minutes;
     uint32_t host_pool_capacity;
+    bool relay_transactions;
     boost::filesystem::path hosts_file;
     boost::filesystem::path debug_file;
     boost::filesystem::path error_file;

--- a/include/bitcoin/bitcoin/network/timeout.hpp
+++ b/include/bitcoin/bitcoin/network/timeout.hpp
@@ -37,14 +37,14 @@ public:
         uint32_t channel_expiration_minutes,
         uint32_t channel_timeout_minutes,
         uint32_t channel_heartbeat_minutes,
-        uint32_t channel_startup_minutes,
+        uint32_t channel_handshake_minutes,
         uint32_t channel_revival_minutes,
         uint32_t connect_timeout_seconds);
 
     boost::posix_time::time_duration expiration;
     boost::posix_time::time_duration inactivity;
     boost::posix_time::time_duration heartbeat;
-    boost::posix_time::time_duration startup;
+    boost::posix_time::time_duration handshake;
     boost::posix_time::time_duration revival;
     boost::posix_time::time_duration connection;
 };

--- a/include/bitcoin/bitcoin/utility/subscriber.hpp
+++ b/include/bitcoin/bitcoin/utility/subscriber.hpp
@@ -31,11 +31,9 @@ namespace libbitcoin {
 
 template <typename... Args>
 class subscriber
-  : public std::enable_shared_from_this<subscriber<Args...>>
 {
 public:
     typedef std::function<void (Args...)> handler_type;
-    typedef std::shared_ptr<subscriber<Args...>> ptr;
 
     subscriber(threadpool& pool)
       : strand_(pool)
@@ -46,7 +44,7 @@ public:
     {
         auto dispatch_subscribe =
             strand_.wrap(&subscriber<Args...>::do_subscribe,
-                this->shared_from_this(), handle);
+                this, handle);
 
         dispatch_subscribe();
     }
@@ -55,7 +53,7 @@ public:
     {
         auto dispatch_relay =
             strand_.wrap(&subscriber<Args...>::do_relay,
-                this->shared_from_this(), std::forward<Args>(params)...);
+                this, std::forward<Args>(params)...);
 
         dispatch_relay();
     }
@@ -84,10 +82,6 @@ private:
     async_strand strand_;
     registry_stack registry_;
 };
-
-// TODO: push into subscriber<Agrs...> (interface break).
-template <typename... Args>
-using subscriber_ptr = std::shared_ptr<subscriber<Args...>>;
 
 } // namespace libbitcoin
 

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -76,6 +76,8 @@ std::string error_category_impl::message(int ev) const BC_NOEXCEPT
             return "resolving hostname failed";
         case error::network_unreachable:
             return "unable to reach remote host";
+        case error::address_blocked:
+            return "address is blocked by policy";
         case error::address_in_use:
             return "address already in use";
         case error::listen_failed:
@@ -86,6 +88,10 @@ std::string error_category_impl::message(int ev) const BC_NOEXCEPT
             return "bad data stream";
         case error::channel_timeout:
             return "connection timed out";
+        case error::connection_limit:
+            return "connection limit reached";
+        case error::connection_to_self:
+            return "connected to self";
 
         // transaction pool
         case error::blockchain_reorganized:

--- a/src/network/acceptor.cpp
+++ b/src/network/acceptor.cpp
@@ -60,13 +60,6 @@ void acceptor::call_handle_accept(const boost::system::error_code& ec,
     const auto proxy = std::make_shared<channel_proxy>(pool_, socket, times_);
     const auto channel_object = std::make_shared<channel>(proxy);
     handle_accept(error::success, channel_object);
-
-    // EKV 7/31/2015: moved this after handle_accept because of a race failure.
-    // start->read_header() would process messages before handle_accept() would
-    // have called the handshake registrations. So handshake could miss the
-    // version message and never complete the handshake. The handshake would
-    // hang until a disconnect was forced by the client or the server expired
-    // the connection. See also connect_with_timeout::call_handle_connect.
     proxy->start();
 }
 

--- a/src/network/channel.cpp
+++ b/src/network/channel.cpp
@@ -38,11 +38,11 @@ channel::~channel()
     stop();
 }
 
-void channel::stop() const
+void channel::stop(const std::error_code& ec)
 {
     const auto proxy = weak_proxy_.lock();
     if (proxy)
-        proxy->stop();
+        proxy->stop(ec);
 }
 
 bool channel::stopped() const

--- a/src/network/channel.cpp
+++ b/src/network/channel.cpp
@@ -19,6 +19,7 @@
  */
 #include <bitcoin/bitcoin/network/channel.hpp>
 
+#include <cstdint>
 #include <bitcoin/bitcoin/config/authority.hpp>
 #include <bitcoin/bitcoin/network/channel_proxy.hpp>
 #include <bitcoin/bitcoin/primitives.hpp>
@@ -27,7 +28,8 @@ namespace libbitcoin {
 namespace network {
 
 channel::channel(channel_proxy_ptr proxy)
-  : weak_proxy_(proxy)
+  : weak_proxy_(proxy),
+    nonce_(0)
 {
 }
 
@@ -61,6 +63,16 @@ config::authority channel::address() const
     return config::authority();
 }
 
+uint64_t channel::nonce() const
+{
+    return nonce_;
+}
+
+void channel::set_nonce(uint64_t nonce)
+{
+    nonce_ = nonce;
+}
+
 void channel::reset_revival()
 {
     const auto proxy = weak_proxy_.lock();
@@ -73,13 +85,6 @@ void channel::set_revival_handler(channel_proxy::revival_handler handler)
     const auto proxy = weak_proxy_.lock();
     if (proxy)
         return proxy->set_revival_handler(handler);
-}
-
-void channel::set_nonce(uint64_t nonce)
-{
-    const auto proxy = weak_proxy_.lock();
-    if (proxy)
-        return proxy->set_nonce(nonce);
 }
 
 void channel::send_raw(const header_type& packet_header,

--- a/src/network/channel_proxy.cpp
+++ b/src/network/channel_proxy.cpp
@@ -379,7 +379,7 @@ void channel_proxy::handle_heartbeat(const boost::system::error_code& ec)
         }
 
         log_debug(LOG_NETWORK)
-            << "Ping sent [" << address() << "] ";
+            << "Ping sent [" << address() << "]";
     };
 
     const auto nonce = pseudo_random();

--- a/src/network/channel_proxy.cpp
+++ b/src/network/channel_proxy.cpp
@@ -115,12 +115,7 @@ void channel_proxy::start()
     set_expiration(expiration);
     set_heartbeat(timeouts_.heartbeat);
     set_revival(timeouts_.revival);
-
-    // TODO: This doesn't achieve the desired behavior because the startup is a
-    // multi-step communication. We need to reset timers after all general 
-    // communications, so this gets reset after the frst handshake stage.
-    // We need to incorporate a timer into the handshake class as noted there.
-    set_timeout(timeouts_.startup);
+    set_timeout(timeouts_.inactivity);
 
     // Subscribe to ping messages.
     subscribe_ping(
@@ -325,7 +320,7 @@ void channel_proxy::set_revival(const time_duration& timeout)
 
 void channel_proxy::handle_expiration(const boost::system::error_code& ec)
 {
-    // Did the timer fired because of cancelation?
+    // Did the timer fire because of cancelation?
     if (aborted(ec))
         return;
 
@@ -337,7 +332,7 @@ void channel_proxy::handle_expiration(const boost::system::error_code& ec)
 
 void channel_proxy::handle_timeout(const boost::system::error_code& ec)
 {
-    // Did the timer fired because of cancelation?
+    // Did the timer fire because of cancelation?
     if (aborted(ec))
         return;
 
@@ -349,7 +344,7 @@ void channel_proxy::handle_timeout(const boost::system::error_code& ec)
 
 void channel_proxy::handle_heartbeat(const boost::system::error_code& ec)
 {
-    // Did the timer fired because of cancelation?
+    // Did the timer fire because of cancelation?
     if (aborted(ec))
         return;
 

--- a/src/network/channel_stream_loader.cpp
+++ b/src/network/channel_stream_loader.cpp
@@ -40,9 +40,9 @@ channel_stream_loader::~channel_stream_loader()
 void channel_stream_loader::load(const std::string& symbol,
     const data_chunk& stream) const
 {
-    auto loader = modules_.find(symbol);
-    if (loader != modules_.end())
-        loader->second->attempt_load(stream);
+    auto it = modules_.find(symbol);
+    if (it != modules_.end())
+        it->second->attempt_load(stream);
 }
 
 } // namespace network

--- a/src/network/channel_stream_loader.cpp
+++ b/src/network/channel_stream_loader.cpp
@@ -34,21 +34,15 @@ channel_stream_loader::channel_stream_loader()
 channel_stream_loader::~channel_stream_loader()
 {
     for (auto module: modules_)
-        delete module;
+        delete module.second;
 }
 
-void channel_stream_loader::add(channel_loader_module_base* module)
-{
-    BITCOIN_ASSERT(module != nullptr);
-    modules_.push_back(module);
-}
-
-void channel_stream_loader::load_lookup(const std::string& symbol,
+void channel_stream_loader::load(const std::string& symbol,
     const data_chunk& stream) const
 {
-    for (auto module: modules_)
-        if (module->lookup_symbol() == symbol)
-            module->attempt_load(stream);
+    auto loader = modules_.find(symbol);
+    if (loader != modules_.end())
+        loader->second->attempt_load(stream);
 }
 
 } // namespace network

--- a/src/network/connect_with_timeout.cpp
+++ b/src/network/connect_with_timeout.cpp
@@ -91,15 +91,10 @@ void connect_with_timeout::handle_timer(const boost::system::error_code& ec,
     if (aborted(ec))
         return;
 
-    auto error = error::boost_to_error_code(ec);
-    if (!error)
-    {
-        // If there is no error the timer fired because of expiration.
-        error = error::channel_timeout;
-        proxy_->stop(error);
-    }
-
-    handle_connect(error, nullptr);
+    // If there is no error the timer fired because of expiration.
+    using namespace error;
+    const auto code = ec ? boost_to_error_code(ec) : channel_timeout;
+    handle_connect(code, nullptr);
 }
 
 } // namespace network

--- a/src/network/connect_with_timeout.cpp
+++ b/src/network/connect_with_timeout.cpp
@@ -81,9 +81,6 @@ void connect_with_timeout::call_handle_connect(
 
     const auto channel_object = std::make_shared<channel>(proxy_);
     handle_connect(error, channel_object);
-
-    // EKV 7/31/2015: moved this after handle_connect because of a race failure.
-    // See also acceptor::call_handle_accept.
     proxy_->start();
 }
 

--- a/src/network/connect_with_timeout.cpp
+++ b/src/network/connect_with_timeout.cpp
@@ -90,7 +90,7 @@ void connect_with_timeout::call_handle_connect(
 void connect_with_timeout::handle_timer(const boost::system::error_code& ec,
     network::connect_handler handle_connect)
 {
-    // Did the timer fired because of cancelation?
+    // Did the timer fire because of cancelation?
     if (aborted(ec))
         return;
 

--- a/src/network/connect_with_timeout.hpp
+++ b/src/network/connect_with_timeout.hpp
@@ -44,8 +44,7 @@ private:
     void call_handle_connect(const boost::system::error_code& ec,
         tcp::resolver::iterator, network::connect_handler handle_connect);
 
-    void handle_timer(const boost::system::error_code& ec,
-        network::connect_handler handle_connect);
+    void handle_timer(const boost::system::error_code& ec);
 
     socket_ptr socket_;
     channel::channel_proxy_ptr proxy_;

--- a/src/network/handshake.cpp
+++ b/src/network/handshake.cpp
@@ -113,7 +113,6 @@ void handshake::ready(channel_ptr node, handshake_handler handle_handshake,
     // for each connection to minimize persistent collisions.
     session_version.nonce = pseudo_random();
 
-    // TODO: add loopback detection to the channel.
     // Add nonce to channel state for loopback detection.
     node->set_nonce(session_version.nonce);
 
@@ -133,9 +132,6 @@ void handshake::ready(channel_ptr node, handshake_handler handle_handshake,
 void handshake::handle_version_sent(const std::error_code& ec,
     channel_ptr node, handshake_handler handle_handshake)
 {
-    // TODO: set channel timeout to handshake duration.
-    // node->set_timeout();
-
     handle_handshake(ec);
 }
 
@@ -149,18 +145,15 @@ void handshake::receive_version(const std::error_code& ec,
         return;
     }
 
-    // TODO: trace out version.version|services|user_agent.
-
+    // TODO: add loopback detection to the channel.
     // TODO: set the protocol version on node (for feature degradation).
-    // node->set_version(version.version);
-
     // TODO: save relay to node and have protocol not relay if false.
-    // This is a feature request independent of the version.
-    // node->set_relay(version.relay);
+    // TODO: trace out version.version|services|user_agent.
+    // node->set_version(version);
 
     if (version.version < bc::peer_minimum_version)
     {
-        node->stop(/* below minimum version */);
+        handle_handshake(error::accept_failed);
         return;
     }
 
@@ -180,8 +173,9 @@ void handshake::receive_verack(const std::error_code& ec, const verack_type&,
 {
     if (!ec)
     {
-        // TODO: reset channel timeout to the non-handshake value.
-        // node->reset_timeout();
+        // TODO: enable channel timeout on node construct.
+        // TODO: disable channel timeout.
+        // node->reset_handshake();
 
         // TODO: we don't really care what it says about IP addresses
         // but we may want to add inbound connnection addresses to hosts.

--- a/src/network/handshake.cpp
+++ b/src/network/handshake.cpp
@@ -95,7 +95,7 @@ void handshake::ready(channel_ptr node, handshake_handler handle_handshake,
         return;
     }
 
-    // Synchrnize three code paths (or error) before calling handle_handshake.
+    // Synchronize all code paths (or errors) before calling handle_handshake.
     constexpr size_t require = 3;
     const auto completion_callback = async_parallel(handle_handshake, require);
 

--- a/src/network/protocol.cpp
+++ b/src/network/protocol.cpp
@@ -219,7 +219,7 @@ void protocol::handle_connect(const std::error_code& ec, channel_ptr node,
     if (ec || !node)
     {
         log_debug(LOG_PROTOCOL)
-            << "Failure connecting to peer [" << peer.to_string() << "] "
+            << "Failure connecting [" << peer.to_string() << "] "
             << ec.message();
 
         // Restart connection attempt.
@@ -271,7 +271,7 @@ void protocol::handle_manual_connect(const std::error_code& ec,
     {
         // Warn because we are supposed to maintain this connection.
         log_warning(LOG_PROTOCOL)
-            << "Failure connecting to peer [" << peer << "] manually: "
+            << "Failure connecting [" << peer << "] manually: "
             << ec.message();
 
         // Retry connection.

--- a/src/network/timeout.cpp
+++ b/src/network/timeout.cpp
@@ -39,13 +39,13 @@ timeout::timeout(
     uint32_t channel_expiration_minutes,
     uint32_t channel_timeout_minutes,
     uint32_t channel_heartbeat_minutes,
-    uint32_t channel_startup_minutes,
+    uint32_t channel_handshake_minutes,
     uint32_t channel_revival_minutes,
     uint32_t connect_timeout_seconds)
   : expiration(0, channel_expiration_minutes, 0),
     inactivity(0, channel_timeout_minutes, 0),
     heartbeat(0, channel_heartbeat_minutes, 0),
-    startup(0, channel_startup_minutes, 0),
+    handshake(0, channel_handshake_minutes, 0),
     revival(0, channel_revival_minutes, 0),
     connection(0, 0, connect_timeout_seconds)
 {


### PR DESCRIPTION
Eliminate macros, stack allocate subscribers, use `std::map` for loader modules, replace "slots" mechanism, use `std::find` vs. loops, use `async_parallel` for seeder completion, simplify `protocol` logging, implement all `version` object sizes, add support and configuration for `version.relay`, implement full `ping` and `pong` support with validation and loopback detection, bypass seeding when host pool is empty, add relay and retries options to `maintain_connection`. Fix handshake timeout regression.