### PR TITLE
Always typedef templated types such as std::vector

### DIFF
--- a/include/bitcoin/bitcoin/chain/script/operation.hpp
+++ b/include/bitcoin/bitcoin/chain/script/operation.hpp
@@ -110,9 +110,9 @@ public:
     /// stack factories
     static stack to_null_data_pattern(data_slice data);
     static stack to_pay_multisig_pattern(uint8_t signatures,
-        const std::vector<ec_compressed>& points);
+        const point_list& points);
     static stack to_pay_multisig_pattern(uint8_t signatures,
-        const std::vector<data_chunk>& points);
+        const data_stack& points);
     static stack to_pay_public_key_pattern(data_slice point);
     static stack to_pay_key_hash_pattern(const short_hash& hash);
     static stack to_pay_script_hash_pattern(const short_hash& hash);

--- a/include/bitcoin/bitcoin/math/elliptic_curve.hpp
+++ b/include/bitcoin/bitcoin/math/elliptic_curve.hpp
@@ -36,6 +36,8 @@ typedef byte_array<ec_secret_size> ec_secret;
 BC_CONSTEXPR size_t ec_compressed_size = 33;
 typedef byte_array<ec_compressed_size> ec_compressed;
 
+typedef std::vector<ec_compressed> point_list;
+
 /// Uncompressed public key:
 BC_CONSTEXPR size_t ec_uncompressed_size = 65;
 typedef byte_array<ec_uncompressed_size> ec_uncompressed;

--- a/include/bitcoin/bitcoin/wallet/stealth_address.hpp
+++ b/include/bitcoin/bitcoin/wallet/stealth_address.hpp
@@ -41,8 +41,6 @@ public:
     static const uint8_t reuse_key_flag;
     static const uint8_t max_filter_bits;
 
-    typedef std::vector<ec_compressed> point_list;
-
     /// Constructors.
     stealth_address();
     stealth_address(const data_chunk& decoded);

--- a/src/chain/script/operation.cpp
+++ b/src/chain/script/operation.cpp
@@ -411,20 +411,20 @@ operation::stack operation::to_pay_public_key_pattern(data_slice point)
 }
 
 operation::stack operation::to_pay_multisig_pattern(uint8_t signatures,
-    const std::vector<ec_compressed>& points)
+    const point_list& points)
 {
     const auto conversion = [](const ec_compressed& point)
     {
         return to_chunk(point);
     };
 
-    std::vector<data_chunk> chunks(points.size());
+    data_stack chunks(points.size());
     std::transform(points.begin(), points.end(), chunks.begin(), conversion);
     return to_pay_multisig_pattern(signatures, chunks);
 }
 
 operation::stack operation::to_pay_multisig_pattern(uint8_t signatures,
-    const std::vector<data_chunk>& points)
+    const data_stack& points)
 {
     static constexpr size_t op_1 = static_cast<uint8_t>(opcode::op_1);
     static constexpr size_t op_16 = static_cast<uint8_t>(opcode::op_16);

--- a/src/wallet/stealth_address.cpp
+++ b/src/wallet/stealth_address.cpp
@@ -255,7 +255,7 @@ uint8_t stealth_address::signatures() const
     return signatures_;
 }
 
-const stealth_address::point_list& stealth_address::spend_keys() const
+const point_list& stealth_address::spend_keys() const
 {
     return spend_keys_;
 }


### PR DESCRIPTION
Switched code to use typedefs which is improves code readability.