### PR TITLE
Tweaks to README organization & OS X rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,16 @@ Next download the [install script](https://github.com/libbitcoin/libbitcoin/blob
 $ wget https://raw.githubusercontent.com/libbitcoin/libbitcoin/version3/install.sh
 $ chmod +x install.sh
 ```
-Finally, install libbitcoin with default build options:
+Finally install libbitcoin with default [build options](#build-notes-for-linux--macos):
 ```sh
 $ sudo ./install.sh
 ```
-(See [Build Notes for Linux / macOS](#build-notes-for-linux--macos) for details on available build options.)
 
 Libbitcoin is now installed in `/usr/local/`.
 
 ### Macintosh
 
-The macOS (OS X) installation differs from Linux in the installation of the compiler and packaged dependencies. Libbitcoin supports both [Homebrew](http://brew.sh) and [MacPorts](https://www.macports.org) package managers. Both require Apple's [Xcode](https://developer.apple.com/xcode) command line tools. Neither requires Xcode as the tools may be installed independently.
+The macOS installation differs from Linux in the installation of the compiler and packaged dependencies. Libbitcoin supports both [Homebrew](http://brew.sh) and [MacPorts](https://www.macports.org) package managers. Both require Apple's [Xcode](https://developer.apple.com/xcode) command line tools. Neither requires Xcode as the tools may be installed independently.
 
 Libbitcoin compiles with Clang on macOS and requires C++11 support. Installation has been verified using Clang based on [LLVM 3.5](http://llvm.org/releases/3.5.0/docs/ReleaseNotes.html). This version or newer should be installed as part of the Xcode command line tools.
 
@@ -114,11 +113,10 @@ Next download the [install script](https://github.com/libbitcoin/libbitcoin/blob
 $ wget https://raw.githubusercontent.com/libbitcoin/libbitcoin/version3/install.sh
 $ chmod +x install.sh
 ```
-Finally install libbitcoin with default build options:
+Finally install libbitcoin with default [build options](#build-notes-for-linux--macos):
 ```sh
 $ ./install.sh
 ```
-(See [Build Notes for Linux / macOS](#build-notes-for-linux--macos) for details on available build options.)
 
 Libbitcoin is now installed in `/usr/local/`.
 
@@ -139,11 +137,10 @@ Next download the [install script](https://github.com/libbitcoin/libbitcoin/blob
 $ wget https://raw.githubusercontent.com/libbitcoin/libbitcoin/version3/install.sh
 $ chmod +x install.sh
 ```
-Finally install libbitcoin with default build options:
+Finally install libbitcoin with default [build options](#build-notes-for-linux--macos):
 ```sh
 $ ./install.sh
 ```
-(See [Build Notes for Linux / macOS](#build-notes-for-linux--macos) for details on available build options.)
 
 Libbitcoin is now installed in `/usr/local/`.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The libbitcoin toolkit is a set of cross platform C++ libraries for building bit
 
 ## Installation
 
-On Linux and Macintosh libbitcoin is built using Autotools as follows.
+On Linux and macOS libbitcoin is built using Autotools as follows.
 ```sh
 $ ./autogen.sh
 $ ./configure
@@ -72,15 +72,15 @@ Finally, install libbitcoin with default build options:
 ```sh
 $ sudo ./install.sh
 ```
-(See [Build Notes for Linux / OS X](#build-notes-for-linux--os-x) for details on available build options.)
+(See [Build Notes for Linux / macOS](#build-notes-for-linux--macos) for details on available build options.)
 
 Libbitcoin is now installed in `/usr/local/`.
 
 ### Macintosh
 
-The OSX installation differs from Linux in the installation of the compiler and packaged dependencies. Libbitcoin supports both [Homebrew](http://brew.sh) and [MacPorts](https://www.macports.org) package managers. Both require Apple's [Xcode](https://developer.apple.com/xcode) command line tools. Neither requires Xcode as the tools may be installed independently.
+The macOS (OS X) installation differs from Linux in the installation of the compiler and packaged dependencies. Libbitcoin supports both [Homebrew](http://brew.sh) and [MacPorts](https://www.macports.org) package managers. Both require Apple's [Xcode](https://developer.apple.com/xcode) command line tools. Neither requires Xcode as the tools may be installed independently.
 
-Libbitcoin compiles with Clang on OSX and requires C++11 support. Installation has been verified using Clang based on [LLVM 3.5](http://llvm.org/releases/3.5.0/docs/ReleaseNotes.html). This version or newer should be installed as part of the Xcode command line tools.
+Libbitcoin compiles with Clang on macOS and requires C++11 support. Installation has been verified using Clang based on [LLVM 3.5](http://llvm.org/releases/3.5.0/docs/ReleaseNotes.html). This version or newer should be installed as part of the Xcode command line tools.
 
 To see your Clang/LLVM  version:
 ```sh
@@ -118,7 +118,7 @@ Finally install libbitcoin with default build options:
 ```sh
 $ ./install.sh
 ```
-(See [Build Notes for Linux / OS X](#build-notes-for-linux--os-x) for details on available build options.)
+(See [Build Notes for Linux / macOS](#build-notes-for-linux--macos) for details on available build options.)
 
 Libbitcoin is now installed in `/usr/local/`.
 
@@ -143,11 +143,11 @@ Finally install libbitcoin with default build options:
 ```sh
 $ ./install.sh
 ```
-(See [Build Notes for Linux / OS X](#build-notes-for-linux--os-x) for details on available build options.)
+(See [Build Notes for Linux / macOS](#build-notes-for-linux--macos) for details on available build options.)
 
 Libbitcoin is now installed in `/usr/local/`.
 
-### Build Notes for Linux / OS X
+### Build Notes for Linux / macOS
 The [install script](https://github.com/libbitcoin/libbitcoin/blob/version3/install.sh) itself is commented so that the manual build steps for each dependency can be inferred by a developer.
 
 You can run the install script from any directory on your system. By default this will build libbitcoin in a subdirectory named `build-libbitcoin` and install it to `/usr/local/`. The install script requires `sudo` only if you do not have access to the installation location, which you can change using the `--prefix` option on the installer command line.

--- a/README.md
+++ b/README.md
@@ -99,10 +99,8 @@ $ xcode-select --install
 
 #### Using Homebrew
 
-First install Homebrew. Installation requires [Ruby](https://www.ruby-lang.org/en) and [cURL](http://curl.haxx.se), which are pre-installed on OSX.
-```sh
-$ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-```
+First install [Homebrew](https://brew.sh). 
+
 Next install the [build system](http://wikipedia.org/wiki/GNU_build_system) (Automake minimum 1.14) and [wget](http://www.gnu.org/software/wget):
 ```sh
 $ brew install autoconf automake libtool pkgconfig wget

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 *The Bitcoin Development Library*
 
+[Documentation](https://github.com/libbitcoin/libbitcoin/wiki) is available on the wiki.
+
 **License Overview**
 
 All files in this repository fall under the license specified in [COPYING](COPYING). The project is licensed as [AGPL with a lesser clause](https://wiki.unsystem.net/en/index.php/Libbitcoin/License). It may be used within a proprietary project, but the core library and any changes to it must be published online. Source code for this library must always remain free for everybody to access.

--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ Next download the [install script](https://github.com/libbitcoin/libbitcoin/blob
 $ wget https://raw.githubusercontent.com/libbitcoin/libbitcoin/version3/install.sh
 $ chmod +x install.sh
 ```
-Finally, install libbitcoin:
+Finally, install libbitcoin with default build options:
 ```sh
 $ sudo ./install.sh
 ```
+(See [Build Notes for Linux / OS X](#build-notes-for-linux--os-x) for details on available build options.)
+
 Libbitcoin is now installed in `/usr/local/`.
 
 ### Macintosh
@@ -112,10 +114,12 @@ Next download the [install script](https://github.com/libbitcoin/libbitcoin/blob
 $ wget https://raw.githubusercontent.com/libbitcoin/libbitcoin/version3/install.sh
 $ chmod +x install.sh
 ```
-Finally install libbitcoin:
+Finally install libbitcoin with default build options:
 ```sh
 $ ./install.sh
 ```
+(See [Build Notes for Linux / OS X](#build-notes-for-linux--os-x) for details on available build options.)
+
 Libbitcoin is now installed in `/usr/local/`.
 
 #### Using MacPorts
@@ -135,15 +139,16 @@ Next download the [install script](https://github.com/libbitcoin/libbitcoin/blob
 $ wget https://raw.githubusercontent.com/libbitcoin/libbitcoin/version3/install.sh
 $ chmod +x install.sh
 ```
-Finally install libbitcoin:
+Finally install libbitcoin with default build options:
 ```sh
 $ ./install.sh
 ```
+(See [Build Notes for Linux / OS X](#build-notes-for-linux--os-x) for details on available build options.)
+
 Libbitcoin is now installed in `/usr/local/`.
 
-#### Notes
-
-The install script itself is commented so that the manual build steps for each dependency can be inferred by a developer.
+### Build Notes for Linux / OS X
+The [install script](https://github.com/libbitcoin/libbitcoin/blob/version3/install.sh) itself is commented so that the manual build steps for each dependency can be inferred by a developer.
 
 You can run the install script from any directory on your system. By default this will build libbitcoin in a subdirectory named `build-libbitcoin` and install it to `/usr/local/`. The install script requires `sudo` only if you do not have access to the installation location, which you can change using the `--prefix` option on the installer command line.
 


### PR DESCRIPTION
While trying to install libbitcoin on Macintosh and Ubuntu for experimenting, I overlooked the important build notes that were effectively buried after the MacPorts install procedure.

This PR mainly changes the Notes heading to 'Build Notes for Linux / macOS' and raises it to H3 level, same as the main platform headings. It then adds reference links to the build notes next to the install statements for Linux, Homebrew, and MacPorts, so the user is aware of the detailed build notes and can go there easily. It also adds a direct link to the `install.sh` script at the top of the notes, before the discussion of specific options.

It adds a link to the wiki documentation parallel to the links already in the libbitcoin-explorer and libbitcoin-server READMEs.

It replaces the detailed install instructions for Homebrew with a link to the Homebrew website, to keep it simple. (The MacPorts procedure already used this arrangement.)

And as a bonus, I'm suggesting to replace OS X with the new name 'macOS'. One instance of the old 'OS X' name is included for search engines.

If these changes are accepted, I'll apply them as needed to the libbitcoin-explorer and libbitcoin-server READMEs for consistency.

I think these tweaks will help the user find the already well-documented build options more easily, and where they need them.