### PR TITLE
Changes for bip-38 in alternate build configurations

### DIFF
--- a/include/bitcoin/bitcoin/wallet/bip38.hpp
+++ b/include/bitcoin/bitcoin/wallet/bip38.hpp
@@ -182,6 +182,8 @@ BC_API data_chunk bip38_lock_intermediate(
     const data_chunk& intermediate, const data_chunk& seedb,
     data_chunk& confirmation_code, bool use_compression);
 
+#ifdef WITH_ICU
+
 /**
  * Performs bip38 validation on the specified confirmation
  * code using the passphrase.  If the address depends on the
@@ -211,6 +213,8 @@ BC_API data_chunk bip38_lock_secret(
  */
 BC_API ec_secret bip38_unlock_secret(
     const encrypted_private_key& bip38_key, const std::string& passphrase);
+
+#endif // WITH_ICU
 
 } // namespace bip38
 } // namespace libbitcoin

--- a/install.sh
+++ b/install.sh
@@ -561,7 +561,7 @@ build_all()
     build_from_tarball_icu $ICU_URL $ICU_ARCHIVE icu $PARALLEL $ICU_OPTIONS
     build_from_tarball_boost $BOOST_URL $BOOST_ARCHIVE boost $PARALLEL $BOOST_OPTIONS
     build_from_github libbitcoin secp256k1 version3 $PARALLEL "$@" $SECP256K1_OPTIONS
-    build_from_travis libbitcoin libbitcoin master $PARALLEL "$@" $BITCOIN_OPTIONS
+    build_from_travis thecodefactory libbitcoin master $PARALLEL "$@" $BITCOIN_OPTIONS
 }
 
 

--- a/src/wallet/bip38.cpp
+++ b/src/wallet/bip38.cpp
@@ -88,13 +88,14 @@ static inline bool is_bip38_ec_multiplied(
     return !is_bip38_ec_non_multiplied(key);
 }
 
-
+#ifdef WITH_ICU
 static std::string normalize_nfc(const std::string& value)
 {
     using namespace boost::locale;
     const generator locale;
     return normalize(value, norm_type::norm_nfc, locale(""));
 }
+#endif
 
 template<class T>
 static bool bip38_scrypt_hash(const data_chunk passphrase,

--- a/src/wallet/bip38.cpp
+++ b/src/wallet/bip38.cpp
@@ -256,6 +256,7 @@ data_chunk bip38_lock_intermediate(
     return bip38_encrypted_key;
 }
 
+#ifdef WITH_ICU
 bool bip38_lock_verify(
     const data_chunk& confirmation_code,
     const std::string& passphrase, std::string& out_address)
@@ -587,6 +588,7 @@ ec_secret bip38_unlock_secret(
     }
     return bip38_decrypted_key;
 }
+#endif
 
 } // namespace bip38
 } // namespace libbitcoin

--- a/test/bip38.cpp
+++ b/test/bip38.cpp
@@ -35,6 +35,7 @@ BOOST_AUTO_TEST_CASE(bip38__lock_test)
     {
         if (!vector.ec_multiplied)
         {
+#ifdef WITH_ICU
             data_chunk unlocked;
             decode_base16(unlocked, vector.unlocked);
 
@@ -46,6 +47,7 @@ BOOST_AUTO_TEST_CASE(bip38__lock_test)
                 vector.passphrase, vector.compressed);
 
             BOOST_REQUIRE_EQUAL(encode_base58(locked), vector.locked);
+#endif // WITH_ICU
         }
         else if (vector.random_seed_data.size() > 0)
         {
@@ -63,16 +65,19 @@ BOOST_AUTO_TEST_CASE(bip38__lock_test)
             BOOST_REQUIRE_EQUAL(encode_base58(confirmation_code),
                 vector.confirmation_code);
 
+#ifdef WITH_ICU
             // lastly, verify the confirmation code
             std::string address;
             const bool ret = bip38_lock_verify(confirmation_code,
                 vector.passphrase, address);
             BOOST_REQUIRE_EQUAL(ret, true);
             BOOST_REQUIRE_EQUAL(address, vector.address);
+#endif // WITH_ICU
         }
     }
 }
 
+#ifdef WITH_ICU
 BOOST_AUTO_TEST_CASE(bip38__unlock_test)
 {
     for (const auto& vector: bip38_test_vector)
@@ -86,6 +91,7 @@ BOOST_AUTO_TEST_CASE(bip38__unlock_test)
         BOOST_REQUIRE_EQUAL(encode_base16(unlocked), vector.unlocked);
     }
 }
+#endif // WITH_ICU
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/bip38.cpp
+++ b/test/bip38.cpp
@@ -25,8 +25,6 @@
 using namespace bc;
 using namespace bc::bip38;
 
-#ifndef ENABLE_TESTNET
-
 BOOST_AUTO_TEST_SUITE(bip38_tests)
 
 BOOST_AUTO_TEST_CASE(bip38__lock_test)
@@ -94,5 +92,3 @@ BOOST_AUTO_TEST_CASE(bip38__unlock_test)
 #endif // WITH_ICU
 
 BOOST_AUTO_TEST_SUITE_END()
-
-#endif // ENABLE_TESTNET

--- a/test/bip38.hpp
+++ b/test/bip38.hpp
@@ -39,8 +39,6 @@ struct bip38_result
 
 typedef std::vector<bip38_result> bip38_result_list;
 
-#ifndef ENABLE_TESTNET
-
 // Test vector list taken from:
 // https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki#Test_vectors
 //
@@ -49,10 +47,88 @@ typedef std::vector<bip38_result> bip38_result_list;
 // recreate the keys.
 //
 // So others were generated and verified using https://bit2factor.com/
+
+#ifdef ENABLE_TESTNET
+
 const bip38_result_list bip38_test_vector
 {
     {
-#ifndef ENABLE_TESTNET
+#ifdef WITH_ICU
+        {
+            "6PRL8jj6dLQjBBJjHMdUKLSNLEpjTyAfmt8GnCnfT87NeQ2BU5eAW1tcsS",
+            "cbf4b9f70470856bb4f40f80b87edb90865997ffee6df315ab166d713af433a5",
+            "TestingOneTwoThree",
+            "",
+            "",
+            "",
+            "",
+            false,
+            false
+        },
+        {
+            "6PRN49fV2yEpyCv1pTaXxwCNuMtJEoYCT19iDTUJiRYdPW1HRyrZapfCWP",
+            "09c2686880095b1a4c249ee3ac4eea8a014f11e6f986d0b5025ac1f39afbd9ae",
+            "Satoshi",
+            "",
+            "",
+            "",
+            "",
+            false,
+            false
+        },
+        {
+            "6PYVB5nHnumbUua1UmsAMPHWHa76Ci48MY79aKYnpKmwxeGqHU2XpXtKvo",
+            "cbf4b9f70470856bb4f40f80b87edb90865997ffee6df315ab166d713af433a5",
+            "TestingOneTwoThree",
+            "",
+            "",
+            "",
+            "",
+            true,
+            false
+        },
+        {
+            "6PYR63Hbut6L25z7t9mufV6wiiqcjfkV3AEKkyKCCNUZXoE6f8yoAc4JPq",
+            "09c2686880095b1a4c249ee3ac4eea8a014f11e6f986d0b5025ac1f39afbd9ae",
+            "Satoshi",
+            "",
+            "",
+            "",
+            "",
+            true,
+            false
+        },
+#endif // WITH_ICU
+        {
+            "6PfTz8uK5eN6KaNwkG2mzBb1AQkWdD8UMTLYvPm3t8cPaKuSGxzNG2cc4X",
+            "fb4bfb0bfe151d524b0b11983b9f826d6a0bc7f7bdc480864a1b557ff0c59eb4",
+            "libbitcoin test",
+            "passphraseo59BauW85etaRsKpbbTrEa5RRYw6bq5K9yrDf4r4N5fcirPdtDKmfJw9oYNoGM",
+            "cfrm38V5eSp6W4TStvncXprCwjhbyPc2RMFS8de6WZjEiU9zc9rRnDxcAeY7d82AHizXHoBxwqh",
+            "d36d8e703d8bd5445044178f69087657fba73d9f3ff211f7",
+            "n2vddqLxpbRVsSDp1dQistCNAxcY2SHoXd",
+            false,
+            true
+        },
+        {
+            "6PfN3FmLygXWEJ98jtnM9PadDuig2CxmHzgDm2GeEWggowp9zHrSLiJkNS",
+            "97c745cc980e5a070e12d0bff3f539b70748aadb406045fc1b42d4ded559a564",
+            "Libbitcoin BIP38 Test Vector",
+            "passphraseouGLY8yjTZQ5Q2bTo8rtKfdbHz4tme7QuPheRgES8KnT6pX5yxFauYhv3SVPDD",
+            "cfrm38V5K4zxzAaonhvHyamnLCSZFMzNQpxLkMNLeUXnD9nThLr9QZQwEVpuk5KNAfJxcwB9H7K",
+            "bbeac8b9bb39381520b6873553544b387bcaa19112602230",
+            "n3FhDKvW2tPG13LKT7HLpn3JfpLioDQf8o",
+            false,
+            true
+        }
+    }
+};
+
+#else // ENABLE_TESTNET
+
+const bip38_result_list bip38_test_vector
+{
+    {
 #ifdef WITH_ICU
         {
             "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg",
@@ -165,7 +241,6 @@ const bip38_result_list bip38_test_vector
             false,
             true
         }
-#endif // ENABLE_TESTNET
     }
 };
 

--- a/test/bip38.hpp
+++ b/test/bip38.hpp
@@ -39,6 +39,8 @@ struct bip38_result
 
 typedef std::vector<bip38_result> bip38_result_list;
 
+#ifndef ENABLE_TESTNET
+
 // Test vector list taken from:
 // https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki#Test_vectors
 //
@@ -50,6 +52,8 @@ typedef std::vector<bip38_result> bip38_result_list;
 const bip38_result_list bip38_test_vector
 {
     {
+#ifndef ENABLE_TESTNET
+#ifdef WITH_ICU
         {
             "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg",
             "cbf4b9f70470856bb4f40f80b87edb90865997ffee6df315ab166d713af433a5",
@@ -94,6 +98,7 @@ const bip38_result_list bip38_test_vector
             true,
             false
         },
+#endif // WITH_ICU
         {
             "6PfQu77ygVyJLZjfvMLyhLMQbYnu5uguoJJ4kMCLqWwPEdfpwANVS76gTX",
             "a43a940577f4e97f5c4d39eb14ff083a98187c64ea7c99ef7ce460833959a519",
@@ -160,8 +165,11 @@ const bip38_result_list bip38_test_vector
             false,
             true
         }
+#endif // ENABLE_TESTNET
     }
 };
+
+#endif // ENABLE_TESTNET
 
 #endif
 


### PR DESCRIPTION
This allows explorer to properly utilize subsets of bip38 when icu is not enabled (lock intermediate mode only), or testnet is enabled (no tests yet). 