### PR TITLE
Move all message subscriptions to resubscriber template.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -244,6 +244,7 @@ include_bitcoin_bitcoin_impl_utility_HEADERS = \
     include/bitcoin/bitcoin/impl/utility/collection.ipp \
     include/bitcoin/bitcoin/impl/utility/data.ipp \
     include/bitcoin/bitcoin/impl/utility/endian.ipp \
+    include/bitcoin/bitcoin/impl/utility/resubscriber.ipp \
     include/bitcoin/bitcoin/impl/utility/serializer.ipp \
     include/bitcoin/bitcoin/impl/utility/subscriber.ipp
 
@@ -303,6 +304,7 @@ include_bitcoin_bitcoin_utility_HEADERS = \
     include/bitcoin/bitcoin/utility/endian.hpp \
     include/bitcoin/bitcoin/utility/logger.hpp \
     include/bitcoin/bitcoin/utility/random.hpp \
+    include/bitcoin/bitcoin/utility/resubscriber.hpp \
     include/bitcoin/bitcoin/utility/sequencer.hpp \
     include/bitcoin/bitcoin/utility/serializer.hpp \
     include/bitcoin/bitcoin/utility/string.hpp \

--- a/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj
@@ -200,6 +200,7 @@
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\unicode\unicode_streambuf.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\utility\array_slice.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\utility\assert.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\utility\resubscriber.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\utility\synchronizer.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\utility\sequencer.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\utility\binary.hpp" />
@@ -248,6 +249,7 @@
     <None Include="..\..\..\..\include\bitcoin\bitcoin\impl\utility\collection.ipp" />
     <None Include="..\..\..\..\include\bitcoin\bitcoin\impl\utility\data.ipp" />
     <None Include="..\..\..\..\include\bitcoin\bitcoin\impl\utility\endian.ipp" />
+    <None Include="..\..\..\..\include\bitcoin\bitcoin\impl\utility\resubscriber.ipp" />
     <None Include="..\..\..\..\include\bitcoin\bitcoin\impl\utility\serializer.ipp" />
     <None Include="..\..\..\..\include\bitcoin\bitcoin\impl\utility\subscriber.ipp" />
     <None Include="packages.config" />

--- a/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj.filters
@@ -126,6 +126,9 @@
     <None Include="..\..\..\..\include\bitcoin\bitcoin\impl\utility\subscriber.ipp">
       <Filter>include\bitcoin\impl\utility</Filter>
     </None>
+    <None Include="..\..\..\..\include\bitcoin\bitcoin\impl\utility\resubscriber.ipp">
+      <Filter>include\bitcoin\impl\utility</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\block.cpp">
@@ -615,6 +618,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\..\src\math\external\lax_der_parsing.h">
       <Filter>src\math\external</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\utility\resubscriber.hpp">
+      <Filter>include\bitcoin\utility</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/include/bitcoin/bitcoin.hpp
+++ b/include/bitcoin/bitcoin.hpp
@@ -80,6 +80,7 @@
 #include <bitcoin/bitcoin/utility/endian.hpp>
 #include <bitcoin/bitcoin/utility/logger.hpp>
 #include <bitcoin/bitcoin/utility/random.hpp>
+#include <bitcoin/bitcoin/utility/resubscriber.hpp>
 #include <bitcoin/bitcoin/utility/sequencer.hpp>
 #include <bitcoin/bitcoin/utility/serializer.hpp>
 #include <bitcoin/bitcoin/utility/string.hpp>

--- a/include/bitcoin/bitcoin/network/handshake.hpp
+++ b/include/bitcoin/bitcoin/network/handshake.hpp
@@ -65,10 +65,10 @@ private:
         handshake_handler completion_callback);
     void handle_verack_sent(const std::error_code& ec,
         handshake_handler completion_callback);
-    void receive_version(const std::error_code& ec,
+    bool receive_version(const std::error_code& ec,
         const version_type& version, channel_ptr node,
         handshake_handler completion_callback);
-    void receive_verack(const std::error_code& ec, const verack_type&,
+    bool receive_verack(const std::error_code& ec, const verack_type&,
         channel_ptr node, handshake_handler completion_callback);
 
     void start_timer(channel_ptr node, handshake_handler completion_callback);

--- a/include/bitcoin/bitcoin/network/protocol.hpp
+++ b/include/bitcoin/bitcoin/network/protocol.hpp
@@ -156,7 +156,7 @@ private:
         completion_handler handle_complete);
     void handle_hosts_save(const std::error_code& ec,
         completion_handler handle_complete);
-    void handle_address_message(const std::error_code& ec,
+    bool handle_address_message(const std::error_code& ec,
         const address_type& message, channel_ptr node);
     void handle_store_address(const std::error_code& ec);
 

--- a/include/bitcoin/bitcoin/network/seeder.hpp
+++ b/include/bitcoin/bitcoin/network/seeder.hpp
@@ -63,7 +63,7 @@ private:
         seeded_handler completion_callback);
     void handle_synced(const std::error_code& ec, size_t host_start_count,
         seeded_handler completion_callback);
-    void handle_receive(const std::error_code& ec, const address_type& message,
+    bool handle_receive(const std::error_code& ec, const address_type& message,
         const config::endpoint& seed, channel_ptr node, 
         seeded_handler completion_callback);
     void handle_send(const std::error_code& ec, const config::endpoint& seed,

--- a/include/bitcoin/bitcoin/utility/resubscriber.hpp
+++ b/include/bitcoin/bitcoin/utility/resubscriber.hpp
@@ -17,54 +17,42 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef LIBBITCOIN_SUBSCRIBER_IPP
-#define LIBBITCOIN_SUBSCRIBER_IPP
+#ifndef  LIBBITCOIN_RESUBSCRIBER_HPP
+#define  LIBBITCOIN_RESUBSCRIBER_HPP
 
+#include <functional>
+#include <memory>
+#include <vector>
 #include <bitcoin/bitcoin/utility/sequencer.hpp>
 #include <bitcoin/bitcoin/utility/threadpool.hpp>
-   
+
 namespace libbitcoin {
 
 template <typename... Args>
-subscriber<Args...>::subscriber(threadpool& pool)
-  : strand_(pool)
+class resubscriber
+  : public std::enable_shared_from_this<resubscriber<Args...>>
 {
-}
+public:
+    typedef std::function<bool(Args...)> resubscription_handler;
+    typedef std::shared_ptr<resubscriber<Args...>> ptr;
 
-template <typename... Args>
-void subscriber<Args...>::subscribe(subscription_handler notifier)
-{
-    strand_.wrap(&subscriber<Args...>::do_subscribe,
-        this->shared_from_this(), notifier)();
-}
+    resubscriber(threadpool& pool);
 
-template <typename... Args>
-void subscriber<Args...>::relay(Args... args)
-{
-    strand_.wrap(&subscriber<Args...>::do_relay,
-        this->shared_from_this(), args...)();
-}
+    void subscribe(resubscription_handler notifier);
+    void relay(Args... args);
 
-template <typename... Args>
-void subscriber<Args...>::do_subscribe(subscription_handler notifier)
-{
-    subscriptions_.push_back(notifier);
-}
+private:
+    typedef std::vector<resubscription_handler> subscription_list;
 
-template <typename... Args>
-void subscriber<Args...>::do_relay(Args... args)
-{
-    if (subscriptions_.empty())
-        return;
+    void do_subscribe(resubscription_handler notifier);
+    void do_relay(Args... args);
 
-    const auto subscriptions_copy = subscriptions_;
-    subscriptions_.clear();
-    for (const auto notifier: subscriptions_copy)
-        notifier(args...);
-}
+    sequencer strand_;
+    subscription_list subscriptions_;
+};
 
 } // namespace libbitcoin
 
-#include <bitcoin/bitcoin/impl/utility/subscriber.ipp>
+#include <bitcoin/bitcoin/impl/utility/resubscriber.ipp>
 
 #endif

--- a/include/bitcoin/bitcoin/utility/subscriber.hpp
+++ b/include/bitcoin/bitcoin/utility/subscriber.hpp
@@ -33,13 +33,12 @@ class subscriber
   : public std::enable_shared_from_this<subscriber<Args...>>
 {
 public:
-    typedef std::function<void (Args...)> subscription_handler;
+    typedef std::function<void(Args...)> subscription_handler;
     typedef std::shared_ptr<subscriber<Args...>> ptr;
 
     subscriber(threadpool& pool);
-    ~subscriber();
 
-    void subscribe(subscription_handler handler);
+    void subscribe(subscription_handler notifier);
     void relay(Args... args);
 
 private:
@@ -51,9 +50,6 @@ private:
     sequencer strand_;
     subscription_list subscriptions_;
 };
-
-template <typename... Args>
-using subscriber_ptr = std::shared_ptr<subscriber<Args...>>;
 
 } // namespace libbitcoin
 

--- a/src/network/seeder.cpp
+++ b/src/network/seeder.cpp
@@ -171,7 +171,7 @@ void seeder::handle_handshake(const std::error_code& ec, channel_ptr node,
     // We could start ping-pong here but probabaly not important.
 
     node->subscribe_address(
-        strand_.wrap(&seeder::handle_receive,
+        std::bind(&seeder::handle_receive,
             this, _1, _2, seed, node, completion_callback));
 
     node->send(get_address_type(),
@@ -191,7 +191,7 @@ void seeder::handle_send(const std::error_code& ec,
     }
 }
 
-void seeder::handle_receive(const std::error_code& ec,
+bool seeder::handle_receive(const std::error_code& ec,
     const address_type& message, const config::endpoint& seed,
     channel_ptr node, seeded_handler completion_callback)
 {
@@ -201,7 +201,7 @@ void seeder::handle_receive(const std::error_code& ec,
             << "Failure getting addresses from seed [" << seed << "] "
             << ec.message();
         completion_callback(error::success);
-        return;
+        return false;
     }
 
     log_info(LOG_PROTOCOL)
@@ -218,6 +218,7 @@ void seeder::handle_receive(const std::error_code& ec,
 
     // We are using this call to keep node in scope until receive.
     node->stop(error::channel_stopped);
+    return false;
 }
 
 // This is called for each individual address in the packet.


### PR DESCRIPTION
This fixes a longstanding race condition in message receipt. Unhandled blocks, as a result of this issue, regularly cause the appearance of orphans. This causes re-requesting of blocks as well as frequent costly reorgs. Eventually the message backlog overloads the node's memory.