### PR TITLE
Add logging for threadpool self-join and unjoinable.

### DIFF
--- a/include/bitcoin/bitcoin/utility/threadpool.hpp
+++ b/include/bitcoin/bitcoin/utility/threadpool.hpp
@@ -88,8 +88,8 @@ public:
      * Wait for all threads in the pool to terminate.
      *
      * WARNING: Do not call this within any of the threads owned by this
-     * threadpool. Doing so will cause a resource deadlock and an
-     * std::system_error exception will be thrown.
+     * threadpool. Doing so would cause a resource deadlock and as a result
+     * std::runtime_error exception will be thrown.
      */
     void join();
 


### PR DESCRIPTION
This does not fix a problem, it is intended to help isolate a troublesome network failure.