### PR TITLE
Added stealth_receiver and stealth_sender classes for stealth

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,6 +185,7 @@ src_libbitcoin_la_SOURCES = \
     src/wallet/payment_address.cpp \
     src/wallet/qrcode.cpp \
     src/wallet/select_outputs.cpp \
+    src/wallet/stealth.cpp \
     src/wallet/stealth_address.cpp \
     src/wallet/uri.cpp \
     src/wallet/parse_encrypted_keys/parse_encrypted_key.hpp \
@@ -316,6 +317,7 @@ test_libbitcoin_test_SOURCES = \
     test/wallet/payment_address.cpp \
     test/wallet/qrcode.cpp \
     test/wallet/stealth_address.cpp \
+    test/wallet/stealth.cpp \
     test/wallet/uri.cpp \
     test/wallet/uri_reader.cpp
 
@@ -578,6 +580,7 @@ include_bitcoin_bitcoin_wallet_HEADERS = \
     include/bitcoin/bitcoin/wallet/payment_address.hpp \
     include/bitcoin/bitcoin/wallet/qrcode.hpp \
     include/bitcoin/bitcoin/wallet/select_outputs.hpp \
+    include/bitcoin/bitcoin/wallet/stealth.hpp \
     include/bitcoin/bitcoin/wallet/stealth_address.hpp \
     include/bitcoin/bitcoin/wallet/uri.hpp \
     include/bitcoin/bitcoin/wallet/uri_reader.hpp

--- a/include/bitcoin/bitcoin.hpp
+++ b/include/bitcoin/bitcoin.hpp
@@ -190,6 +190,7 @@
 #include <bitcoin/bitcoin/wallet/qrcode.hpp>
 #include <bitcoin/bitcoin/wallet/select_outputs.hpp>
 #include <bitcoin/bitcoin/wallet/stealth_address.hpp>
+#include <bitcoin/bitcoin/wallet/stealth.hpp>
 #include <bitcoin/bitcoin/wallet/uri.hpp>
 #include <bitcoin/bitcoin/wallet/uri_reader.hpp>
 

--- a/include/bitcoin/bitcoin/wallet/stealth.hpp
+++ b/include/bitcoin/bitcoin/wallet/stealth.hpp
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2011-2015 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_WALLET_STEALTH_HPP
+#define LIBBITCOIN_WALLET_STEALTH_HPP
+
+#include <bitcoin/bitcoin/math/elliptic_curve.hpp>
+#include <bitcoin/bitcoin/utility/data.hpp>
+#include <bitcoin/bitcoin/wallet/payment_address.hpp>
+#include <bitcoin/bitcoin/wallet/stealth_address.hpp>
+
+namespace libbitcoin {
+namespace wallet {
+
+class stealth_receiver
+{
+public:
+    /// Constructors.
+    stealth_receiver(
+        const ec_secret& scan_private, const ec_secret& spend_private,
+        uint8_t version=payment_address::mainnet_p2kh);
+
+    /// Step 1. Receiver creates a stealth address
+    const stealth_address generate_stealth_address();
+
+    /// Step 3. Receiver generates address and compares it to the
+    /// one in the blockchain.
+    const payment_address derive_address(const ec_compressed& ephemeral_public);
+
+    /// Final step. Once address is confirmed, derive the private spend key.
+    /// This can again be converted to a public key for double checking.
+    const ec_secret derive_private(const ec_compressed& ephemeral_public);
+
+private:
+    const ec_secret& scan_private_;
+    const ec_secret& spend_private_;
+    const uint8_t version_;
+
+    ec_compressed spend_public_;
+};
+
+class stealth_sender
+{
+public:
+    /// Constructors.
+    stealth_sender(uint8_t version=payment_address::mainnet_p2kh);
+
+    /// Step 2. Sender generates a send address from the stealth address
+    /// This version generates a random ephemeral_private.
+    void send_to_stealth_address(const stealth_address& stealth_addr);
+    /// Use a given ephemeral_private instead.
+    void send_to_stealth_address(const stealth_address& stealth_addr,
+        const ec_secret& ephemeral_private);
+
+    /// Accessors.
+    /// Attach this script to the output before the send output.
+    const chain::script& meta_script() const;
+    /// Send money to this address.
+    const payment_address& send_address() const;
+
+private:
+    const uint8_t version_;
+    chain::script meta_script_;
+    payment_address send_address_;
+};
+    
+} // namespace wallet
+} // namespace libbitcoin
+
+#endif
+

--- a/src/wallet/stealth.cpp
+++ b/src/wallet/stealth.cpp
@@ -38,15 +38,14 @@ stealth_receiver::stealth_receiver(
   : scan_private_(scan_private), spend_private_(spend_private),
     version_(version)
 {
+    DEBUG_ONLY(bool success =) secret_to_public(spend_public_, spend_private_);
+    BITCOIN_ASSERT(success);
 }
 
 const stealth_address stealth_receiver::generate_stealth_address()
 {
     ec_compressed scan_public;
     DEBUG_ONLY(bool success =) secret_to_public(scan_public, scan_private_);
-    BITCOIN_ASSERT(success);
-
-    DEBUG_ONLY(bool success =) secret_to_public(spend_public_, spend_private_);
     BITCOIN_ASSERT(success);
 
     const binary empty;

--- a/src/wallet/stealth.cpp
+++ b/src/wallet/stealth.cpp
@@ -115,7 +115,7 @@ void stealth_sender::send_to_stealth_address(const stealth_address& stealth_addr
     data_chunk output_data(
         ephemeral_public.begin() + 1, ephemeral_public.end());
     BITCOIN_ASSERT(output_data.size() == 32);
-    data_chunk random_padding(4);
+    data_chunk random_padding(8);
     pseudo_random_fill(random_padding);
     extend_data(output_data, random_padding);
     BITCOIN_ASSERT(output_data.size() == 40);

--- a/src/wallet/stealth.cpp
+++ b/src/wallet/stealth.cpp
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2011-2015 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <bitcoin/bitcoin/wallet/stealth.hpp>
+
+#include <bitcoin/bitcoin/chain/script.hpp>
+#include <bitcoin/bitcoin/math/stealth.hpp>
+#include <bitcoin/bitcoin/utility/assert.hpp>
+#include <bitcoin/bitcoin/utility/random.hpp>
+
+namespace libbitcoin {
+namespace wallet {
+
+using namespace libbitcoin::machine;
+
+// Stealth receiver
+// ----------------------------------------------------------------------------
+
+stealth_receiver::stealth_receiver(
+    const ec_secret& scan_private, const ec_secret& spend_private,
+    uint8_t version)
+  : scan_private_(scan_private), spend_private_(spend_private),
+    version_(version)
+{
+}
+
+const stealth_address stealth_receiver::generate_stealth_address()
+{
+    ec_compressed scan_public;
+    DEBUG_ONLY(bool success =) secret_to_public(scan_public, scan_private_);
+    BITCOIN_ASSERT(success);
+
+    DEBUG_ONLY(bool success =) secret_to_public(spend_public_, spend_private_);
+    BITCOIN_ASSERT(success);
+
+    const binary empty;
+
+    const point_list spend_keys = { spend_public_ };
+
+    return stealth_address(empty, scan_public, spend_keys);
+}
+
+const payment_address stealth_receiver::derive_address(
+    const ec_compressed& ephemeral_public)
+{
+    ec_compressed receiver_public;
+    DEBUG_ONLY(bool success =) uncover_stealth(
+        receiver_public, ephemeral_public, scan_private_, spend_public_);
+    BITCOIN_ASSERT(success);
+
+    return payment_address(receiver_public, version_);
+}
+
+const ec_secret stealth_receiver::derive_private(
+    const ec_compressed& ephemeral_public)
+{
+    ec_secret receiver_private;
+    DEBUG_ONLY(bool success =) uncover_stealth(
+        receiver_private, ephemeral_public, scan_private_, spend_private_);
+    BITCOIN_ASSERT(success);
+    return receiver_private;
+}
+
+// Stealth sender
+// ----------------------------------------------------------------------------
+
+stealth_sender::stealth_sender(uint8_t version)
+  : version_(version)
+{
+}
+
+void stealth_sender::send_to_stealth_address(
+    const stealth_address& stealth_addr)
+{
+    ec_secret ephemeral_private;
+    data_chunk seed(12);
+    pseudo_random_fill(seed);
+    DEBUG_ONLY(bool success =) create_ephemeral_key(ephemeral_private, seed);
+    BITCOIN_ASSERT(success);
+    send_to_stealth_address(stealth_addr, ephemeral_private);
+}
+void stealth_sender::send_to_stealth_address(const stealth_address& stealth_addr,
+    const ec_secret& ephemeral_private)
+{
+    ec_compressed ephemeral_public;
+    DEBUG_ONLY(bool success =) secret_to_public(
+        ephemeral_public, ephemeral_private);
+    BITCOIN_ASSERT(success);
+
+    const auto& spend_keys = stealth_addr.spend_keys();
+    BITCOIN_ASSERT(!spend_keys.empty());
+    // Sender derives stealth public, requiring ephemeral private.
+    ec_compressed sender_public;
+    uncover_stealth(
+        sender_public, stealth_addr.scan_key(),
+        ephemeral_private, spend_keys[0]);
+
+    send_address_ = payment_address(sender_public, version_);
+
+    data_chunk output_data(
+        ephemeral_public.begin() + 1, ephemeral_public.end());
+    BITCOIN_ASSERT(output_data.size() == 32);
+    data_chunk random_padding(4);
+    pseudo_random_fill(random_padding);
+    extend_data(output_data, random_padding);
+    BITCOIN_ASSERT(output_data.size() == 40);
+
+    meta_script_.from_operations({
+        operation(opcode::return_),
+        operation(output_data)
+    });
+}
+
+const chain::script& stealth_sender::meta_script() const
+{
+    return meta_script_;
+}
+const payment_address& stealth_sender::send_address() const
+{
+    return send_address_;
+}
+
+} // namespace wallet
+} // namespace libbitcoin
+

--- a/test/wallet/stealth.cpp
+++ b/test/wallet/stealth.cpp
@@ -20,8 +20,6 @@
 #include <boost/test/unit_test.hpp>
 #include <bitcoin/bitcoin.hpp>
 
-#include <iostream>
-
 using namespace bc;
 using namespace bc::wallet;
 

--- a/test/wallet/stealth.cpp
+++ b/test/wallet/stealth.cpp
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2011-2015 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <boost/test/unit_test.hpp>
+#include <bitcoin/bitcoin.hpp>
+
+#include <iostream>
+
+using namespace bc;
+using namespace bc::wallet;
+
+BOOST_AUTO_TEST_SUITE(wallet_stealth_tests)
+
+#define MAIN_KEY "tprv8ctN3HAF9dCgX9ggdCwiZHa7c3UHuG2Ev4jgYWDhTHDUVWKKsg7znbr3vYtmCzVqcMQsjd9cSKsyKGaDvTAUMkw1UphETe1j8LcT21eWPkH"
+#define STEALTH_ADDRESS "vJmudwspxzmEoz1AP5tTrRMcuop6XjNWa1SnjHFmLeSc9DAkro6J6oYnD7MubLHx9wT3rm7D6xgA8U9Lr9zjzijhVSuUbYdMNYUN27"
+#define EPHEMERAL_PRIVATE "f91e673103863bbeb0ef1852cd8eade6b73ea55afc9b1873be62bf628eac072a"
+#define RECEIVER_PRIVATE "fc696c9f7143916f24977210c806101866c7fa13cc06982978d80518c91af2fb"
+
+#define DERIVED_ADDRESS "mtKffkQLTw2D6f6mTkrWfi8qxLv4jL1LrK"
+
+ec_compressed extract_ephemeral_public(const chain::script& meta_script)
+{
+    ec_compressed ephemeral_public;
+    BOOST_REQUIRE(is_stealth_script(meta_script));
+    ephemeral_public[0] = ephemeral_public_key_sign;
+    const data_chunk& data = meta_script.operations()[1].data();
+    std::copy(data.begin(), data.end(), ephemeral_public.begin() + 1);
+    return ephemeral_public;
+}
+
+BOOST_AUTO_TEST_CASE(stealth__exchange_between_sender_and_receiver)
+{
+    hd_private main_key(MAIN_KEY, hd_private::testnet);
+    const auto scan_key = main_key.derive_private(
+        0 + hd_first_hardened_key);
+    const auto spend_key = main_key.derive_private(
+        1 + hd_first_hardened_key);
+    const auto scan_private = scan_key.secret();
+    const auto spend_private = spend_key.secret();
+
+    stealth_receiver receiver(scan_private, spend_private,
+        payment_address::testnet_p2kh);
+    stealth_sender sender(payment_address::testnet_p2kh);
+
+    const stealth_address stealth_addr = receiver.generate_stealth_address();
+    BOOST_REQUIRE_EQUAL(stealth_addr.encoded(), STEALTH_ADDRESS);
+
+    // Instead of generating a random ephemeral_private, we are going to
+    // use this one instead.
+    ec_secret ephemeral_private;
+    BOOST_REQUIRE(decode_base16(ephemeral_private, EPHEMERAL_PRIVATE));
+    sender.send_to_stealth_address(stealth_addr, ephemeral_private);
+
+    /////////////////////////////////////////
+    // Send sends BTC to send_address
+    // Output before is ephemeral_public
+    // Padded to 40 bytes
+    /////////////////////////////////////////
+
+    BOOST_REQUIRE_EQUAL(sender.send_address().encoded(), DERIVED_ADDRESS);
+
+    // Rows:
+    //   [ephemkey:32] [address:20] [tx_hash:32]
+
+    // client.fetch_stealth()
+
+    /////////////////////////////////////////
+    // Receiver scans the blockchain
+    // And gets a list of keys and addresses for scanning
+    /////////////////////////////////////////
+
+    // Normally this is returned by the blockchain server.
+    ec_compressed ephemeral_public = extract_ephemeral_public(
+        sender.meta_script());
+
+    // Now the receiver should be able to regenerate the send_address
+    // using just the ephemeral_public.
+    const auto derived_address = receiver.derive_address(ephemeral_public);
+    BOOST_REQUIRE_EQUAL(derived_address, sender.send_address());
+
+    // Only reciever can derive stealth private, as it requires both scan
+    // and spend private.
+    const auto& receiver_private = receiver.derive_private(ephemeral_public);
+    ec_compressed receiver_public;
+    secret_to_public(receiver_public, receiver_private);
+
+    payment_address receiver_address(receiver_public,
+        payment_address::testnet_p2kh);
+
+    // Now we've re-derived the same key again.
+    // And we also have the private key.
+    BOOST_REQUIRE_EQUAL(receiver_address, sender.send_address());
+    BOOST_REQUIRE_EQUAL(encode_base16(receiver_private), RECEIVER_PRIVATE);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
Unit test is also included. Example usage:

    // Receiver
    // -----------------------------------
    // ...

    stealth_receiver receiver(scan_private, spend_private);

    const stealth_address stealth_addr = receiver.generate_stealth_address();

    // Sender
    // -----------------------------------

    stealth_sender sender();
    sender.send_to_stealth_address(stealth_addr);

    // Make new tx with these outputs:
    //   sender.meta_script()
    //   sender.send_address()

    // client.fetch_stealth() returns ephemeral_public
    // derived from meta_script output.

    // Receiver
    // -----------------------------------

    // Now the receiver should be able to regenerate the send_address
    // using just the ephemeral_public.
    const auto derived_address = receiver.derive_address(ephemeral_public);

    if (derived_address == actual_address)
    {
        // Stealth payment detected

        // Only reciever can derive stealth private, as it requires both scan
        // and spend private.
        const auto& receiver_private =
            receiver.derive_private(ephemeral_public);

        // ...
    }
