### PR TITLE
Remove opcode::raw_data dependence in parsing.

### DIFF
--- a/include/bitcoin/bitcoin/chain/script/script.hpp
+++ b/include/bitcoin/bitcoin/chain/script/script.hpp
@@ -118,6 +118,12 @@ public:
     static code verify(const transaction& tx, uint32_t input_index,
         const script& prevout_script, uint32_t flags);
 
+    script();
+    script(const operation::stack& operations);
+    script(operation::stack&& operations);
+    script(const script& other);
+    script(script&& other);
+
     script_pattern pattern() const;
     bool is_raw_data() const;
     bool from_data(const data_chunk& data, bool prefix, parse_mode mode);
@@ -138,9 +144,14 @@ public:
 
     operation::stack operations;
 
+    script& operator=(script&& other);
+    script& operator=(const script& other);
+
 private:
     bool deserialize(const data_chunk& raw_script, parse_mode mode);
     bool parse(const data_chunk& raw_script);
+
+    bool is_raw_;
 };
 
 } // namespace chain

--- a/src/chain/script/script.cpp
+++ b/src/chain/script/script.cpp
@@ -98,6 +98,45 @@ script script::factory_from_data(reader& source, bool prefix, parse_mode mode)
     return instance;
 }
 
+script::script()
+  : operations(), is_raw_(false)
+{
+}
+
+script::script(const operation::stack& operations)
+  : operations(operations), is_raw_(false)
+{
+}
+
+script::script(operation::stack&& operations)
+  : operations(std::forward<operation::stack>(operations)), is_raw_(false)
+{
+}
+
+script::script(const script& other)
+  : operations(other.operations), is_raw_(other.is_raw_)
+{
+}
+
+script::script(script&& other)
+  : operations(std::forward<operation::stack>(other.operations)), is_raw_(other.is_raw_)
+{
+}
+
+script& script::operator=(script&& other)
+{
+    operations = std::move(other.operations);
+    is_raw_ = other.is_raw_;
+    return *this;
+}
+
+script& script::operator=(const script& other)
+{
+    operations = other.operations;
+    is_raw_ = other.is_raw_;
+    return *this;
+}
+
 script_pattern script::pattern() const
 {
     if (operation::is_null_data_pattern(operations))
@@ -132,8 +171,7 @@ script_pattern script::pattern() const
 
 bool script::is_raw_data() const
 {
-    return (operations.size() == 1) &&
-        (operations[0].code == opcode::raw_data);
+    return (operations.size() == 1) && is_raw_;
 }
 
 bool script::is_valid() const
@@ -147,6 +185,7 @@ bool script::is_valid() const
 void script::reset()
 {
     operations.clear();
+    is_raw_ = false;
 }
 
 bool script::from_data(const data_chunk& data, bool prefix, parse_mode mode)
@@ -231,7 +270,7 @@ void script::to_data(writer& sink, bool prefix) const
     if (prefix)
         sink.write_variable_uint_little_endian(satoshi_content_size());
 
-    if ((operations.size() > 0) && (operations[0].code == opcode::raw_data))
+    if (is_raw_data())
         sink.write_data(operations[0].data);
     else
         for (const auto& op: operations)
@@ -240,7 +279,7 @@ void script::to_data(writer& sink, bool prefix) const
 
 uint64_t script::satoshi_content_size() const
 {
-    if (operations.size() > 0 && (operations[0].code == opcode::raw_data))
+    if (is_raw_data())
         return (operations[0].serialized_size() - 1);
 
     const auto value = [](uint64_t total, const operation& op)
@@ -397,6 +436,7 @@ bool script::deserialize(const data_chunk& raw_script, parse_mode mode)
 
         operations.clear();
         operations.push_back(std::move(op));
+        is_raw_ = true;
     }
 
     return result;

--- a/src/chain/script/script.cpp
+++ b/src/chain/script/script.cpp
@@ -232,7 +232,7 @@ void script::to_data(writer& sink, bool prefix) const
         sink.write_variable_uint_little_endian(satoshi_content_size());
 
     if ((operations.size() > 0) && (operations[0].code == opcode::raw_data))
-        operations[0].to_data(sink);
+        sink.write_data(operations[0].data);
     else
         for (const auto& op: operations)
             op.to_data(sink);
@@ -241,7 +241,7 @@ void script::to_data(writer& sink, bool prefix) const
 uint64_t script::satoshi_content_size() const
 {
     if (operations.size() > 0 && (operations[0].code == opcode::raw_data))
-        return operations[0].serialized_size();
+        return (operations[0].serialized_size() - 1);
 
     const auto value = [](uint64_t total, const operation& op)
     {


### PR DESCRIPTION
Addresses libbitcoin/libbitcoin-server#143, an error introduced in serialization rewrite along with the issue present prior to rewrite.

TODO: remove the opcode entirely - I have not tracked down whether it is in use external to this repo.