### PR TITLE
Make static class members public

### DIFF
--- a/include/bitcoin/bitcoin/wallet/select_outputs.hpp
+++ b/include/bitcoin/bitcoin/wallet/select_outputs.hpp
@@ -28,7 +28,7 @@
 namespace libbitcoin {
 namespace wallet {
 
-class BC_API select_outputs
+struct BC_API select_outputs
 {
     enum class algorithm
     {


### PR DESCRIPTION
I opted to make this a struct, but we could alternatively declare what's inside public.  Usage is disallowed otherwise and assuming that's not intended since it's useful.