### PR TITLE
Review of new bitcoin uri implementation.

### DIFF
--- a/include/bitcoin/bitcoin/wallet/bitcoin_uri.hpp
+++ b/include/bitcoin/bitcoin/wallet/bitcoin_uri.hpp
@@ -36,8 +36,9 @@ namespace wallet {
 class BC_API uri_visitor
 {
 public:
-    virtual bool got_address(std::string& address) = 0;
-    virtual bool got_param(std::string& key, std::string& value) = 0;
+    virtual bool set_address(const std::string& address) = 0;
+    virtual bool set_param(const std::string& key,
+        const std::string& value) = 0;
 };
 
 /**
@@ -53,15 +54,15 @@ public:
     typedef boost::optional<uint64_t> optional_amount;
     typedef boost::optional<std::string> optional_string;
 
+    bool set_address(const std::string& address);
+    bool set_param(const std::string& key, const std::string& value);
+
     optional_address address;
     optional_stealth stealth;
     optional_amount amount;
     optional_string label;
     optional_string message;
     optional_string r;
-
-    bool got_address(std::string& address);
-    bool got_param(std::string& key, std::string& value);
 };
 
 /**
@@ -71,8 +72,8 @@ public:
  * false allows these malformed URI's to parse anyhow.
  * @return false if the URI is malformed.
  */
-BC_API bool uri_parse(const std::string& uri,
-    uri_visitor& result, bool strict=true);
+BC_API bool uri_parse(uri_visitor& out, const std::string& uri,
+    bool strict=true);
 
 /**
  * Assembles a bitcoin URI string.
@@ -92,7 +93,7 @@ public:
     BC_API void write_address(const std::string& address);
     BC_API void write_param(const std::string& key, const std::string& value);
 
-    BC_API std::string string() const;
+    BC_API std::string encoded() const;
 
 private:
     std::string address_;

--- a/include/bitcoin/bitcoin/wallet/uri.hpp
+++ b/include/bitcoin/bitcoin/wallet/uri.hpp
@@ -37,8 +37,8 @@ public:
      * Decodes a URI from a string.
      * @param strict Set to false to tolerate unescaped special characters.
      */
-    bool decode(const std::string& in, bool strict=true);
-    std::string encode() const;
+    bool decode(const std::string& encoded, bool strict=true);
+    std::string encoded() const;
 
     /**
      * Returns the lowercased URI scheme.

--- a/src/wallet/uri.cpp
+++ b/src/wallet/uri.cpp
@@ -64,7 +64,7 @@ static bool is_query(const char c)
     return is_path_char(c) || '/' == c || '?' == c;
 }
 
-static bool is_qchar(const char c)
+static bool is_query_char(const char c)
 {
     return is_query(c) && '&' != c && '=' != c;
 }
@@ -372,18 +372,18 @@ void uri::encode_query(const query_map& map)
 {
     auto first = true;
     std::ostringstream query;
-    for (const auto& i: map)
+    for (const auto& term: map)
     {
         if (!first)
             query << '&';
 
         first = false;
-        query << escape(i.first, is_qchar);
-        if (!i.second.empty())
-            query << '=' << escape(i.second, is_qchar);
+        query << escape(term.first, is_query_char);
+        if (!term.second.empty())
+            query << '=' << escape(term.second, is_query_char);
     }
 
-    has_query_ = true;
+    has_query_ = !map.empty();
     query_ = query.str();
 }
 

--- a/test/wallet/bitcoin_uri.cpp
+++ b/test/wallet/bitcoin_uri.cpp
@@ -265,6 +265,13 @@ BOOST_AUTO_TEST_CASE(uri_parse__custom_result__custom_parameter_type__test)
     BOOST_REQUIRE_EQUAL(custom.myparam.get(), "here");
 }
 
+BOOST_AUTO_TEST_CASE(uri_writer__encoded__unparameterized_uri__test)
+{
+    uri_writer writer;
+    writer.write_address("113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    BOOST_REQUIRE_EQUAL(writer.encoded(), "bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+}
+
 BOOST_AUTO_TEST_CASE(uri_writer__encoded__typical_uri__test)
 {
     uri_writer writer;

--- a/test/wallet/uri.cpp
+++ b/test/wallet/uri.cpp
@@ -21,13 +21,14 @@
 #include <bitcoin/bitcoin.hpp>
 
 using namespace bc;
+using namespace bc::wallet;
 
 BOOST_AUTO_TEST_SUITE(uri_tests)
 
-BOOST_AUTO_TEST_CASE(uri_basic_test)
+BOOST_AUTO_TEST_CASE(uri__parse__http_roundtrip__test)
 {
-    const std::string test = "http://github.com/libbitcoin?good=true#nice";
-    wallet::uri parsed;
+    const auto test = "http://github.com/libbitcoin?good=true#nice";
+    uri parsed;
     BOOST_REQUIRE(parsed.decode(test));
 
     BOOST_REQUIRE(parsed.has_authority());
@@ -40,13 +41,13 @@ BOOST_AUTO_TEST_CASE(uri_basic_test)
     BOOST_REQUIRE_EQUAL(parsed.query(), "good=true");
     BOOST_REQUIRE_EQUAL(parsed.fragment(), "nice");
 
-    BOOST_REQUIRE_EQUAL(parsed.encode(), test);
+    BOOST_REQUIRE_EQUAL(parsed.encoded(), test);
 }
 
-BOOST_AUTO_TEST_CASE(uri_messy_roundtrip_test)
+BOOST_AUTO_TEST_CASE(uri__parse__messy_roundtrip__test)
 {
-    const std::string test = "TEST:%78?%79#%7a";
-    wallet::uri parsed;
+    const auto test = "TEST:%78?%79#%7a";
+    uri parsed;
     BOOST_REQUIRE(parsed.decode(test));
 
     BOOST_REQUIRE(!parsed.has_authority());
@@ -58,12 +59,12 @@ BOOST_AUTO_TEST_CASE(uri_messy_roundtrip_test)
     BOOST_REQUIRE_EQUAL(parsed.query(), "y");
     BOOST_REQUIRE_EQUAL(parsed.fragment(), "z");
 
-    BOOST_REQUIRE_EQUAL(parsed.encode(), test);
+    BOOST_REQUIRE_EQUAL(parsed.encoded(), test);
 }
 
-BOOST_AUTO_TEST_CASE(uri_scheme_test)
+BOOST_AUTO_TEST_CASE(uri__parse__scheme__test)
 {
-    wallet::uri parsed;
+    uri parsed;
     BOOST_REQUIRE(!parsed.decode(""));
     BOOST_REQUIRE(!parsed.decode(":"));
     BOOST_REQUIRE(!parsed.decode("1:"));
@@ -77,9 +78,9 @@ BOOST_AUTO_TEST_CASE(uri_scheme_test)
     BOOST_REQUIRE_EQUAL(parsed.path(), ":");
 }
 
-BOOST_AUTO_TEST_CASE(uri_non_strict_test)
+BOOST_AUTO_TEST_CASE(uri__parsing__non_strict__test)
 {
-    wallet::uri parsed;
+    uri parsed;
     BOOST_REQUIRE(!parsed.decode("test:?テスト"));
 
     BOOST_REQUIRE(parsed.decode("test:テスト", false));
@@ -87,10 +88,9 @@ BOOST_AUTO_TEST_CASE(uri_non_strict_test)
     BOOST_REQUIRE_EQUAL(parsed.path(), "テスト");
 }
 
-BOOST_AUTO_TEST_CASE(uri_authority_test)
+BOOST_AUTO_TEST_CASE(uri__parse__authority__test)
 {
-    wallet::uri parsed;
-
+    uri parsed;
     BOOST_REQUIRE(parsed.decode("test:/"));
     BOOST_REQUIRE(!parsed.has_authority());
     BOOST_REQUIRE_EQUAL(parsed.path(), "/");
@@ -115,10 +115,9 @@ BOOST_AUTO_TEST_CASE(uri_authority_test)
     BOOST_REQUIRE_EQUAL(parsed.path(), "/path/");
 }
 
-BOOST_AUTO_TEST_CASE(uri_query_test)
+BOOST_AUTO_TEST_CASE(uri__parse__query__test)
 {
-    wallet::uri parsed;
-
+    uri parsed;
     BOOST_REQUIRE(parsed.decode("test:#?"));
     BOOST_REQUIRE(!parsed.has_query());
 
@@ -137,10 +136,9 @@ BOOST_AUTO_TEST_CASE(uri_query_test)
     BOOST_REQUIRE_EQUAL(map["z"], "");
 }
 
-BOOST_AUTO_TEST_CASE(uri_fragment_test)
+BOOST_AUTO_TEST_CASE(uri__parse__fragment__test)
 {
-    wallet::uri parsed;
-
+    uri parsed;
     BOOST_REQUIRE(parsed.decode("test:?"));
     BOOST_REQUIRE(!parsed.has_fragment());
 
@@ -153,24 +151,20 @@ BOOST_AUTO_TEST_CASE(uri_fragment_test)
     BOOST_REQUIRE_EQUAL(parsed.fragment(), "?");
 }
 
-BOOST_AUTO_TEST_CASE(uri_encode_test)
+BOOST_AUTO_TEST_CASE(uri__encode__positive__test)
 {
-    wallet::uri out;
+    uri out;
     out.set_scheme("test");
     out.set_authority("user@hostname");
     out.set_path("/some/path/?/#");
     out.set_query("tacos=yummy");
     out.set_fragment("good evening");
-
-    BOOST_REQUIRE_EQUAL(out.encode(),
-        "test://user@hostname/some/path/%3F/%23?tacos=yummy#good%20evening");
+    BOOST_REQUIRE_EQUAL(out.encoded(), "test://user@hostname/some/path/%3F/%23?tacos=yummy#good%20evening");
 
     out.remove_authority();
     out.remove_query();
     out.remove_fragment();
-
-    BOOST_REQUIRE_EQUAL(out.encode(),
-        "test:/some/path/%3F/%23");
+    BOOST_REQUIRE_EQUAL(out.encoded(), "test:/some/path/%3F/%23");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Overall looks great, found a couple of extra copies, but no material issues just minor style.

### Review
#### Source
* Place [member variables](https://github.com/libbitcoin/libbitcoin/blob/master/style_guide.md#hpp-format) below methods in class declaration.
* Don't treat non-Boolean values or expressions as Boolean.
    * For example `if (!foo.size()) ...` and `if (foo.compare(0, 4, "req-")) ...`.
* Try to name out parameters using `out` or `out_` prefix.
* Avoid making changes to out parameters unless the result is successful.
* Place out parameters on left.
    * This avoids the conflict that occurs with defaulted parameters, which can only go on the right, forcing out parameters to the middle.
* Use `const` and `auto` wherever possible unless there's a compelling readability reason.
* Minimize use of `this->` pointer by using alternative names.
* Avoid acronyms and abbreviations.
* Restrict doc comment formatting to public headers.
* Use a blank line after scope closing and indented full statements, if followed by another statement.
* Use a blank line before any comment and try to keep comments on dedicated line.
* `std::string encoded()` vs. `std::string encode()`
    * The verb implies that the object will be encoded.
    * The noun/adjective implies that an encoded value is to be produced.
* `set_address(...)` \ `set_param(...)` vs. `got_address(..)` \ `got_param(...)`
    * It took me a while to figure out that the call to "got" meant that the parser had "got" a valid result that it wanted to store in the parse result. The methods are on the parse result and from its perspective these are setters.

#### Test
* Avoid testing more than one concept in a single test and use names to indicate fail condition.
    * This allows a failure to be quickly associated with the root cause.
    * For example, I was confused for a while because the `"bitcOin:&"` test was set to "expect fail" in the "scheme" test case. But the scheme is valid, so the failure expectation was coming from an unrelated test of the "path" (address) portion of the URI.
* Use four part test naming convention to clearly document the full vector and expectations.
    *  class|file__method|function__conditions__expectations|test
    * This should also mostly eliminate the need for comments in test cases.
* Avoid Boolean test checks when comparisons are available.
    * This provides much more detail in test failure messages.
* Avoid line wrapping in test cases.
    * Given that there are no conditions, tests can be absolutely flat.
    * Tests must be visually verifiable - since there's no testing of the test cases, and this helps make them easier to follow quickly.
    * Test helper code (non-declarative) should be isolated from the individual test (and even tested itself if it's to be broadly used).