### PR TITLE
Modify "switchover heights" for proper activation measurement.

### DIFF
--- a/include/bitcoin/bitcoin/constants.hpp
+++ b/include/bitcoin/bitcoin/constants.hpp
@@ -88,19 +88,8 @@ BC_CONSTFUNC uint64_t max_money()
 }
 
 #ifdef ENABLE_TESTNET
-    // Block 514 is the first block after [Feb 15 2014].
-    // Testnet started bip16 before mainnet.
-    BC_CONSTEXPR uint32_t bip16_switchover_timestamp = 1333238400;
-    BC_CONSTEXPR uint32_t bip16_switchover_height = 514;
-    BC_CONSTEXPR uint32_t bip65_switchover_height = 0;
-    BC_CONSTEXPR uint32_t bip66_switchover_height = 0;
     BC_CONSTEXPR uint16_t protocol_port = 18333;
 #else
-    // [April 1 2012]
-    BC_CONSTEXPR uint32_t bip16_switchover_timestamp = 1333238400;
-    BC_CONSTEXPR uint32_t bip16_switchover_height = 173805;
-    BC_CONSTEXPR uint32_t bip65_switchover_height = 0;
-    BC_CONSTEXPR uint32_t bip66_switchover_height = 0;
     BC_CONSTEXPR uint16_t protocol_port = 8333;
 #endif
 

--- a/include/bitcoin/bitcoin/script.hpp
+++ b/include/bitcoin/bitcoin/script.hpp
@@ -155,9 +155,22 @@ enum class opcode : uint8_t
 typedef enum script_context_ : uint32_t
 {
     none_enabled = 0,
+
+    /// pay-to-script-hash enabled
     bip16_enabled = 1 << 0,
-    bip65_enabled = 1 << 1,
-    bip66_enabled = 1 << 2,
+
+    /// no duplicated unspent transaction ids
+    bip30_enabled = 1 << 1,
+
+    /// coinbase must include height
+    bip34_enabled = 1 << 2,
+
+    /// strict DER signatures required
+    bip66_enabled = 1 << 3,
+
+    /// nop2 becomes check locktime verify
+    bip65_enabled = 1 << 4,
+
     all_enabled = 0xffffffff
 } script_context;
 
@@ -335,6 +348,7 @@ BC_API script_type parse_script(data_slice raw_script);
 BC_API data_chunk save_script(const script_type& script);
 BC_API size_t script_size(const script_type& script);
 
+BC_API bool is_active(uint32_t flags, script_context flag);
 BC_API bool check_ec_signature(const ec_signature& signature,
     uint8_t hash_type, const ec_point& public_key, 
     const script_type& script_code, const transaction_type& parent_tx,

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -44,7 +44,7 @@ static const data_chunk stack_true_value{1};
 constexpr size_t op_counter_limit = 201;
 
 // Test flags for a given context.
-bool is_context(uint32_t flags, script_context flag)
+bool is_active(uint32_t flags, script_context flag)
 {
     return (flag & flags) != 0;
 }
@@ -174,7 +174,7 @@ bool script_type::run(const script_type& input_script,
         return false;
 
     // Additional validation for pay-to-script-hash transactions
-    if (is_context(flags, script_context::bip16_enabled) &&
+    if (is_active(flags, script_context::bip16_enabled) &&
         type() == payment_type::script_hash)
     {
         if (!is_push_only(copy_script.operations()))
@@ -1510,24 +1510,24 @@ bool script_type::run_operation(const operation& op,
 
         case opcode::checksig:
             return op_checksig(parent_tx, input_index, 
-                is_context(flags, script_context::bip66_enabled));
+                is_active(flags, script_context::bip66_enabled));
 
         case opcode::checksigverify:
             return op_checksigverify(parent_tx, input_index,
-                is_context(flags, script_context::bip66_enabled)) ==
+                is_active(flags, script_context::bip66_enabled)) ==
                     result::valid;
 
         case opcode::checkmultisig:
             return op_checkmultisig(parent_tx, input_index,
-                is_context(flags, script_context::bip66_enabled));
+                is_active(flags, script_context::bip66_enabled));
 
         case opcode::checkmultisigverify:
             return op_checkmultisigverify(parent_tx, input_index,
-                is_context(flags, script_context::bip66_enabled)) ==
+                is_active(flags, script_context::bip66_enabled)) ==
                     result::valid;
 
         case opcode::checklocktimeverify:
-            return is_context(flags, script_context::bip65_enabled) ?
+            return is_active(flags, script_context::bip65_enabled) ?
                 op_checklocktimeverify(parent_tx, input_index) : true;
 
         case opcode::op_nop1:
@@ -1854,7 +1854,7 @@ std::string opcode_to_string(opcode code, uint32_t flags)
         ////case opcode::op_nop2:
         ////    return "nop2";
         case opcode::checklocktimeverify:
-            return is_context(flags, script_context::bip65_enabled) ? 
+            return is_active(flags, script_context::bip65_enabled) ? 
                 "checklocktimeverify" : "nop2";
         case opcode::op_nop3:
             return "nop3";


### PR DESCRIPTION
Libbitcoin has previously relied on hardcoded heights (for testnet and mainnet) to determine consensus softfork activation and enforcement. These have been incomplete and not fully-constraining validation in the activation ranges. This is more problematic and complex in the midst of a soft fork than the full/proper implementation. These are also potentially invalidated in the case of a deep reorg. This work will activate according to the various BIP specifications, currently BIP16/30/34/66/65.