### PR TITLE
Rename output_point::validation to validation_type

### DIFF
--- a/include/bitcoin/bitcoin/chain/output_point.hpp
+++ b/include/bitcoin/bitcoin/chain/output_point.hpp
@@ -38,7 +38,7 @@ public:
 
     // This validation data IS copied on output_point copy/move.
     // These properties facilitate block and transaction validation.
-    struct validation
+    struct validation_type
     {
         /// This is a .height sentinel.
         static const size_t not_specified;
@@ -56,7 +56,7 @@ public:
         /// This must be set to not_specified if the input is coinbase.
         /// This must be set to not_specified if the output is non-coinbase.
         /// This may be set to not_specified if the prevout is spent.
-        size_t height = validation::not_specified;
+        size_t height = validation_type::not_specified;
 
         /// The output cache contains the output referenced by the input point.
         /// If the cache.value is not_found then the output has not been found.
@@ -106,7 +106,7 @@ public:
     bool is_mature(size_t target_height) const;
 
     // These fields do not participate in serialization or comparison.
-    mutable validation validation;
+    mutable validation_type validation;
 
 protected:
     // So that input may call reset from its own.

--- a/src/chain/output_point.cpp
+++ b/src/chain/output_point.cpp
@@ -28,7 +28,7 @@
 namespace libbitcoin {
 namespace chain {
 
-const size_t output_point::validation::not_specified = max_size_t;
+const size_t output_point::validation_type::not_specified = max_size_t;
 
 // Constructors.
 //-----------------------------------------------------------------------------
@@ -149,7 +149,7 @@ output_point output_point::factory_from_data(reader& source)
 // For tx pool validation target_height is that of any candidate block.
 bool output_point::is_mature(size_t target_height) const
 {
-    if (validation.height == validation::not_specified)
+    if (validation.height == validation_type::not_specified)
         return true;
 
     // The (non-coinbase) outpoint refers to a coinbase output, measure depth.


### PR DESCRIPTION
Currently I cannot create a pointer of the libbitcoin::chain::output_point::validation* type because there is a value in that class with the same name and the compiler gets confused. This pull request renames the type with a suffix so it can be specified.