### PR TITLE
bitcoin_uri reader-writer based on new interface/parser

### DIFF
--- a/include/bitcoin/bitcoin/wallet/uri_reader.hpp
+++ b/include/bitcoin/bitcoin/wallet/uri_reader.hpp
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2011-2015 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_WALLET_URI_READER_HPP
+#define LIBBITCOIN_WALLET_URI_READER_HPP
+
+#include <string>
+#include <bitcoin/bitcoin/define.hpp>
+#include <bitcoin/bitcoin/wallet/uri.hpp>
+
+namespace libbitcoin {
+namespace wallet {
+
+/**
+ * Interface for URI deserialization.
+ * The URI parser calls these methods as it extracts each URI component.
+ * A false return from any setter is expected to terminate the parser.
+ */
+class BC_API uri_reader
+{
+public:
+
+    /**
+     * Parses any URI string into its individual components.
+     * @param[in]  uri     The URI to parse.
+     * @param[in]  strict  Only accept properly-escaped parameters.
+     * @return The parsed URI or a default instance if the `uri` is malformed
+     * according to the  `UriReader`.
+     */
+    template <class UriReader>
+    static UriReader parse(const std::string& uri, bool strict=true)
+    {
+        wallet::uri parsed;
+        if (!parsed.decode(uri, strict))
+            return UriReader();
+
+        UriReader out;
+        out.set_strict(strict);
+        out.set_scheme(parsed.scheme());
+        if (parsed.has_authority() && !out.set_authority(parsed.authority()))
+            return UriReader();
+
+        if (!parsed.path().empty() && !out.set_path(parsed.path()))
+            return UriReader();
+
+        if (parsed.has_fragment() && !out.set_fragment(parsed.fragment()))
+            return UriReader();
+
+        const auto query = parsed.decode_query();
+        for (const auto& term: query)
+        {
+            const auto& key = term.first;
+            const auto& value = term.second;
+            if (!key.empty() && !out.set_parameter(key, value))
+                return UriReader();
+        }
+
+        return out;
+    }
+
+    /// uri_reader interface.
+    virtual void set_strict(bool strict) = 0;
+    virtual bool set_scheme(const std::string& scheme) = 0;
+    virtual bool set_authority(const std::string& authority) = 0;
+    virtual bool set_path(const std::string& path) = 0;
+    virtual bool set_fragment(const std::string& fragment) = 0;
+    virtual bool set_parameter(const std::string& key,
+        const std::string& value) = 0;
+};
+
+} // namespace wallet
+} // namespace libbitcoin
+
+#endif

--- a/src/wallet/uri.cpp
+++ b/src/wallet/uri.cpp
@@ -109,7 +109,7 @@ static std::string unescape(const std::string& in)
         if ('%' == *i && 2 < in.end() - i && is_base16(i[1]) &&
             is_base16(i[2]))
         {
-            const char temp[] = {i[1], i[2], 0};
+            const char temp[] = { i[1], i[2], 0 };
             out.push_back(base16_literal(temp)[0]);
             i += 3;
         }

--- a/test/wallet/uri_reader.cpp
+++ b/test/wallet/uri_reader.cpp
@@ -1,0 +1,298 @@
+/**
+ * Copyright (c) 2011-2015 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <boost/test/unit_test.hpp>
+
+#include <boost/optional.hpp>
+#include <bitcoin/bitcoin.hpp>
+
+using namespace bc;
+using namespace bc::wallet;
+
+BOOST_AUTO_TEST_SUITE(uri_reader_tests)
+
+// Test helper that relies on bitcoin_uri.
+static bitcoin_uri parse(const std::string& uri, bool strict=true)
+{
+    return uri_reader::parse<bitcoin_uri>(uri, strict);
+}
+
+// Demonstrate custom uri_reader.
+struct custom_reader
+  : public uri_reader
+{
+    custom_reader()
+      : strict_(true), authority_(false)
+    {
+    }
+
+    bool is_valid() const
+    {
+        return !myscheme.empty() && !authority_;
+    }
+
+    void set_strict(bool strict)
+    {
+        strict_ = strict;
+    }
+
+    virtual bool set_scheme(const std::string& scheme)
+    {
+        myscheme = scheme;
+        return true;
+    }
+
+    virtual bool set_authority(const std::string& authority)
+    {
+        // This URI doesn't support an authority component.
+        authority_ = true;
+        return false;
+    }
+
+    virtual bool set_path(const std::string& path)
+    {
+        mypath = path;
+        return true;
+    }
+
+    virtual bool set_fragment(const std::string& fragment)
+    {
+        myfragment.emplace(fragment);
+        return true;
+    }
+
+    virtual bool set_parameter(const std::string& key, const std::string& value)
+    {
+        if (key == "myparam1")
+            myparam1.emplace(value);
+        else if (key == "myparam2")
+            myparam2.emplace(value);
+        else
+            return !strict_;
+
+        return true;
+    }
+
+    std::string myscheme;
+    std::string myauthority;
+    std::string mypath;
+
+    // Use optionals when there is a semantic distinction between no value and default value.
+    boost::optional<std::string> myfragment;
+    boost::optional<std::string> myparam1;
+    boost::optional<std::string> myparam2;
+
+private:
+    bool strict_;
+    bool authority_;
+};
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__typical_uri__test)
+{
+    const auto uri = parse("bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD?amount=0.1");
+    BOOST_REQUIRE(uri);
+    BOOST_REQUIRE_EQUAL(uri.payment().encoded(), "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    BOOST_REQUIRE_EQUAL(uri.amount(), 10000000u);
+    BOOST_REQUIRE(uri.label().empty());
+    BOOST_REQUIRE(uri.message().empty());
+    BOOST_REQUIRE(uri.r().empty());
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse___positive_scheme__test)
+{
+    BOOST_REQUIRE(parse("bitcoin:"));
+    BOOST_REQUIRE(parse("Bitcoin:"));
+    BOOST_REQUIRE(parse("bitcOin:"));
+    BOOST_REQUIRE(parse("BITCOIN:"));
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__negative_scheme__test)
+{
+    BOOST_REQUIRE(!parse("bitcorn:"));
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse___positive_empty_name_parameter__test)
+{
+    BOOST_REQUIRE(parse("bitcoin:?"));
+    BOOST_REQUIRE(parse("bitcoin:?&"));
+    BOOST_REQUIRE(parse("bitcoin:?=y"));
+    BOOST_REQUIRE(parse("bitcoin:?="));
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse___positive_unknown_optional_parameter__test)
+{
+    BOOST_REQUIRE(parse("bitcoin:?x=y"));
+    BOOST_REQUIRE(parse("bitcoin:?x="));
+    BOOST_REQUIRE(parse("bitcoin:?x"));
+
+    const auto uri = parse("bitcoin:?ignore=true");
+    BOOST_REQUIRE(uri);
+    BOOST_REQUIRE(uri.address().empty());
+    BOOST_REQUIRE_EQUAL(uri.amount(), 0);
+    BOOST_REQUIRE(uri.label().empty());
+    BOOST_REQUIRE(uri.message().empty());
+    BOOST_REQUIRE(uri.r().empty());
+    BOOST_REQUIRE(uri.parameter("ignore").empty());
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__negative_unknown_required_parameter__test)
+{
+    const auto uri = parse("bitcoin:?req-ignore=false");
+    BOOST_REQUIRE(!uri);
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__address__test)
+{
+    const auto uri = parse("bitcoin:113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    BOOST_REQUIRE(uri);
+    BOOST_REQUIRE_EQUAL(uri.payment().encoded(), "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    BOOST_REQUIRE_EQUAL(uri.amount(), 0);
+    BOOST_REQUIRE(uri.label().empty());
+    BOOST_REQUIRE(uri.message().empty());
+    BOOST_REQUIRE(uri.r().empty());
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__uri_encoded_address__test)
+{
+    const auto uri = parse("bitcoin:%3113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+    BOOST_REQUIRE(uri);
+    BOOST_REQUIRE_EQUAL(uri.payment().encoded(), "113Pfw4sFqN1T5kXUnKbqZHMJHN9oyjtgD");
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__negative_address__test)
+{
+    BOOST_REQUIRE(!parse("bitcoin:&"));
+    BOOST_REQUIRE(!parse("bitcoin:19l88"));
+    BOOST_REQUIRE(!parse("bitcoin:19z88"));
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__amount_only__test)
+{
+    const auto uri = parse("bitcoin:?amount=4.2");
+    BOOST_REQUIRE(uri);
+    BOOST_REQUIRE(!uri.payment());
+    BOOST_REQUIRE_EQUAL(uri.amount(), 420000000u);
+    BOOST_REQUIRE(uri.label().empty());
+    BOOST_REQUIRE(uri.message().empty());
+    BOOST_REQUIRE(uri.r().empty());
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__minimal_amount__test)
+{
+    const auto uri = parse("bitcoin:?amount=.");
+    BOOST_REQUIRE(uri);
+    BOOST_REQUIRE_EQUAL(uri.amount(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__invalid_amount__test)
+{
+    BOOST_REQUIRE(!parse("bitcoin:amount=4.2.1"));
+    BOOST_REQUIRE(!parse("bitcoin:amount=bob"));
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__label_only__test)
+{
+    const auto uri = parse("bitcoin:?label=test");
+    BOOST_REQUIRE(uri);
+    BOOST_REQUIRE(!uri.payment());
+    BOOST_REQUIRE_EQUAL(uri.amount(), 0);
+    BOOST_REQUIRE_EQUAL(uri.label(), "test");
+    BOOST_REQUIRE(uri.message().empty());
+    BOOST_REQUIRE(uri.r().empty());
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__reserved_symbol_with_lowercase_percent__test)
+{
+    const auto uri = parse("bitcoin:?label=%26%3d%6b");
+    BOOST_REQUIRE_EQUAL(uri.label(), "&=k");
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__negative_percent_encoding__test)
+{
+    BOOST_REQUIRE(!parse("bitcoin:label=%3"));
+    BOOST_REQUIRE(!parse("bitcoin:label=%3G"));
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__encoded_multibyte_utf8__test)
+{
+    const auto uri = parse("bitcoin:?label=%E3%83%95");
+    BOOST_REQUIRE_EQUAL(uri.label(), "フ");
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__non_strict_encoded_multibyte_utf8_with_unencoded_label_space__test)
+{
+    const auto uri = parse("bitcoin:?label=Some テスト", false);
+    BOOST_REQUIRE_EQUAL(uri.label(), "Some テスト");
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__negative_strict_encoded_multibyte_utf8_with_unencoded_label_space__test)
+{
+    BOOST_REQUIRE(!parse("bitcoin:?label=Some テスト", true));
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__message_only__test)
+{
+    const auto uri = parse("bitcoin:?message=Hi%20Alice");
+    BOOST_REQUIRE(!uri.payment());
+    BOOST_REQUIRE_EQUAL(uri.amount(), 0);
+    BOOST_REQUIRE(uri.label().empty());
+    BOOST_REQUIRE_EQUAL(uri.message(), "Hi Alice");
+    BOOST_REQUIRE(uri.r().empty());
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__payment_protocol_only__test)
+{
+    const auto uri = parse("bitcoin:?r=http://www.example.com?purchase%3Dshoes");
+    BOOST_REQUIRE(!uri.payment());
+    BOOST_REQUIRE_EQUAL(uri.amount(), 0);
+    BOOST_REQUIRE(uri.label().empty());
+    BOOST_REQUIRE(uri.message().empty());
+    BOOST_REQUIRE_EQUAL(uri.r(), "http://www.example.com?purchase=shoes");
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__custom_reader_optional_parameter_type__test)
+{
+    const auto custom = uri_reader::parse<custom_reader>("foo:part/abc?myparam1=1&myparam2=2#myfrag");
+    BOOST_REQUIRE(custom.is_valid());
+    BOOST_REQUIRE_EQUAL(custom.myscheme, "foo");
+    BOOST_REQUIRE_EQUAL(custom.mypath, "part/abc");
+    BOOST_REQUIRE(custom.myfragment);
+    BOOST_REQUIRE_EQUAL(custom.myfragment.get(), "myfrag");
+    BOOST_REQUIRE(custom.myparam1);
+    BOOST_REQUIRE_EQUAL(custom.myparam1.get(), "1");
+    BOOST_REQUIRE(custom.myparam2);
+    BOOST_REQUIRE_EQUAL(custom.myparam2.get(), "2");
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__custom_reader_unsupported_component__invalid)
+{
+    BOOST_REQUIRE(!uri_reader::parse<custom_reader>("foo://bar:42/part/abc?myparam1=1&myparam2=2#myfrag").is_valid());
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__custom_reader_strict__test)
+{
+    BOOST_REQUIRE(!uri_reader::parse<custom_reader>("foo:?unknown=fail-when-strict").is_valid());
+}
+
+BOOST_AUTO_TEST_CASE(uri_reader__parse__custom_reader_not_strict__test)
+{
+    BOOST_REQUIRE(uri_reader::parse<custom_reader>("foo:?unknown=not-fail-when-not-strict", false).is_valid());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This creates a unified reader-writer based on the scheme-agnostic `uri`.

The `uri_parse` function has been templatized to resolve the problem of returning a partially-initialized URI in the failure case. It has also been moved statically into `uri_reader`, as it accepts a reader as its template (formerly out) parameter.

Bitcoin semantics have been removed from the general purpose parse function by incorporating them into the visitor (implemented by the `bitcoin_uri`). The `uri_reader` interface is expanded to require full general  parsing callbacks, allowing it to support any uri scheme.

The unified reader-writer hides all properties behind accessors in order to maintain consistent state. This was easier without using optional return values, and is generally easier to access, but it removes the ability for a user of `bitcoin_uri` to distinguish between not-set parameters and explicitly-provided parameters with default values. However in the Bitcoin uri scheme there is no meaningful difference, so hopefully this is sufficient.