### PR TITLE
Revert alert removal.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -112,6 +112,8 @@ src_libbitcoin_la_SOURCES = \
     src/math/external/zeroize.c \
     src/math/external/zeroize.h \
     src/message/address.cpp \
+    src/message/alert.cpp \
+    src/message/alert_payload.cpp \
     src/message/block.cpp \
     src/message/block_transactions.cpp \
     src/message/compact_block.cpp \
@@ -263,6 +265,8 @@ test_libbitcoin_test_SOURCES = \
     test/math/stealth.cpp \
     test/math/uint256.cpp \
     test/message/address.cpp \
+    test/message/alert.cpp \
+    test/message/alert_payload.cpp \
     test/message/block.cpp \
     test/message/block_transactions.cpp \
     test/message/compact_block.cpp \
@@ -475,6 +479,8 @@ include_bitcoin_bitcoin_math_HEADERS = \
 include_bitcoin_bitcoin_messagedir = ${includedir}/bitcoin/bitcoin/message
 include_bitcoin_bitcoin_message_HEADERS = \
     include/bitcoin/bitcoin/message/address.hpp \
+    include/bitcoin/bitcoin/message/alert.hpp \
+    include/bitcoin/bitcoin/message/alert_payload.hpp \
     include/bitcoin/bitcoin/message/block.hpp \
     include/bitcoin/bitcoin/message/block_transactions.hpp \
     include/bitcoin/bitcoin/message/compact_block.hpp \

--- a/builds/msvc/vs2013/libbitcoin-test/libbitcoin-test.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin-test/libbitcoin-test.vcxproj
@@ -111,6 +111,8 @@
     <ClCompile Include="..\..\..\..\test\math\limits.cpp" />
     <ClCompile Include="..\..\..\..\test\math\stealth.cpp" />
     <ClCompile Include="..\..\..\..\test\message\address.cpp" />
+    <ClCompile Include="..\..\..\..\test\message\alert.cpp" />
+    <ClCompile Include="..\..\..\..\test\message\alert_payload.cpp" />
     <ClCompile Include="..\..\..\..\test\message\block.cpp">
       <ObjectFileName>$(IntDir)block_message.obj</ObjectFileName>
     </ClCompile>

--- a/builds/msvc/vs2013/libbitcoin-test/libbitcoin-test.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin-test/libbitcoin-test.vcxproj.filters
@@ -80,6 +80,9 @@
     <ClCompile Include="..\..\..\..\test\message\version.cpp">
       <Filter>src\message</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\test\message\alert.cpp">
+      <Filter>src\message</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\test\message\filter_clear.cpp">
       <Filter>src\message</Filter>
     </ClCompile>
@@ -105,6 +108,9 @@
       <Filter>src\message</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\test\message\pong.cpp">
+      <Filter>src\message</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\test\message\alert_payload.cpp">
       <Filter>src\message</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\test\message\heading.cpp">

--- a/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj
@@ -134,6 +134,8 @@
     <ClCompile Include="..\..\..\..\src\math\secp256k1_initializer.cpp" />
     <ClCompile Include="..\..\..\..\src\math\stealth.cpp" />
     <ClCompile Include="..\..\..\..\src\message\address.cpp" />
+    <ClCompile Include="..\..\..\..\src\message\alert.cpp" />
+    <ClCompile Include="..\..\..\..\src\message\alert_payload.cpp" />
     <ClCompile Include="..\..\..\..\src\message\block.cpp">
       <ObjectFileName>$(IntDir)block_message.obj</ObjectFileName>
     </ClCompile>
@@ -297,6 +299,8 @@
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\math\limits.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\math\stealth.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\message\address.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\message\alert.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\message\alert_payload.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\message\block.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\message\block_transactions.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\message\compact_block.hpp" />

--- a/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin/libbitcoin.vcxproj.filters
@@ -377,6 +377,9 @@
     <ClCompile Include="..\..\..\..\src\message\reject.cpp">
       <Filter>src\message</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\message\alert.cpp">
+      <Filter>src\message</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\message\filter_add.cpp">
       <Filter>src\message</Filter>
     </ClCompile>
@@ -396,6 +399,9 @@
       <Filter>src\message</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\message\pong.cpp">
+      <Filter>src\message</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\message\alert_payload.cpp">
       <Filter>src\message</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\chain\input.cpp">
@@ -871,6 +877,9 @@
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\utility\delegates.hpp">
       <Filter>include\bitcoin\utility</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\message\alert.hpp">
+      <Filter>include\bitcoin\message</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\message\filter_clear.hpp">
       <Filter>include\bitcoin\message</Filter>
     </ClInclude>
@@ -896,6 +905,9 @@
       <Filter>include\bitcoin\message</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\message\pong.hpp">
+      <Filter>include\bitcoin\message</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\message\alert_payload.hpp">
       <Filter>include\bitcoin\message</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\bitcoin\bitcoin\chain\input.hpp">

--- a/include/bitcoin/bitcoin.hpp
+++ b/include/bitcoin/bitcoin.hpp
@@ -90,6 +90,8 @@
 #include <bitcoin/bitcoin/math/stealth.hpp>
 #include <bitcoin/bitcoin/math/uint256.hpp>
 #include <bitcoin/bitcoin/message/address.hpp>
+#include <bitcoin/bitcoin/message/alert.hpp>
+#include <bitcoin/bitcoin/message/alert_payload.hpp>
 #include <bitcoin/bitcoin/message/block.hpp>
 #include <bitcoin/bitcoin/message/block_transactions.hpp>
 #include <bitcoin/bitcoin/message/compact_block.hpp>

--- a/include/bitcoin/bitcoin/message/alert.hpp
+++ b/include/bitcoin/bitcoin/message/alert.hpp
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2011-2017 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_MESSAGE_ALERT_HPP
+#define LIBBITCOIN_MESSAGE_ALERT_HPP
+
+#include <istream>
+#include <memory>
+#include <string>
+#include <bitcoin/bitcoin/define.hpp>
+#include <bitcoin/bitcoin/utility/data.hpp>
+#include <bitcoin/bitcoin/utility/reader.hpp>
+#include <bitcoin/bitcoin/utility/writer.hpp>
+
+namespace libbitcoin {
+namespace message {
+
+class BC_API alert
+{
+public:
+    typedef std::shared_ptr<alert> ptr;
+    typedef std::shared_ptr<const alert> const_ptr;
+
+    static alert factory_from_data(uint32_t version, const data_chunk& data);
+    static alert factory_from_data(uint32_t version, std::istream& stream);
+    static alert factory_from_data(uint32_t version, reader& source);
+
+    alert();
+    alert(const data_chunk& payload, const data_chunk& signature);
+    alert(data_chunk&& payload, data_chunk&& signature);
+    alert(const alert& other);
+    alert(alert&& other);
+
+    data_chunk& payload();
+    const data_chunk& payload() const;
+    void set_payload(const data_chunk& value);
+    void set_payload(data_chunk&& value);
+
+    data_chunk& signature();
+    const  data_chunk& signature() const;
+    void set_signature(const data_chunk& value);
+    void set_signature(data_chunk&& value);
+
+    bool from_data(uint32_t version, const data_chunk& data);
+    bool from_data(uint32_t version, std::istream& stream);
+    bool from_data(uint32_t version, reader& source);
+    data_chunk to_data(uint32_t version) const;
+    void to_data(uint32_t version, std::ostream& stream) const;
+    void to_data(uint32_t version, writer& sink) const;
+    bool is_valid() const;
+    void reset();
+    size_t serialized_size(uint32_t version) const;
+
+    /// This class is move assignable but not copy assignable.
+    alert& operator=(alert&& other);
+    void operator=(const alert&) = delete;
+
+    bool operator==(const alert& other) const;
+    bool operator!=(const alert& other) const;
+
+    static const std::string command;
+    static const uint32_t version_minimum;
+    static const uint32_t version_maximum;
+
+private:
+    data_chunk payload_;
+    data_chunk signature_;
+};
+
+} // namespace message
+} // namespace libbitcoin
+
+#endif

--- a/include/bitcoin/bitcoin/message/alert_payload.hpp
+++ b/include/bitcoin/bitcoin/message/alert_payload.hpp
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2011-2017 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_MESSAGE_ALERT_FORMATTED_PAYLOAD_HPP
+#define LIBBITCOIN_MESSAGE_ALERT_FORMATTED_PAYLOAD_HPP
+
+#include <istream>
+#include <string>
+#include <bitcoin/bitcoin/define.hpp>
+#include <bitcoin/bitcoin/math/elliptic_curve.hpp>
+#include <bitcoin/bitcoin/utility/data.hpp>
+#include <bitcoin/bitcoin/utility/reader.hpp>
+#include <bitcoin/bitcoin/utility/writer.hpp>
+
+namespace libbitcoin {
+namespace message {
+
+class BC_API alert_payload
+{
+public:
+    static alert_payload factory_from_data(uint32_t version,
+        const data_chunk& data);
+    static alert_payload factory_from_data(uint32_t version,
+        std::istream& stream);
+    static alert_payload factory_from_data(uint32_t version,
+        reader& source);
+
+    alert_payload();
+    alert_payload(uint32_t version, uint64_t relay_until, uint64_t expiration,
+        uint32_t id, uint32_t cancel, const std::vector<uint32_t>& set_cancel,
+        uint32_t min_version, uint32_t max_version,
+        const std::vector<std::string>& set_sub_version, uint32_t priority,
+        const std::string& comment, const std::string& status_bar,
+        const std::string& reserved);
+    alert_payload(uint32_t version, uint64_t relay_until, uint64_t expiration,
+        uint32_t id, uint32_t cancel, std::vector<uint32_t>&& set_cancel,
+        uint32_t min_version, uint32_t max_version,
+        std::vector<std::string>&& set_sub_version, uint32_t priority,
+        std::string&& comment, std::string&& status_bar,
+        std::string&& reserved);
+    alert_payload(const alert_payload& other);
+    alert_payload(alert_payload&& other);
+
+    uint32_t version() const;
+    void set_version(uint32_t value);
+
+    uint64_t relay_until() const;
+    void set_relay_until(uint64_t value);
+
+    uint64_t expiration() const;
+    void set_expiration(uint64_t value);
+
+    uint32_t id() const;
+    void set_id(uint32_t value);
+
+    uint32_t cancel() const;
+    void set_cancel(uint32_t value);
+
+    std::vector<uint32_t>& set_cancel();
+    const std::vector<uint32_t>& set_cancel() const;
+    void set_set_cancel(const std::vector<uint32_t>& value);
+    void set_set_cancel(std::vector<uint32_t>&& value);
+
+    uint32_t min_version() const;
+    void set_min_version(uint32_t value);
+
+    uint32_t max_version() const;
+    void set_max_version(uint32_t value);
+
+    std::vector<std::string>& set_sub_version();
+    const std::vector<std::string>& set_sub_version() const;
+    void set_set_sub_version(const std::vector<std::string>& value);
+    void set_set_sub_version(std::vector<std::string>&& value);
+
+    uint32_t priority() const;
+    void set_priority(uint32_t value);
+
+    std::string& comment();
+    const std::string& comment() const;
+    void set_comment(const std::string& value);
+    void set_comment(std::string&& value);
+
+    std::string& status_bar();
+    const std::string& status_bar() const;
+    void set_status_bar(const std::string& value);
+    void set_status_bar(std::string&& value);
+
+    std::string& reserved();
+    const std::string& reserved() const;
+    void set_reserved(const std::string& value);
+    void set_reserved(std::string&& value);
+
+    bool from_data(uint32_t version, const data_chunk& data);
+    bool from_data(uint32_t version, std::istream& stream);
+    bool from_data(uint32_t version, reader& source);
+    data_chunk to_data(uint32_t version) const;
+    void to_data(uint32_t version, std::ostream& stream) const;
+    void to_data(uint32_t version, writer& sink) const;
+    bool is_valid() const;
+    void reset();
+    size_t serialized_size(uint32_t version) const;
+
+    /// This class is move assignable but not copy assignable.
+    alert_payload& operator=(alert_payload&& other);
+    void operator=(const alert_payload&) = delete;
+
+    bool operator==(const alert_payload& other) const;
+    bool operator!=(const alert_payload& other) const;
+
+    static const ec_uncompressed satoshi_public_key;
+
+private:
+    uint32_t version_;
+    uint64_t relay_until_;
+    uint64_t expiration_;
+    uint32_t id_;
+    uint32_t cancel_;
+    std::vector<uint32_t> set_cancel_;
+    uint32_t min_version_;
+    uint32_t max_version_;
+    std::vector<std::string> set_sub_version_;
+    uint32_t priority_;
+    std::string comment_;
+    std::string status_bar_;
+    std::string reserved_;
+};
+
+} // namespace message
+} // namespace libbitcoin
+
+#endif

--- a/include/bitcoin/bitcoin/message/heading.hpp
+++ b/include/bitcoin/bitcoin/message/heading.hpp
@@ -38,6 +38,7 @@ enum class message_type
 {
     unknown,
     address,
+    alert,
     block,
     block_transactions,
     compact_block,

--- a/include/bitcoin/bitcoin/message/messages.hpp
+++ b/include/bitcoin/bitcoin/message/messages.hpp
@@ -23,6 +23,8 @@
 #include <cstddef>
 #include <bitcoin/bitcoin/math/limits.hpp>
 #include <bitcoin/bitcoin/message/address.hpp>
+#include <bitcoin/bitcoin/message/alert.hpp>
+#include <bitcoin/bitcoin/message/alert_payload.hpp>
 #include <bitcoin/bitcoin/message/block.hpp>
 #include <bitcoin/bitcoin/message/block_transactions.hpp>
 #include <bitcoin/bitcoin/message/compact_block.hpp>
@@ -67,7 +69,7 @@
 // pong         v1      60001   BIP031
 // reject       v3      70002   BIP061
 // ----------------------------------------------------------------------------
-// alert        --                      obsolete
+// alert        --                      no intent to support
 // checkorder   --                      obsolete
 // reply        --                      obsolete
 // submitorder  --                      obsolete

--- a/src/message/alert.cpp
+++ b/src/message/alert.cpp
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2011-2017 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <bitcoin/bitcoin/message/alert.hpp>
+
+#include <bitcoin/bitcoin/math/limits.hpp>
+#include <bitcoin/bitcoin/message/messages.hpp>
+#include <bitcoin/bitcoin/message/version.hpp>
+#include <bitcoin/bitcoin/utility/assert.hpp>
+#include <bitcoin/bitcoin/utility/container_sink.hpp>
+#include <bitcoin/bitcoin/utility/container_source.hpp>
+#include <bitcoin/bitcoin/utility/istream_reader.hpp>
+#include <bitcoin/bitcoin/utility/ostream_writer.hpp>
+
+namespace libbitcoin {
+namespace message {
+
+const std::string alert::command = "alert";
+const uint32_t alert::version_minimum = version::level::minimum;
+const uint32_t alert::version_maximum = version::level::maximum;
+
+alert alert::factory_from_data(uint32_t version, const data_chunk& data)
+{
+    alert instance;
+    instance.from_data(version, data);
+    return instance;
+}
+
+alert alert::factory_from_data(uint32_t version, std::istream& stream)
+{
+    alert instance;
+    instance.from_data(version, stream);
+    return instance;
+}
+
+alert alert::factory_from_data(uint32_t version, reader& source)
+{
+    alert instance;
+    instance.from_data(version, source);
+    return instance;
+}
+
+alert::alert()
+  : payload_(), signature_()
+{
+}
+
+alert::alert(const data_chunk& payload, const data_chunk& signature)
+  : payload_(payload), signature_(signature)
+{
+}
+
+alert::alert(data_chunk&& payload, data_chunk&& signature)
+  : payload_(std::move(payload)), signature_(std::move(signature))
+{
+}
+
+alert::alert(const alert& other)
+  : alert(other.payload_, other.signature_)
+{
+}
+
+alert::alert(alert&& other)
+  : alert(std::move(other.payload_), std::move(other.signature_))
+{
+}
+
+bool alert::is_valid() const
+{
+    return !payload_.empty() || !signature_.empty();
+}
+
+void alert::reset()
+{
+    payload_.clear();
+    payload_.shrink_to_fit();
+    signature_.clear();
+    signature_.shrink_to_fit();
+}
+
+bool alert::from_data(uint32_t version, const data_chunk& data)
+{
+    data_source istream(data);
+    return from_data(version, istream);
+}
+
+bool alert::from_data(uint32_t version, std::istream& stream)
+{
+    istream_reader source(stream);
+    return from_data(version, source);
+}
+
+bool alert::from_data(uint32_t version, reader& source)
+{
+    reset();
+
+    payload_ = source.read_bytes(source.read_size_little_endian());
+    signature_ = source.read_bytes(source.read_size_little_endian());
+
+    if (!source)
+        reset();
+
+    return source;
+}
+
+data_chunk alert::to_data(uint32_t version) const
+{
+    data_chunk data;
+    data.reserve(serialized_size(version));
+    data_sink ostream(data);
+    to_data(version, ostream);
+    ostream.flush();
+    BITCOIN_ASSERT(data.size() == serialized_size(version));
+    return data;
+}
+
+void alert::to_data(uint32_t version, std::ostream& stream) const
+{
+    ostream_writer sink(stream);
+    to_data(version, sink);
+}
+
+void alert::to_data(uint32_t version, writer& sink) const
+{
+    sink.write_variable_little_endian(payload_.size());
+    sink.write_bytes(payload_);
+    sink.write_variable_little_endian(signature_.size());
+    sink.write_bytes(signature_);
+}
+
+size_t alert::serialized_size(uint32_t version) const
+{
+    return message::variable_uint_size(payload_.size()) + payload_.size() +
+        message::variable_uint_size(signature_.size()) + signature_.size();
+}
+
+data_chunk& alert::payload()
+{
+    return payload_;
+}
+
+const data_chunk& alert::payload() const
+{
+    return payload_;
+}
+
+void alert::set_payload(const data_chunk& value)
+{
+    payload_ = value;
+}
+
+void alert::set_payload(data_chunk&& value)
+{
+    payload_ = std::move(value);
+}
+
+data_chunk& alert::signature()
+{
+    return signature_;
+}
+
+const data_chunk& alert::signature() const
+{
+    return signature_;
+}
+
+void alert::set_signature(const data_chunk& value)
+{
+    signature_ = value;
+}
+
+void alert::set_signature(data_chunk&& value)
+{
+    signature_ = std::move(value);
+}
+
+alert& alert::operator=(alert&& other)
+{
+    payload_ = std::move(other.payload_);
+    signature_ = std::move(other.signature_);
+    return *this;
+}
+
+bool alert::operator==(const alert& other) const
+{
+    return (payload_ == other.payload_)
+        && (signature_ == other.signature_);
+}
+
+bool alert::operator!=(const alert& other) const
+{
+    return !(*this == other);
+}
+
+} // namespace message
+} // namespace libbitcoin

--- a/src/message/alert_payload.cpp
+++ b/src/message/alert_payload.cpp
@@ -1,0 +1,537 @@
+/**
+ * Copyright (c) 2011-2017 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <bitcoin/bitcoin/message/alert_payload.hpp>
+
+#include <bitcoin/bitcoin/constants.hpp>
+#include <bitcoin/bitcoin/message/messages.hpp>
+#include <bitcoin/bitcoin/utility/container_sink.hpp>
+#include <bitcoin/bitcoin/utility/container_source.hpp>
+#include <bitcoin/bitcoin/utility/istream_reader.hpp>
+#include <bitcoin/bitcoin/utility/ostream_writer.hpp>
+
+namespace libbitcoin {
+namespace message {
+
+// Libbitcon doesn't use this.
+const ec_uncompressed alert_payload::satoshi_public_key
+{
+    {
+        0x04, 0xfc, 0x97, 0x02, 0x84, 0x78, 0x40, 0xaa, 0xf1, 0x95, 0xde,
+        0x84, 0x42, 0xeb, 0xec, 0xed, 0xf5, 0xb0, 0x95, 0xcd, 0xbb, 0x9b,
+        0xc7, 0x16, 0xbd, 0xa9, 0x11, 0x09, 0x71, 0xb2, 0x8a, 0x49, 0xe0,
+        0xea, 0xd8, 0x56, 0x4f, 0xf0, 0xdb, 0x22, 0x20, 0x9e, 0x03, 0x74,
+        0x78, 0x2c, 0x09, 0x3b, 0xb8, 0x99, 0x69, 0x2d, 0x52, 0x4e, 0x9d,
+        0x6a, 0x69, 0x56, 0xe7, 0xc5, 0xec, 0xbc, 0xd6, 0x82, 0x84
+    }
+};
+
+alert_payload alert_payload::factory_from_data(uint32_t version,
+    const data_chunk& data)
+{
+    alert_payload instance;
+    instance.from_data(version, data);
+    return instance;
+}
+
+alert_payload alert_payload::factory_from_data(uint32_t version,
+    std::istream& stream)
+{
+    alert_payload instance;
+    instance.from_data(version, stream);
+    return instance;
+}
+
+alert_payload alert_payload::factory_from_data(uint32_t version,
+    reader& source)
+{
+    alert_payload instance;
+    instance.from_data(version, source);
+    return instance;
+}
+
+alert_payload::alert_payload()
+  : version_(0),
+    relay_until_(0),
+    expiration_(0),
+    id_(0),
+    cancel_(0),
+    min_version_(0),
+    max_version_(0),
+    priority_(0)
+{
+}
+
+alert_payload::alert_payload(
+    uint32_t version,
+    uint64_t relay_until,
+    uint64_t expiration,
+    uint32_t id,
+    uint32_t cancel,
+    const std::vector<uint32_t>& set_cancel,
+    uint32_t min_version,
+    uint32_t max_version,
+    const std::vector<std::string>& set_sub_version,
+    uint32_t priority,
+    const std::string& comment,
+    const std::string& status_bar,
+    const std::string& reserved)
+  : version_(version),
+    relay_until_(relay_until),
+    expiration_(expiration),
+    id_(id),
+    cancel_(cancel),
+    set_cancel_(set_cancel),
+    min_version_(min_version),
+    max_version_(max_version),
+    set_sub_version_(set_sub_version),
+    priority_(priority),
+    comment_(comment),
+    status_bar_(status_bar),
+    reserved_(reserved)
+{
+}
+
+alert_payload::alert_payload(
+    uint32_t version,
+    uint64_t relay_until,
+    uint64_t expiration,
+    uint32_t id,
+    uint32_t cancel,
+    std::vector<uint32_t>&& set_cancel,
+    uint32_t min_version,
+    uint32_t max_version,
+    std::vector<std::string>&& set_sub_version,
+    uint32_t priority,
+    std::string&& comment,
+    std::string&& status_bar,
+    std::string&& reserved)
+  : version_(version),
+    relay_until_(relay_until),
+    expiration_(expiration),
+    id_(id),
+    cancel_(cancel),
+    set_cancel_(std::move(set_cancel)),
+    min_version_(min_version),
+    max_version_(max_version),
+    set_sub_version_(std::move(set_sub_version)),
+    priority_(priority),
+    comment_(std::move(comment)),
+    status_bar_(std::move(status_bar)),
+    reserved_(std::move(reserved))
+{
+}
+
+alert_payload::alert_payload(const alert_payload& other)
+  : alert_payload(
+        other.version_,
+        other.relay_until_,
+        other.expiration_,
+        other.id_,
+        other.cancel_,
+        other.set_cancel_,
+        other.min_version_,
+        other.max_version_,
+        other.set_sub_version_,
+        other.priority_,
+        other.comment_,
+        other.status_bar_,
+        other.reserved_)
+{
+}
+
+alert_payload::alert_payload(alert_payload&& other)
+  : alert_payload(
+        other.version_,
+        other.relay_until_,
+        other.expiration_,
+        other.id_,
+        other.cancel_,
+        std::move(other.set_cancel_),
+        other.min_version_,
+        other.max_version_,
+        std::move(other.set_sub_version_),
+        other.priority_,
+        std::move(other.comment_),
+        std::move(other.status_bar_),
+        std::move(other.reserved_))
+{
+}
+
+bool alert_payload::is_valid() const
+{
+    return (version_ != 0)
+        || (relay_until_ != 0)
+        || (expiration_ != 0)
+        || (id_ != 0)
+        || (cancel_ != 0)
+        || !set_cancel_.empty()
+        || (min_version_ != 0)
+        || (max_version_ != 0)
+        || !set_sub_version_.empty()
+        || (priority_ != 0)
+        || !comment_.empty()
+        || !status_bar_.empty()
+        || !reserved_.empty();
+}
+
+void alert_payload::reset()
+{
+    version_ = 0;
+    relay_until_ = 0;
+    expiration_ = 0;
+    id_ = 0;
+    cancel_ = 0;
+    set_cancel_.clear();
+    set_cancel_.shrink_to_fit();
+    min_version_ = 0;
+    max_version_ = 0;
+    set_sub_version_.clear();
+    set_sub_version_.shrink_to_fit();
+    priority_ = 0;
+    comment_.clear();
+    comment_.shrink_to_fit();
+    status_bar_.clear();
+    status_bar_.shrink_to_fit();
+    reserved_.clear();
+    reserved_.shrink_to_fit();
+}
+
+bool alert_payload::from_data(uint32_t version, const data_chunk& data)
+{
+    data_source istream(data);
+    return from_data(version, istream);
+}
+
+bool alert_payload::from_data(uint32_t version, std::istream& stream)
+{
+    istream_reader source(stream);
+    return from_data(version, source);
+}
+
+bool alert_payload::from_data(uint32_t version, reader& source)
+{
+    reset();
+
+    this->version_ = source.read_4_bytes_little_endian();
+    relay_until_ = source.read_8_bytes_little_endian();
+    expiration_ = source.read_8_bytes_little_endian();
+    id_ = source.read_4_bytes_little_endian();
+    cancel_ = source.read_4_bytes_little_endian();
+    set_cancel_.reserve(source.read_size_little_endian());
+
+    for (size_t i = 0; i < set_cancel_.capacity() && source; i++)
+        set_cancel_.push_back(source.read_4_bytes_little_endian());
+
+    min_version_ = source.read_4_bytes_little_endian();
+    max_version_ = source.read_4_bytes_little_endian();
+    set_sub_version_.reserve(source.read_size_little_endian());
+
+    for (size_t i = 0; i < set_sub_version_.capacity() && source; i++)
+        set_sub_version_.push_back(source.read_string());
+
+    priority_ = source.read_4_bytes_little_endian();
+    comment_ = source.read_string();
+    status_bar_ = source.read_string();
+    reserved_ = source.read_string();
+
+    if (!source)
+        reset();
+
+    return source;
+}
+
+data_chunk alert_payload::to_data(uint32_t version) const
+{
+    data_chunk data;
+    data.reserve(serialized_size(version));
+    data_sink ostream(data);
+    to_data(version, ostream);
+    ostream.flush();
+    BITCOIN_ASSERT(data.size() == serialized_size(version));
+    return data;
+}
+
+void alert_payload::to_data(uint32_t version, std::ostream& stream) const
+{
+    ostream_writer sink(stream);
+    to_data(version, sink);
+}
+
+void alert_payload::to_data(uint32_t version, writer& sink) const
+{
+    sink.write_4_bytes_little_endian(this->version_);
+    sink.write_8_bytes_little_endian(relay_until_);
+    sink.write_8_bytes_little_endian(expiration_);
+    sink.write_4_bytes_little_endian(id_);
+    sink.write_4_bytes_little_endian(cancel_);
+    sink.write_variable_little_endian(set_cancel_.size());
+
+    for (const auto& entry: set_cancel_)
+        sink.write_4_bytes_little_endian(entry);
+
+    sink.write_4_bytes_little_endian(min_version_);
+    sink.write_4_bytes_little_endian(max_version_);
+    sink.write_variable_little_endian(set_sub_version_.size());
+
+    for (const auto& entry: set_sub_version_)
+        sink.write_string(entry);
+
+    sink.write_4_bytes_little_endian(priority_);
+    sink.write_string(comment_);
+    sink.write_string(status_bar_);
+    sink.write_string(reserved_);
+}
+
+size_t alert_payload::serialized_size(uint32_t version) const
+{
+    size_t size = 40u +
+        message::variable_uint_size(comment_.size()) + comment_.size() +
+        message::variable_uint_size(status_bar_.size()) + status_bar_.size() +
+        message::variable_uint_size(reserved_.size()) + reserved_.size() +
+        message::variable_uint_size(set_cancel_.size()) + (4 * set_cancel_.size()) +
+        message::variable_uint_size(set_sub_version_.size());
+
+    for (const auto& sub_version : set_sub_version_)
+        size += message::variable_uint_size(sub_version.size()) + sub_version.size();
+
+    return size;
+}
+
+uint32_t alert_payload::version() const
+{
+    return version_;
+}
+
+void alert_payload::set_version(uint32_t value)
+{
+    version_ = value;
+}
+
+uint64_t alert_payload::relay_until() const
+{
+    return relay_until_;
+}
+
+void alert_payload::set_relay_until(uint64_t value)
+{
+    relay_until_ = value;
+}
+
+uint64_t alert_payload::expiration() const
+{
+    return expiration_;
+}
+
+void alert_payload::set_expiration(uint64_t value)
+{
+    expiration_ = value;
+}
+
+uint32_t alert_payload::id() const
+{
+    return id_;
+}
+
+void alert_payload::set_id(uint32_t value)
+{
+    id_ = value;
+}
+
+uint32_t alert_payload::cancel() const
+{
+    return cancel_;
+}
+
+void alert_payload::set_cancel(uint32_t value)
+{
+    cancel_ = value;
+}
+
+std::vector<uint32_t>& alert_payload::set_cancel()
+{
+    return set_cancel_;
+}
+
+const std::vector<uint32_t>& alert_payload::set_cancel() const
+{
+    return set_cancel_;
+}
+
+void alert_payload::set_set_cancel(const std::vector<uint32_t>& value)
+{
+    set_cancel_ = value;
+}
+
+void alert_payload::set_set_cancel(std::vector<uint32_t>&& value)
+{
+    set_cancel_ = std::move(value);
+}
+
+uint32_t alert_payload::min_version() const
+{
+    return min_version_;
+}
+
+void alert_payload::set_min_version(uint32_t value)
+{
+    min_version_ = value;
+}
+
+uint32_t alert_payload::max_version() const
+{
+    return max_version_;
+}
+
+void alert_payload::set_max_version(uint32_t value)
+{
+    max_version_ = value;
+}
+
+std::vector<std::string>& alert_payload::set_sub_version()
+{
+    return set_sub_version_;
+}
+
+const std::vector<std::string>& alert_payload::set_sub_version() const
+{
+    return set_sub_version_;
+}
+
+void alert_payload::set_set_sub_version(const std::vector<std::string>& value)
+{
+    set_sub_version_ = value;
+}
+
+void alert_payload::set_set_sub_version(std::vector<std::string>&& value)
+{
+    set_sub_version_ = std::move(value);
+}
+
+uint32_t alert_payload::priority() const
+{
+    return priority_;
+}
+
+void alert_payload::set_priority(uint32_t value)
+{
+    priority_ = value;
+}
+
+std::string& alert_payload::comment()
+{
+    return comment_;
+}
+
+const std::string& alert_payload::comment() const
+{
+    return comment_;
+}
+
+void alert_payload::set_comment(const std::string& value)
+{
+    comment_ = value;
+}
+
+void alert_payload::set_comment(std::string&& value)
+{
+    comment_ = std::move(value);
+}
+
+std::string& alert_payload::status_bar()
+{
+    return status_bar_;
+}
+
+const std::string& alert_payload::status_bar() const
+{
+    return status_bar_;
+}
+
+void alert_payload::set_status_bar(const std::string& value)
+{
+    status_bar_ = value;
+}
+
+void alert_payload::set_status_bar(std::string&& value)
+{
+    status_bar_ = std::move(value);
+}
+
+std::string& alert_payload::reserved()
+{
+    return reserved_;
+}
+
+const std::string& alert_payload::reserved() const
+{
+    return reserved_;
+}
+
+void alert_payload::set_reserved(const std::string& value)
+{
+    reserved_ = value;
+}
+
+void alert_payload::set_reserved(std::string&& value)
+{
+    reserved_ = std::move(value);
+}
+
+alert_payload& alert_payload::operator=(alert_payload&& other)
+{
+    version_ = other.version_;
+    relay_until_ = other.relay_until_;
+    expiration_ = other.expiration_;
+    id_ = other.id_;
+    cancel_ = other.cancel_;
+    set_cancel_ = std::move(other.set_cancel_);
+    min_version_ = other.min_version_;
+    max_version_ = other.max_version_;
+    set_sub_version_ = std::move(other.set_sub_version_);
+    priority_ = other.priority_;
+    comment_ = std::move(other.comment_);
+    status_bar_ = std::move(other.status_bar_);
+    reserved_ = std::move(other.reserved_);
+    return *this;
+}
+
+bool alert_payload::operator==(const alert_payload& other) const
+{
+    return (version_ == other.version_)
+        && (relay_until_ == other.relay_until_)
+        && (expiration_ == other.expiration_)
+        && (id_ == other.id_)
+        && (cancel_ == other.cancel_)
+        && (set_cancel_ == other.set_cancel_)
+        && (min_version_ == other.min_version_)
+        && (max_version_ == other.max_version_)
+        && (set_sub_version_ == other.set_sub_version_)
+        && (priority_ == other.priority_)
+        && (comment_ == other.comment_)
+        && (status_bar_ == other.status_bar_)
+        && (reserved_ == other.reserved_);
+}
+
+bool alert_payload::operator!=(const alert_payload& other) const
+{
+    return !(*this == other);
+}
+
+} // namespace message
+} // namespace libbitcoin

--- a/src/message/heading.cpp
+++ b/src/message/heading.cpp
@@ -181,6 +181,8 @@ message_type heading::type() const
     // TODO: convert to static map.
     if (command_ == address::command)
         return message_type::address;
+    if (command_ == alert::command)
+        return message_type::alert;
     if (command_ == block_transactions::command)
         return message_type::block_transactions;
     if (command_ == block::command)

--- a/test/message/alert.cpp
+++ b/test/message/alert.cpp
@@ -1,0 +1,349 @@
+/**
+ * Copyright (c) 2011-2017 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <boost/test/unit_test.hpp>
+#include <bitcoin/bitcoin.hpp>
+
+using namespace bc;
+
+BOOST_AUTO_TEST_SUITE(alert_tests)
+
+BOOST_AUTO_TEST_CASE(alert__constructor_1__always__invalid)
+{
+    message::alert instance;
+    BOOST_REQUIRE(!instance.is_valid());
+}
+
+BOOST_AUTO_TEST_CASE(alert__constructor_2__always__equals_params)
+{
+    const data_chunk payload = to_chunk(base16_literal("0123456789abcdef"));
+    const data_chunk signature = to_chunk(base16_literal("fedcba9876543210"));
+
+    message::alert instance(payload, signature);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(payload == instance.payload());
+    BOOST_REQUIRE(signature == instance.signature());
+}
+
+BOOST_AUTO_TEST_CASE(alert__constructor_3__always__equals_params)
+{
+    const auto payload = to_chunk(base16_literal("0123456789abcdef"));
+    const auto signature = to_chunk(base16_literal("fedcba9876543210"));
+    auto dup_payload = payload;
+    auto dup_signature = signature;
+
+    message::alert instance(std::move(dup_payload), std::move(dup_signature));
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(payload == instance.payload());
+    BOOST_REQUIRE(signature == instance.signature());
+}
+
+BOOST_AUTO_TEST_CASE(alert__constructor_4__always__equals_params)
+{
+    const data_chunk payload = to_chunk(base16_literal("0123456789abcdef"));
+    const data_chunk signature = to_chunk(base16_literal("fedcba9876543210"));
+
+    message::alert value(payload, signature);
+    message::alert instance(value);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(value == instance);
+    BOOST_REQUIRE(payload == instance.payload());
+    BOOST_REQUIRE(signature == instance.signature());
+}
+
+BOOST_AUTO_TEST_CASE(alert__constructor_5__always__equals_params)
+{
+    const data_chunk payload = to_chunk(base16_literal("0123456789abcdef"));
+    const data_chunk signature = to_chunk(base16_literal("fedcba9876543210"));
+
+    message::alert value(payload, signature);
+    message::alert instance(std::move(value));
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(payload == instance.payload());
+    BOOST_REQUIRE(signature == instance.signature());
+}
+
+BOOST_AUTO_TEST_CASE(alert__from_data__insufficient_bytes__failure)
+{
+    const data_chunk raw{ 0xab, 0x11 };
+    message::alert instance;
+
+    BOOST_REQUIRE(!instance.from_data(message::version::level::minimum, raw));
+    BOOST_REQUIRE(!instance.is_valid());
+}
+
+BOOST_AUTO_TEST_CASE(alert__factory_from_data_1__wiki_sample__success)
+{
+    const data_chunk raw_payload
+    {
+        0x01, 0x00, 0x00, 0x00, 0x37, 0x66, 0x40, 0x4f, 0x00,
+        0x00, 0x00, 0x00, 0xb3, 0x05, 0x43, 0x4f, 0x00, 0x00, 0x00,
+        0x00, 0xf2, 0x03, 0x00, 0x00, 0xf1, 0x03, 0x00, 0x00, 0x00,
+        0x10, 0x27, 0x00, 0x00, 0x48, 0xee, 0x00, 0x00, 0x00, 0x64,
+        0x00, 0x00, 0x00, 0x00, 0x46, 0x53, 0x65, 0x65, 0x20, 0x62,
+        0x69, 0x74, 0x63, 0x6f, 0x69, 0x6e, 0x2e, 0x6f, 0x72, 0x67,
+        0x2f, 0x66, 0x65, 0x62, 0x32, 0x30, 0x20, 0x69, 0x66, 0x20,
+        0x79, 0x6f, 0x75, 0x20, 0x68, 0x61, 0x76, 0x65, 0x20, 0x74,
+        0x72, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x20, 0x63, 0x6f, 0x6e,
+        0x6e, 0x65, 0x63, 0x74, 0x69, 0x6e, 0x67, 0x20, 0x61, 0x66,
+        0x74, 0x65, 0x72, 0x20, 0x32, 0x30, 0x20, 0x46, 0x65, 0x62,
+        0x72, 0x75, 0x61, 0x72, 0x79, 0x00
+    };
+
+    const data_chunk raw_signature
+    {
+        0x30, 0x45, 0x02, 0x21, 0x00, 0x83, 0x89, 0xdf, 0x45, 0xf0,
+        0x70, 0x3f, 0x39, 0xec, 0x8c, 0x1c, 0xc4, 0x2c, 0x13, 0x81,
+        0x0f, 0xfc, 0xae, 0x14, 0x99, 0x5b, 0xb6, 0x48, 0x34, 0x02,
+        0x19, 0xe3, 0x53, 0xb6, 0x3b, 0x53, 0xeb, 0x02, 0x20, 0x09,
+        0xec, 0x65, 0xe1, 0xc1, 0xaa, 0xee, 0xc1, 0xfd, 0x33, 0x4c,
+        0x6b, 0x68, 0x4b, 0xde, 0x2b, 0x3f, 0x57, 0x30, 0x60, 0xd5,
+        0xb7, 0x0c, 0x3a, 0x46, 0x72, 0x33, 0x26, 0xe4, 0xe8, 0xa4,
+        0xf1
+    };
+
+    const data_chunk raw
+    {
+        0x73, 0x01, 0x00, 0x00, 0x00, 0x37, 0x66, 0x40, 0x4f, 0x00,
+        0x00, 0x00, 0x00, 0xb3, 0x05, 0x43, 0x4f, 0x00, 0x00, 0x00,
+        0x00, 0xf2, 0x03, 0x00, 0x00, 0xf1, 0x03, 0x00, 0x00, 0x00,
+        0x10, 0x27, 0x00, 0x00, 0x48, 0xee, 0x00, 0x00, 0x00, 0x64,
+        0x00, 0x00, 0x00, 0x00, 0x46, 0x53, 0x65, 0x65, 0x20, 0x62,
+        0x69, 0x74, 0x63, 0x6f, 0x69, 0x6e, 0x2e, 0x6f, 0x72, 0x67,
+        0x2f, 0x66, 0x65, 0x62, 0x32, 0x30, 0x20, 0x69, 0x66, 0x20,
+        0x79, 0x6f, 0x75, 0x20, 0x68, 0x61, 0x76, 0x65, 0x20, 0x74,
+        0x72, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x20, 0x63, 0x6f, 0x6e,
+        0x6e, 0x65, 0x63, 0x74, 0x69, 0x6e, 0x67, 0x20, 0x61, 0x66,
+        0x74, 0x65, 0x72, 0x20, 0x32, 0x30, 0x20, 0x46, 0x65, 0x62,
+        0x72, 0x75, 0x61, 0x72, 0x79, 0x00, 0x47, 0x30, 0x45, 0x02,
+        0x21, 0x00, 0x83, 0x89, 0xdf, 0x45, 0xf0, 0x70, 0x3f, 0x39,
+        0xec, 0x8c, 0x1c, 0xc4, 0x2c, 0x13, 0x81, 0x0f, 0xfc, 0xae,
+        0x14, 0x99, 0x5b, 0xb6, 0x48, 0x34, 0x02, 0x19, 0xe3, 0x53,
+        0xb6, 0x3b, 0x53, 0xeb, 0x02, 0x20, 0x09, 0xec, 0x65, 0xe1,
+        0xc1, 0xaa, 0xee, 0xc1, 0xfd, 0x33, 0x4c, 0x6b, 0x68, 0x4b,
+        0xde, 0x2b, 0x3f, 0x57, 0x30, 0x60, 0xd5, 0xb7, 0x0c, 0x3a,
+        0x46, 0x72, 0x33, 0x26, 0xe4, 0xe8, 0xa4, 0xf1
+    };
+
+    const message::alert expected{ raw_payload, raw_signature };
+    const auto result = message::alert::factory_from_data(
+        message::version::level::minimum, raw);
+
+    BOOST_REQUIRE(result.is_valid());
+    BOOST_REQUIRE_EQUAL(raw.size(), result.serialized_size(message::version::level::minimum));
+    BOOST_REQUIRE(result == expected);
+
+    const auto data = expected.to_data(message::version::level::minimum);
+
+    BOOST_REQUIRE_EQUAL(raw.size(), data.size());
+    BOOST_REQUIRE_EQUAL(data.size(), expected.serialized_size(message::version::level::minimum));
+}
+
+BOOST_AUTO_TEST_CASE(alert__factory_from_data_1__roundtrip__success)
+{
+    const message::alert expected
+    {
+        { 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 },
+        { 0x04, 0xff, 0xab, 0xcd, 0xee }
+    };
+
+    const auto data = expected.to_data(message::version::level::minimum);
+    const auto result = message::alert::factory_from_data(
+        message::version::level::minimum, data);
+
+    BOOST_REQUIRE(result.is_valid());
+    BOOST_REQUIRE(expected == result);
+    BOOST_REQUIRE_EQUAL(data.size(), result.serialized_size(message::version::level::minimum));
+    BOOST_REQUIRE_EQUAL(expected.serialized_size(message::version::level::minimum), result.serialized_size(message::version::level::minimum));
+}
+
+BOOST_AUTO_TEST_CASE(alert__factory_from_data_2__roundtrip__success)
+{
+    const message::alert expected
+    {
+        { 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 },
+        { 0x04, 0xff, 0xab, 0xcd, 0xee }
+    };
+
+    const auto data = expected.to_data(message::version::level::minimum);
+    data_source istream(data);
+    const auto result = message::alert::factory_from_data(message::version::level::minimum, istream);
+
+    BOOST_REQUIRE(result.is_valid());
+    BOOST_REQUIRE(expected == result);
+    BOOST_REQUIRE_EQUAL(data.size(), result.serialized_size(message::version::level::minimum));
+    BOOST_REQUIRE_EQUAL(expected.serialized_size(message::version::level::minimum), result.serialized_size(message::version::level::minimum));
+}
+
+BOOST_AUTO_TEST_CASE(alert__factory_from_data_3__roundtrip__success)
+{
+    const message::alert expected
+    {
+        { 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 },
+        { 0x04, 0xff, 0xab, 0xcd, 0xee }
+    };
+
+    const auto data = expected.to_data(message::version::level::minimum);
+    data_source istream(data);
+    istream_reader source(istream);
+    const auto result = message::alert::factory_from_data(
+        message::version::level::minimum, source);
+
+    BOOST_REQUIRE(result.is_valid());
+    BOOST_REQUIRE(expected == result);
+    BOOST_REQUIRE_EQUAL(data.size(), result.serialized_size(message::version::level::minimum));
+    BOOST_REQUIRE_EQUAL(expected.serialized_size(message::version::level::minimum), result.serialized_size(message::version::level::minimum));
+}
+
+BOOST_AUTO_TEST_CASE(alert__payload_accessor_1__always__returns_initialized)
+{
+    const data_chunk payload = to_chunk(base16_literal("0123456789abcdef"));
+    const data_chunk signature = to_chunk(base16_literal("fedcba9876543210"));
+
+    message::alert instance(payload, signature);
+    BOOST_REQUIRE(payload == instance.payload());
+}
+
+BOOST_AUTO_TEST_CASE(alert__payload_accessor_2__always__returns_initialized)
+{
+    const data_chunk payload = to_chunk(base16_literal("0123456789abcdef"));
+    const data_chunk signature = to_chunk(base16_literal("fedcba9876543210"));
+
+    const message::alert instance(payload, signature);
+    BOOST_REQUIRE(payload == instance.payload());
+}
+
+BOOST_AUTO_TEST_CASE(alert__payload_setter_1__roundtrip__success)
+{
+    const auto value = to_chunk(base16_literal("aabbccddeeff"));
+    message::alert instance;
+    BOOST_REQUIRE(instance.payload() != value);
+    instance.set_payload(value);
+    BOOST_REQUIRE(value == instance.payload());
+}
+
+BOOST_AUTO_TEST_CASE(alert__payload_setter_2__roundtrip__success)
+{
+    const auto value = to_chunk(base16_literal("aabbccddeeff"));
+    auto dup_value = value;
+    message::alert instance;
+    BOOST_REQUIRE(instance.payload() != value);
+    instance.set_payload(std::move(dup_value));
+    BOOST_REQUIRE(value == instance.payload());
+}
+
+BOOST_AUTO_TEST_CASE(alert__signature_accessor_1__always__returns_initialized)
+{
+    const data_chunk payload = to_chunk(base16_literal("0123456789abcdef"));
+    const data_chunk signature = to_chunk(base16_literal("fedcba9876543210"));
+
+    message::alert instance(payload, signature);
+    BOOST_REQUIRE(signature == instance.signature());
+}
+
+BOOST_AUTO_TEST_CASE(alert__signature_accessor_2__always__returns_initialized)
+{
+    const data_chunk payload = to_chunk(base16_literal("0123456789abcdef"));
+    const data_chunk signature = to_chunk(base16_literal("fedcba9876543210"));
+
+    const message::alert instance(payload, signature);
+    BOOST_REQUIRE(signature == instance.signature());
+}
+
+BOOST_AUTO_TEST_CASE(alert__signature_setter_1__roundtrip__success)
+{
+    const auto value = to_chunk(base16_literal("aabbccddeeff"));
+    message::alert instance;
+    BOOST_REQUIRE(instance.signature() != value);
+    instance.set_signature(value);
+    BOOST_REQUIRE(value == instance.signature());
+}
+
+BOOST_AUTO_TEST_CASE(alert__signature_setter_2__roundtrip__success)
+{
+    const auto value = to_chunk(base16_literal("aabbccddeeff"));
+    auto dup_value = value;
+    message::alert instance;
+    BOOST_REQUIRE(instance.signature() != value);
+    instance.set_signature(std::move(dup_value));
+    BOOST_REQUIRE(value == instance.signature());
+}
+
+BOOST_AUTO_TEST_CASE(alert__operator_assign_equals__always__matches_equivalent)
+{
+    const data_chunk payload = to_chunk(base16_literal("0123456789abcdef"));
+    const data_chunk signature = to_chunk(base16_literal("fedcba9876543210"));
+
+    message::alert value(payload, signature);
+
+    BOOST_REQUIRE(value.is_valid());
+
+    message::alert instance;
+    BOOST_REQUIRE(!instance.is_valid());
+
+    instance = std::move(value);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(payload == instance.payload());
+    BOOST_REQUIRE(signature == instance.signature());
+}
+
+BOOST_AUTO_TEST_CASE(alert__operator_boolean_equals__duplicates__returns_true)
+{
+    const message::alert expected(
+        to_chunk(base16_literal("0123456789abcdef")),
+        to_chunk(base16_literal("fedcba9876543210")));
+
+    message::alert instance(expected);
+    BOOST_REQUIRE(instance == expected);
+}
+
+BOOST_AUTO_TEST_CASE(alert__operator_boolean_equals__differs__returns_false)
+{
+    const message::alert expected(
+        to_chunk(base16_literal("0123456789abcdef")),
+        to_chunk(base16_literal("fedcba9876543210")));
+
+    message::alert instance;
+    BOOST_REQUIRE_EQUAL(false, instance == expected);
+}
+
+BOOST_AUTO_TEST_CASE(alert__operator_boolean_not_equals__duplicates__returns_false)
+{
+    const message::alert expected(
+        to_chunk(base16_literal("0123456789abcdef")),
+        to_chunk(base16_literal("fedcba9876543210")));
+
+    message::alert instance(expected);
+    BOOST_REQUIRE_EQUAL(false, instance != expected);
+}
+
+BOOST_AUTO_TEST_CASE(alert__operator_boolean_not_equals__differs__returns_true)
+{
+    const message::alert expected(
+        to_chunk(base16_literal("0123456789abcdef")),
+        to_chunk(base16_literal("fedcba9876543210")));
+
+    message::alert instance;
+    BOOST_REQUIRE(instance != expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/message/alert_payload.cpp
+++ b/test/message/alert_payload.cpp
@@ -1,0 +1,835 @@
+/**
+ * Copyright (c) 2011-2017 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <boost/test/unit_test.hpp>
+#include <bitcoin/bitcoin.hpp>
+
+using namespace bc;
+
+BOOST_AUTO_TEST_SUITE(alert_payload_tests)
+
+BOOST_AUTO_TEST_CASE(alert_payload__constructor_1__always__invalid)
+{
+    message::alert_payload instance;
+    BOOST_REQUIRE(!instance.is_valid());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__constructor_2__always__equals_params)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(version, instance.version());
+    BOOST_REQUIRE_EQUAL(relay_until, instance.relay_until());
+    BOOST_REQUIRE_EQUAL(expiration, instance.expiration());
+    BOOST_REQUIRE_EQUAL(id, instance.id());
+    BOOST_REQUIRE_EQUAL(cancel, instance.cancel());
+    BOOST_REQUIRE(set_cancel == instance.set_cancel());
+    BOOST_REQUIRE_EQUAL(min_version, instance.min_version());
+    BOOST_REQUIRE_EQUAL(max_version, instance.max_version());
+    BOOST_REQUIRE(set_sub_version == instance.set_sub_version());
+    BOOST_REQUIRE_EQUAL(priority, instance.priority());
+    BOOST_REQUIRE_EQUAL(comment, instance.comment());
+    BOOST_REQUIRE_EQUAL(status_bar, instance.status_bar());
+    BOOST_REQUIRE_EQUAL(reserved, instance.reserved());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__constructor_3__always__equals_params)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    auto dup_set_cancel = set_cancel;
+    auto dup_set_sub_version = set_sub_version;
+    auto dup_comment = comment;
+    auto dup_status_bar = status_bar;
+    auto dup_reserved = reserved;
+
+    message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, std::move(dup_set_cancel), min_version, max_version,
+        std::move(dup_set_sub_version), priority, std::move(dup_comment),
+        std::move(dup_status_bar), std::move(dup_reserved));
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(version, instance.version());
+    BOOST_REQUIRE_EQUAL(relay_until, instance.relay_until());
+    BOOST_REQUIRE_EQUAL(expiration, instance.expiration());
+    BOOST_REQUIRE_EQUAL(id, instance.id());
+    BOOST_REQUIRE_EQUAL(cancel, instance.cancel());
+    BOOST_REQUIRE(set_cancel == instance.set_cancel());
+    BOOST_REQUIRE_EQUAL(min_version, instance.min_version());
+    BOOST_REQUIRE_EQUAL(max_version, instance.max_version());
+    BOOST_REQUIRE(set_sub_version == instance.set_sub_version());
+    BOOST_REQUIRE_EQUAL(priority, instance.priority());
+    BOOST_REQUIRE_EQUAL(comment, instance.comment());
+    BOOST_REQUIRE_EQUAL(status_bar, instance.status_bar());
+    BOOST_REQUIRE_EQUAL(reserved, instance.reserved());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__constructor_4__always__equals_params)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    message::alert_payload value(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    message::alert_payload instance(value);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(version, instance.version());
+    BOOST_REQUIRE_EQUAL(relay_until, instance.relay_until());
+    BOOST_REQUIRE_EQUAL(expiration, instance.expiration());
+    BOOST_REQUIRE_EQUAL(id, instance.id());
+    BOOST_REQUIRE_EQUAL(cancel, instance.cancel());
+    BOOST_REQUIRE(set_cancel == instance.set_cancel());
+    BOOST_REQUIRE_EQUAL(min_version, instance.min_version());
+    BOOST_REQUIRE_EQUAL(max_version, instance.max_version());
+    BOOST_REQUIRE(set_sub_version == instance.set_sub_version());
+    BOOST_REQUIRE_EQUAL(priority, instance.priority());
+    BOOST_REQUIRE_EQUAL(comment, instance.comment());
+    BOOST_REQUIRE_EQUAL(status_bar, instance.status_bar());
+    BOOST_REQUIRE_EQUAL(reserved, instance.reserved());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__constructor_5__always__equals_params)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    message::alert_payload value(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    message::alert_payload instance(std::move(value));
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(version, instance.version());
+    BOOST_REQUIRE_EQUAL(relay_until, instance.relay_until());
+    BOOST_REQUIRE_EQUAL(expiration, instance.expiration());
+    BOOST_REQUIRE_EQUAL(id, instance.id());
+    BOOST_REQUIRE_EQUAL(cancel, instance.cancel());
+    BOOST_REQUIRE(set_cancel == instance.set_cancel());
+    BOOST_REQUIRE_EQUAL(min_version, instance.min_version());
+    BOOST_REQUIRE_EQUAL(max_version, instance.max_version());
+    BOOST_REQUIRE(set_sub_version == instance.set_sub_version());
+    BOOST_REQUIRE_EQUAL(priority, instance.priority());
+    BOOST_REQUIRE_EQUAL(comment, instance.comment());
+    BOOST_REQUIRE_EQUAL(status_bar, instance.status_bar());
+    BOOST_REQUIRE_EQUAL(reserved, instance.reserved());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__from_data__insufficient_bytes__failure)
+{
+    data_chunk raw{ 0xab, 0x11 };
+    message::alert_payload instance;
+
+    BOOST_REQUIRE(!instance.from_data(message::version::level::minimum, raw));
+    BOOST_REQUIRE(!instance.is_valid());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__factory_from_data_1__wiki_sample_test__success)
+{
+    const data_chunk raw
+    {
+        0x01, 0x00, 0x00, 0x00, 0x37, 0x66, 0x40, 0x4f, 0x00, 0x00,
+        0x00, 0x00, 0xb3, 0x05, 0x43, 0x4f, 0x00, 0x00, 0x00, 0x00,
+        0xf2, 0x03, 0x00, 0x00, 0xf1, 0x03, 0x00, 0x00, 0x00, 0x10,
+        0x27, 0x00, 0x00, 0x48, 0xee, 0x00, 0x00, 0x00, 0x64, 0x00,
+        0x00, 0x00, 0x00, 0x46, 0x53, 0x65, 0x65, 0x20, 0x62, 0x69,
+        0x74, 0x63, 0x6f, 0x69, 0x6e, 0x2e, 0x6f, 0x72, 0x67, 0x2f,
+        0x66, 0x65, 0x62, 0x32, 0x30, 0x20, 0x69, 0x66, 0x20, 0x79,
+        0x6f, 0x75, 0x20, 0x68, 0x61, 0x76, 0x65, 0x20, 0x74, 0x72,
+        0x6f, 0x75, 0x62, 0x6c, 0x65, 0x20, 0x63, 0x6f, 0x6e, 0x6e,
+        0x65, 0x63, 0x74, 0x69, 0x6e, 0x67, 0x20, 0x61, 0x66, 0x74,
+        0x65, 0x72, 0x20, 0x32, 0x30, 0x20, 0x46, 0x65, 0x62, 0x72,
+        0x75, 0x61, 0x72, 0x79, 0x00
+    };
+
+    const message::alert_payload expected
+    {
+        1,
+        1329620535,
+        1329792435,
+        1010,
+        1009,
+        std::vector<uint32_t>{},
+        10000,
+        61000,
+        std::vector<std::string>{},
+        100,
+        "",
+        "See bitcoin.org/feb20 if you have trouble connecting after 20 February",
+        ""
+    };
+
+    const auto result = message::alert_payload::factory_from_data(
+        message::version::level::minimum, raw);
+
+    BOOST_REQUIRE(result.is_valid());
+    BOOST_REQUIRE_EQUAL(raw.size(), result.serialized_size(message::version::level::minimum));
+    BOOST_REQUIRE(result == expected);
+
+    const auto data = expected.to_data(message::version::level::minimum);
+
+    BOOST_REQUIRE_EQUAL(raw.size(), data.size());
+    BOOST_REQUIRE_EQUAL(data.size(), expected.serialized_size(message::version::level::minimum));
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__factory_from_data_1__roundtrip__success)
+{
+    message::alert_payload expected
+    {
+        5,
+        105169,
+        723544,
+        1779,
+        1678,
+        {
+            10, 25256, 37, 98485, 250
+        },
+        75612,
+        81354,
+        {
+            "alpha", "beta", "gamma", "delta"
+        },
+        781,
+        "My Comment",
+        "My Status Bar",
+        "RESERVED?"
+    };
+
+    const auto data = expected.to_data(message::version::level::minimum);
+    const auto result = message::alert_payload::factory_from_data(
+        message::version::level::minimum, data);
+
+    BOOST_REQUIRE(result.is_valid());
+    BOOST_REQUIRE(expected == result);
+    BOOST_REQUIRE_EQUAL(data.size(), result.serialized_size(message::version::level::minimum));
+    BOOST_REQUIRE_EQUAL(expected.serialized_size(message::version::level::minimum), result.serialized_size(message::version::level::minimum));
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__factory_from_data_2__roundtrip__success)
+{
+    message::alert_payload expected
+    {
+        5,
+        105169,
+        723544,
+        1779,
+        1678,
+        {
+            10, 25256, 37, 98485, 250
+        },
+        75612,
+        81354,
+        {
+            "alpha", "beta", "gamma", "delta"
+        },
+        781,
+        "My Comment",
+        "My Status Bar",
+        "RESERVED?"
+    };
+
+    const auto data = expected.to_data(message::version::level::minimum);
+    data_source istream(data);
+    const auto result = message::alert_payload::factory_from_data(
+        message::version::level::minimum, istream);
+
+    BOOST_REQUIRE(result.is_valid());
+    BOOST_REQUIRE(expected == result);
+    BOOST_REQUIRE_EQUAL(data.size(), result.serialized_size(message::version::level::minimum));
+    BOOST_REQUIRE_EQUAL(expected.serialized_size(message::version::level::minimum), result.serialized_size(message::version::level::minimum));
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__factory_from_data_3__roundtrip__success)
+{
+    const message::alert_payload expected
+    {
+        5,
+        105169,
+        723544,
+        1779,
+        1678,
+        {
+            10, 25256, 37, 98485, 250
+        },
+        75612,
+        81354,
+        {
+            "alpha", "beta", "gamma", "delta"
+        },
+        781,
+        "My Comment",
+        "My Status Bar",
+        "RESERVED?"
+    };
+
+    const auto data = expected.to_data(message::version::level::minimum);
+    data_source istream(data);
+    istream_reader source(istream);
+    const auto result = message::alert_payload::factory_from_data(
+        message::version::level::minimum, source);
+
+    BOOST_REQUIRE(result.is_valid());
+    BOOST_REQUIRE(expected == result);
+    BOOST_REQUIRE_EQUAL(data.size(), result.serialized_size(message::version::level::minimum));
+    BOOST_REQUIRE_EQUAL(expected.serialized_size(message::version::level::minimum), result.serialized_size(message::version::level::minimum));
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__version__roundtrip__success)
+{
+    uint32_t value = 1234u;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.version() != value);
+    instance.set_version(value);
+    BOOST_REQUIRE_EQUAL(value, instance.version());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__relay_until__roundtrip__success)
+{
+    uint64_t value = 5121234u;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.relay_until() != value);
+    instance.set_relay_until(value);
+    BOOST_REQUIRE_EQUAL(value, instance.relay_until());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__expiration__roundtrip__success)
+{
+    uint64_t value = 5121234u;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.expiration() != value);
+    instance.set_expiration(value);
+    BOOST_REQUIRE_EQUAL(value, instance.expiration());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__id__roundtrip__success)
+{
+    uint32_t value = 68215u;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.id() != value);
+    instance.set_id(value);
+    BOOST_REQUIRE_EQUAL(value, instance.id());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__cancel__roundtrip__success)
+{
+    uint32_t value = 68215u;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.cancel() != value);
+    instance.set_cancel(value);
+    BOOST_REQUIRE_EQUAL(value, instance.cancel());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__set_cancel_accessor_1__always__returns_initialized)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(set_cancel == instance.set_cancel());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__set_cancel_accessor_2__always__returns_initialized)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    const message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(set_cancel == instance.set_cancel());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__set_cancel_setter_1__roundtrip__success)
+{
+    const std::vector<uint32_t> value = { 68215u, 34542u, 4756u };
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.set_cancel() != value);
+    instance.set_set_cancel(value);
+    BOOST_REQUIRE(value == instance.set_cancel());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__set_cancel_setter_2__roundtrip__success)
+{
+    const std::vector<uint32_t> value = { 68215u, 34542u, 4756u };
+    auto dup_value = value;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.set_cancel() != value);
+    instance.set_set_cancel(std::move(dup_value));
+    BOOST_REQUIRE(value == instance.set_cancel());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__min_version__roundtrip__success)
+{
+    uint32_t value = 68215u;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.min_version() != value);
+    instance.set_min_version(value);
+    BOOST_REQUIRE_EQUAL(value, instance.min_version());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__max_version__roundtrip__success)
+{
+    uint32_t value = 68215u;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.max_version() != value);
+    instance.set_max_version(value);
+    BOOST_REQUIRE_EQUAL(value, instance.max_version());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__set_sub_version_accessor_1__always__returns_initialized)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(set_sub_version == instance.set_sub_version());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__set_sub_version_accessor_2__always__returns_initialized)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    const message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(set_sub_version == instance.set_sub_version());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__set_sub_version_setter_1__roundtrip__success)
+{
+    const std::vector<std::string> value = { "asdfa", "sgfdf", "Tryertsd" };
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.set_sub_version() != value);
+    instance.set_set_sub_version(value);
+    BOOST_REQUIRE(value == instance.set_sub_version());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__set_sub_version_setter_2__roundtrip__success)
+{
+    const std::vector<std::string> value = { "asdfa", "sgfdf", "Tryertsd" };
+    auto dup_value = value;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.set_sub_version() != value);
+    instance.set_set_sub_version(std::move(dup_value));
+    BOOST_REQUIRE(value == instance.set_sub_version());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__priority__roundtrip__success)
+{
+    uint32_t value = 68215u;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.priority() != value);
+    instance.set_priority(value);
+    BOOST_REQUIRE_EQUAL(value, instance.priority());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__comment_accessor_1__always__returns_initialized)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(comment, instance.comment());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__comment_accessor_2__always__returns_initialized)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    const message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(comment, instance.comment());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__comment_setter_1__roundtrip__success)
+{
+    const std::string value = "asdfa";
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.comment() != value);
+    instance.set_comment(value);
+    BOOST_REQUIRE(value == instance.comment());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__comment_setter_2__roundtrip__success)
+{
+    const std::string value = "Tryertsd";
+    auto dup_value = value;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.comment() != value);
+    instance.set_comment(std::move(dup_value));
+    BOOST_REQUIRE(value == instance.comment());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__status_bar_accessor_1__always__returns_initialized)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(status_bar, instance.status_bar());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__status_bar_accessor_2__always__returns_initialized)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    const message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(status_bar, instance.status_bar());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__status_bar_setter_1__roundtrip__success)
+{
+    const std::string value = "asdfa";
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.status_bar() != value);
+    instance.set_status_bar(value);
+    BOOST_REQUIRE(value == instance.status_bar());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__status_bar_setter_2__roundtrip__success)
+{
+    const std::string value = "Tryertsd";
+    auto dup_value = value;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.status_bar() != value);
+    instance.set_status_bar(std::move(dup_value));
+    BOOST_REQUIRE(value == instance.status_bar());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__reserved_accessor_1__always__returns_initialized)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(reserved, instance.reserved());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__reserved_accessor_2__always__returns_initialized)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    const message::alert_payload instance(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(reserved, instance.reserved());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__reserved_setter_1__roundtrip__success)
+{
+    const std::string value = "asdfa";
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.reserved() != value);
+    instance.set_reserved(value);
+    BOOST_REQUIRE(value == instance.reserved());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__reserved_setter_2__roundtrip__success)
+{
+    const std::string value = "Tryertsd";
+    auto dup_value = value;
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance.reserved() != value);
+    instance.set_reserved(std::move(dup_value));
+    BOOST_REQUIRE(value == instance.reserved());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__operator_assign_equals__always__matches_equivalent)
+{
+    const uint32_t version = 3452u;
+    const uint64_t relay_until = 64556u;
+    const uint64_t expiration = 78545u;
+    const uint32_t id = 43547u;
+    const uint32_t cancel = 546562345u;
+    const std::vector<uint32_t> set_cancel = { 2345u, 346754u, 234u, 4356u };
+    const uint32_t min_version = 4644u;
+    const uint32_t max_version = 89876u;
+    const std::vector<std::string> set_sub_version = { "foo", "bar", "baz" };
+    const uint32_t priority = 34323u;
+    const std::string comment = "asfgsddsa";
+    const std::string status_bar = "fgjdfhjg";
+    const std::string reserved = "utyurtevc";
+
+    message::alert_payload value(version, relay_until, expiration, id,
+        cancel, set_cancel, min_version, max_version, set_sub_version,
+        priority, comment, status_bar, reserved);
+
+    BOOST_REQUIRE(value.is_valid());
+
+    message::alert_payload instance;
+    BOOST_REQUIRE(!instance.is_valid());
+
+    instance = std::move(value);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE_EQUAL(version, instance.version());
+    BOOST_REQUIRE_EQUAL(relay_until, instance.relay_until());
+    BOOST_REQUIRE_EQUAL(expiration, instance.expiration());
+    BOOST_REQUIRE_EQUAL(id, instance.id());
+    BOOST_REQUIRE_EQUAL(cancel, instance.cancel());
+    BOOST_REQUIRE(set_cancel == instance.set_cancel());
+    BOOST_REQUIRE_EQUAL(min_version, instance.min_version());
+    BOOST_REQUIRE_EQUAL(max_version, instance.max_version());
+    BOOST_REQUIRE(set_sub_version == instance.set_sub_version());
+    BOOST_REQUIRE_EQUAL(priority, instance.priority());
+    BOOST_REQUIRE_EQUAL(comment, instance.comment());
+    BOOST_REQUIRE_EQUAL(status_bar, instance.status_bar());
+    BOOST_REQUIRE_EQUAL(reserved, instance.reserved());
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__operator_boolean_equals__duplicates__returns_true)
+{
+    const message::alert_payload expected(3452u, 64556u, 78545u, 43547u,
+        546562345u, { 2345u, 346754u, 234u, 4356u }, 4644u, 89876u,
+        { "foo", "bar", "baz" }, 34323u, "asfgsddsa", "fgjdfhjg", "utyurtevc");
+
+    message::alert_payload instance(expected);
+    BOOST_REQUIRE(instance == expected);
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__operator_boolean_equals__differs__returns_false)
+{
+    const message::alert_payload expected(3452u, 64556u, 78545u, 43547u,
+        546562345u, { 2345u, 346754u, 234u, 4356u }, 4644u, 89876u,
+        { "foo", "bar", "baz" }, 34323u, "asfgsddsa", "fgjdfhjg", "utyurtevc");
+
+    message::alert_payload instance;
+    BOOST_REQUIRE_EQUAL(false, instance == expected);
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__operator_boolean_not_equals__duplicates__returns_false)
+{
+    const message::alert_payload expected(3452u, 64556u, 78545u, 43547u,
+        546562345u, { 2345u, 346754u, 234u, 4356u }, 4644u, 89876u,
+        { "foo", "bar", "baz" }, 34323u, "asfgsddsa", "fgjdfhjg", "utyurtevc");
+
+    message::alert_payload instance(expected);
+    BOOST_REQUIRE_EQUAL(false, instance != expected);
+}
+
+BOOST_AUTO_TEST_CASE(alert_payload__operator_boolean_not_equals__differs__returns_true)
+{
+    const message::alert_payload expected(3452u, 64556u, 78545u, 43547u,
+        546562345u, { 2345u, 346754u, 234u, 4356u }, 4644u, 89876u,
+        { "foo", "bar", "baz" }, 34323u, "asfgsddsa", "fgjdfhjg", "utyurtevc");
+
+    message::alert_payload instance;
+    BOOST_REQUIRE(instance != expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/message/heading.cpp
+++ b/test/message/heading.cpp
@@ -288,6 +288,8 @@ BOOST_AUTO_TEST_CASE(heading__type__all_cases__match_expected)
     BOOST_REQUIRE(message::message_type::unknown == instance.type());
     instance.set_command(message::address::command);
     BOOST_REQUIRE(message::message_type::address == instance.type());
+    instance.set_command(message::alert::command);
+    BOOST_REQUIRE(message::message_type::alert == instance.type());
     instance.set_command(message::block::command);
     BOOST_REQUIRE(message::message_type::block == instance.type());
     instance.set_command(message::block_transactions::command);


### PR DESCRIPTION
There are way too many old peers forwarding alerts now that Core has published the private key.