### PR TITLE
Prevent threadpool destruct without join.

### DIFF
--- a/include/bitcoin/bitcoin/define.hpp
+++ b/include/bitcoin/bitcoin/define.hpp
@@ -89,6 +89,9 @@ namespace bc = libbitcoin;
     #endif
 #endif
 
+// Avoid namespace conflict between boost::placeholders and std::placeholders. 
+#define BOOST_BIND_NO_PLACEHOLDERS
+
 // Define so we can have better visibility of lcov exclusion ranges.
 #define LCOV_EXCL_START(text)
 #define LCOV_EXCL_STOP()

--- a/src/utility/threadpool.cpp
+++ b/src/utility/threadpool.cpp
@@ -35,6 +35,7 @@ threadpool::threadpool(size_t number_threads, thread_priority priority)
 threadpool::~threadpool()
 {
     shutdown();
+    join();
 }
 
 void threadpool::spawn(size_t number_threads, thread_priority priority)


### PR DESCRIPTION
This is primarily to simplify trivial API usage.