### PR TITLE
Add functions for working with variable length address strings.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -169,6 +169,7 @@ src_libbitcoin_la_SOURCES = \
     src/utility/thread.cpp \
     src/utility/threadpool.cpp \
     src/utility/work.cpp \
+    src/wallet/address_status.cpp \
     src/wallet/bitcoin_uri.cpp \
     src/wallet/dictionary.cpp \
     src/wallet/ec_private.cpp \
@@ -562,6 +563,7 @@ include_bitcoin_bitcoin_utility_HEADERS = \
 
 include_bitcoin_bitcoin_walletdir = ${includedir}/bitcoin/bitcoin/wallet
 include_bitcoin_bitcoin_wallet_HEADERS = \
+    include/bitcoin/bitcoin/wallet/address_status.hpp \
     include/bitcoin/bitcoin/wallet/bitcoin_uri.hpp \
     include/bitcoin/bitcoin/wallet/dictionary.hpp \
     include/bitcoin/bitcoin/wallet/ec_private.hpp \

--- a/include/bitcoin/bitcoin/wallet/address_status.hpp
+++ b/include/bitcoin/bitcoin/wallet/address_status.hpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2011-2015 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_WALLET_ADDRESS_STATUS_HPP
+#define LIBBITCOIN_WALLET_ADDRESS_STATUS_HPP
+
+#include <string>
+
+namespace libbitcoin {
+namespace wallet {
+
+enum class address_status_type
+{
+    mainnet_p2kh,
+    mainnet_p2sh,
+    testnet_p2kh,
+    testnet_p2sh,
+    stealth,
+    invalid
+};
+
+/// Return the type of address.
+address_status_type address_status(const std::string& address);
+
+/// Whether the string is a mainnet Bitcoin address.
+bool is_mainnet_address(const std::string& address);
+/// Whether the string is a testnet Bitcoin address.
+bool is_testnet_address(const std::string& address);
+/// Whether the string is a stealth address.
+bool is_stealth_address(const std::string& address);
+
+/// Whether the string is a valid address (status is not invalid).
+bool is_valid_address(const std::string& address);
+
+} // namespace wallet
+} // namespace libbitcoin
+
+#endif
+

--- a/include/bitcoin/bitcoin/wallet/payment_address.hpp
+++ b/include/bitcoin/bitcoin/wallet/payment_address.hpp
@@ -77,6 +77,8 @@ public:
     friend std::ostream& operator<<(std::ostream& out,
         const payment_address& of);
 
+    bool is_valid() const;
+
     /// Cast operators.
     operator const bool() const;
     operator const short_hash&() const;

--- a/include/bitcoin/bitcoin/wallet/stealth_address.hpp
+++ b/include/bitcoin/bitcoin/wallet/stealth_address.hpp
@@ -59,6 +59,8 @@ public:
     friend std::ostream& operator<<(std::ostream& out,
         const stealth_address& of);
 
+    bool is_valid() const;
+
     /// Cast operators.
     operator const bool() const;
     operator const data_chunk() const;

--- a/src/wallet/address_status.cpp
+++ b/src/wallet/address_status.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2011-2015 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <bitcoin/bitcoin/wallet/address_status.hpp>
+
+#include <bitcoin/bitcoin/wallet/payment_address.hpp>
+#include <bitcoin/bitcoin/wallet/stealth_address.hpp>
+
+namespace libbitcoin {
+namespace wallet {
+
+address_status_type payment_address_type(const uint8_t version)
+{
+    if (version == payment_address::mainnet_p2kh)
+        return address_status_type::mainnet_p2kh;
+    else if (version == payment_address::mainnet_p2sh)
+        return address_status_type::mainnet_p2sh;
+    else if (version == payment_address::testnet_p2kh)
+        return address_status_type::testnet_p2kh;
+    else if (version == payment_address::testnet_p2sh)
+        return address_status_type::testnet_p2sh;
+    else
+        return address_status_type::invalid;
+}
+
+address_status_type address_status(const std::string& address)
+{
+    const payment_address payaddr(address);
+    const stealth_address stealth(address);
+    if (payaddr.is_valid())
+        return payment_address_type(payaddr.version());
+    else if (stealth.is_valid())
+        return address_status_type::stealth;
+    else
+        return address_status_type::invalid;
+}
+
+bool is_mainnet_address(const std::string& address)
+{
+    const auto status = address_status(address);
+    return status == address_status_type::mainnet_p2kh ||
+           status == address_status_type::mainnet_p2sh;
+}
+bool is_testnet_address(const std::string& address)
+{
+    const auto status = address_status(address);
+    return status == address_status_type::testnet_p2kh ||
+           status == address_status_type::testnet_p2sh;
+}
+bool is_stealth_address(const std::string& address)
+{
+    const auto status = address_status(address);
+    return status == address_status_type::stealth;
+}
+
+bool is_valid_address(const std::string& address)
+{
+    return address_status(address) != address_status_type::invalid;
+}
+
+} // namespace wallet
+} // namespace libbitcoin
+

--- a/src/wallet/payment_address.cpp
+++ b/src/wallet/payment_address.cpp
@@ -231,6 +231,11 @@ std::ostream& operator<<(std::ostream& out, const payment_address& of)
     return out;
 }
 
+bool payment_address::is_valid() const
+{
+    return valid_;
+}
+
 // Static functions.
 // ----------------------------------------------------------------------------
 

--- a/src/wallet/stealth_address.cpp
+++ b/src/wallet/stealth_address.cpp
@@ -367,5 +367,10 @@ std::ostream& operator<<(std::ostream& out, const stealth_address& of)
     return out;
 }
 
+bool stealth_address::is_valid() const
+{
+    return valid_;
+}
+
 } // namespace wallet
 } // namespace libbitcoin


### PR DESCRIPTION
Add functions for working with variable length address strings. Getting their type. Adds these functions:

    enum class address_status_type
    {
        mainnet_p2kh,
        mainnet_p2sh,
        testnet_p2kh,
        testnet_p2sh,
        stealth,
        invalid
    };

    /// Return the type of address.
    address_status_type address_status(const std::string& address);

    /// Whether the string is a mainnet Bitcoin address.
    bool is_mainnet_address(const std::string& address);
    /// Whether the string is a testnet Bitcoin address.
    bool is_testnet_address(const std::string& address);
    /// Whether the string is a stealth address.
    bool is_stealth_address(const std::string& address);

    /// Whether the string is a valid address (status is not invalid).
    bool is_valid_address(const std::string& address);

This is added to bitcoin/wallet/address_status.hpp