### PR TITLE
Fix base16 locale dependency issues

### DIFF
--- a/include/bitcoin/bitcoin/formats/base16.hpp
+++ b/include/bitcoin/bitcoin/formats/base16.hpp
@@ -27,6 +27,13 @@
 namespace libbitcoin {
 
 /**
+ * Returns true if a character is a hexadecimal digit.
+ * The C standard library function `isxdigit` depends on the current locale,
+ * and does not necessarily match the base16 encoding.
+ */
+bool is_base16(const char c);
+
+/**
  * Convert data into a user-readable hex string.
  */
 BC_API std::string encode_base16(data_slice data);

--- a/src/formats/base10.cpp
+++ b/src/formats/base10.cpp
@@ -26,6 +26,14 @@
 
 namespace libbitcoin {
 
+/**
+ * Returns true if a character is one of `[0-9]`.
+ *
+ * The C standard library function `isdigit` depends on the current locale,
+ * and doesn't necessarily correspond to the valid base10 encoding digits.
+ * The Microsoft `isdigit` includes superscript characters like '²'
+ * in some locales, for example.
+ */
 static bool is_digit(const char c)
 {
     return '0' <= c && c <= '9';

--- a/src/formats/base16.cpp
+++ b/src/formats/base16.cpp
@@ -20,7 +20,6 @@
 #include <bitcoin/bitcoin/formats/base16.hpp>
 
 #include <algorithm>
-#include <ctype.h>
 #include <iomanip>
 #include <sstream>
 #include <boost/algorithm/string.hpp>
@@ -35,6 +34,14 @@ std::string encode_base16(data_slice data)
     for (int val: data)
         ss << std::setw(2) << val;
     return ss.str();
+}
+
+bool is_base16(const char c)
+{
+    return
+        ('0' <= c && c <= '9') ||
+        ('A' <= c && c <= 'F') ||
+        ('a' <= c && c <= 'f');
 }
 
 static unsigned from_hex(const char c)
@@ -94,7 +101,7 @@ hash_digest hash_literal(const char (&string)[2 * hash_size + 1])
 // For support of template implementation only, do not call directly.
 bool decode_base16_private(uint8_t* out, size_t out_size, const char* in)
 {
-    if (!std::all_of(in, in + 2 * out_size, isxdigit))
+    if (!std::all_of(in, in + 2 * out_size, is_base16))
         return false;
 
     for (size_t i = 0; i < out_size; ++i)

--- a/src/wallet/uri.cpp
+++ b/src/wallet/uri.cpp
@@ -20,7 +20,6 @@
 #include <bitcoin/bitcoin/wallet/uri.hpp>
 
 #include <cstdint>
-#include <ctype.h>
 #include <iomanip>
 #include <boost/algorithm/string.hpp>
 #include <bitcoin/bitcoin/define.hpp>
@@ -61,7 +60,7 @@ static std::string unescape(sci& i, sci end, bool (*is_valid)(const char))
     // Find the end of the valid-character run:
     size_t count = 0;
     while (end != i && (is_valid(i[0]) ||
-        ('%' == *i && 2 < end - i && isxdigit(i[1]) && isxdigit(i[2]))))
+        ('%' == *i && 2 < end - i && is_base16(i[1]) && is_base16(i[2]))))
     {
         ++count;
         if ('%' == *i)

--- a/test/chain/script.cpp
+++ b/test/chain/script.cpp
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#include <ctype.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/lexical_cast.hpp>
@@ -43,7 +42,7 @@ bool is_hex_data(const std::string& token)
     if (!boost::starts_with(token, "0x"))
         return false;
     std::string hex_part(token.begin() + 2, token.end());
-    return boost::all(hex_part, [](char c) { return isxdigit(c); });
+    return boost::all(hex_part, [](char c) { return is_base16(c); });
 }
 
 bool is_quoted_string(const std::string& token)


### PR DESCRIPTION
The C standard library character classification functions depend
on the current locale, and can give crazy answers in some situations.

Provide our own is_base16 function that unambiguously corresponds
to the valid character range for that format.