### PR TITLE
Remove unimplemented hd_lineage::operator< definition.

### DIFF
--- a/include/bitcoin/bitcoin/wallet/hd_public.hpp
+++ b/include/bitcoin/bitcoin/wallet/hd_public.hpp
@@ -49,7 +49,6 @@ struct BC_API hd_lineage
     uint32_t parent_fingerprint;
     uint32_t child_number;
 
-    bool operator<(const hd_lineage& other) const;
     bool operator==(const hd_lineage& other) const;
     bool operator!=(const hd_lineage& other) const;
 };


### PR DESCRIPTION
Library builds and links fine. `make check` passes.