### PR TITLE
HACK: make set_originator() const.

### DIFF
--- a/include/bitcoin/bitcoin/message/block_message.hpp
+++ b/include/bitcoin/bitcoin/message/block_message.hpp
@@ -82,14 +82,16 @@ public:
         bool with_transaction_count=true) const;
 
     uint64_t originator() const;
-    void set_originator(uint64_t value);
+
+    // HACK: The fact that this is const makes it unsafe.
+    void set_originator(uint64_t value) const;
 
     static const std::string command;
     static const uint32_t version_minimum;
     static const uint32_t version_maximum;
 
 private:
-    uint64_t originator_;
+    mutable uint64_t originator_;
 };
 
 } // namespace message

--- a/include/bitcoin/bitcoin/message/transaction_message.hpp
+++ b/include/bitcoin/bitcoin/message/transaction_message.hpp
@@ -73,15 +73,18 @@ public:
     void to_data(uint32_t version, std::ostream& stream) const;
     void to_data(uint32_t version, writer& sink) const;
     uint64_t serialized_size(uint32_t version=version::level::canonical) const;
+
     uint64_t originator() const;
-    void set_originator(uint64_t value);
+
+    // HACK: The fact that this is const makes it unsafe.
+    void set_originator(uint64_t value) const;
 
     static const std::string command;
     static const uint32_t version_minimum;
     static const uint32_t version_maximum;
 
 private:
-    uint64_t originator_;
+    mutable uint64_t originator_;
 };
 
 } // namespace message

--- a/src/chain/block.cpp
+++ b/src/chain/block.cpp
@@ -98,7 +98,7 @@ inline size_t locator_size(size_t top)
 }
 
 // This algorithm is a network best practice, not a consensus rule.
-block::indexes locator_heights(size_t top)
+block::indexes block::locator_heights(size_t top)
 {
     size_t step = 1;
     block::indexes heights;

--- a/src/message/block_message.cpp
+++ b/src/message/block_message.cpp
@@ -155,7 +155,7 @@ uint64_t block_message::originator() const
     return originator_;
 }
 
-void block_message::set_originator(uint64_t value)
+void block_message::set_originator(uint64_t value) const
 {
     originator_ = value;
 }

--- a/src/message/transaction_message.cpp
+++ b/src/message/transaction_message.cpp
@@ -154,7 +154,7 @@ uint64_t transaction_message::originator() const
     return originator_;
 }
 
-void transaction_message::set_originator(uint64_t value)
+void transaction_message::set_originator(uint64_t value) const
 {
     originator_ = value;
 }


### PR DESCRIPTION
This provides simple temporary relief for a node break. Previously block/tx messages were passed via non-const pointers and could thus be modified without compiler complaint. Now that they are correctly const this issue is exposed (i.e. not new). Because these messages are handled via public subscription they must not be modified in an unsafe manner. In order to be both safe and correct, this message must be handled by the implementation before any other subscribers receive it.