### PR TITLE
Move internal double-spend check from blockchain:: to chain::

### DIFF
--- a/include/bitcoin/bitcoin/chain/block.hpp
+++ b/include/bitcoin/bitcoin/chain/block.hpp
@@ -178,6 +178,7 @@ public:
 
 protected:
     void reset();
+    size_t non_coinbase_input_count() const;
 
 private:
     chain::header header_;

--- a/include/bitcoin/bitcoin/chain/output_point.hpp
+++ b/include/bitcoin/bitcoin/chain/output_point.hpp
@@ -99,9 +99,8 @@ public:
     // Validation.
     //-----------------------------------------------------------------------------
 
-    /// False if previous output is not cached.
-    /// True if the previous output is mature enough to spend from target.
-    bool is_mature(size_t target_height) const;
+    /// True if cached previous output is mature enough to spend from target.
+    bool is_mature(size_t height) const;
 
     // THIS IS FOR LIBRARY USE ONLY, DO NOT CREATE A DEPENDENCY ON IT.
     mutable validation_type validation;

--- a/include/bitcoin/bitcoin/chain/point.hpp
+++ b/include/bitcoin/bitcoin/chain/point.hpp
@@ -62,6 +62,7 @@ public:
     point& operator=(point&& other);
     point& operator=(const point& other);
 
+    bool operator<(const point& other) const;
     bool operator==(const point& other) const;
     bool operator!=(const point& other) const;
 

--- a/include/bitcoin/bitcoin/chain/transaction.hpp
+++ b/include/bitcoin/bitcoin/chain/transaction.hpp
@@ -129,7 +129,7 @@ public:
     // Deprecated (unsafe).
     ins& inputs();
 
-    const input::list& inputs() const;
+    const ins& inputs() const;
     void set_inputs(const ins& value);
     void set_inputs(ins&& value);
 
@@ -147,7 +147,8 @@ public:
     //-----------------------------------------------------------------------------
 
     uint64_t fees() const;
-    output_point::list missing_previous_outputs() const;
+    point::list previous_outputs() const;
+    point::list missing_previous_outputs() const;
     hash_list missing_previous_transactions() const;
     uint64_t total_input_value() const;
     uint64_t total_output_value() const;
@@ -157,8 +158,9 @@ public:
     bool is_coinbase() const;
     bool is_null_non_coinbase() const;
     bool is_oversized_coinbase() const;
-    bool is_immature(size_t target_height) const;
+    bool is_mature(size_t height) const;
     bool is_overspent() const;
+    bool is_internal_double_spend() const;
     bool is_double_spend(bool include_unconfirmed) const;
     bool is_missing_previous_outputs() const;
     bool is_final(size_t block_height, uint32_t block_time) const;

--- a/include/bitcoin/bitcoin/error.hpp
+++ b/include/bitcoin/bitcoin/error.hpp
@@ -100,7 +100,7 @@ enum error_code_t
     first_not_coinbase = 28,
     extra_coinbases = 29,
     internal_duplicate = 49,
-    internal_double_spend = 15,
+    block_internal_double_spend = 15,
     merkle_mismatch = 31,
     block_legacy_sigop_limit = 30,
 
@@ -116,6 +116,7 @@ enum error_code_t
     spend_overflow = 21,
     invalid_coinbase_script_size = 22,
     coinbase_transaction = 16,
+    transaction_internal_double_spend = 72,
     transaction_size_limit = 53,
     transaction_legacy_sigop_limit = 54,
 

--- a/src/chain/block.cpp
+++ b/src/chain/block.cpp
@@ -23,12 +23,14 @@
 #include <limits>
 #include <cfenv>
 #include <cmath>
+#include <iterator>
 #include <memory>
 #include <numeric>
 #include <type_traits>
 #include <utility>
 #include <bitcoin/bitcoin/chain/chain_state.hpp>
 #include <bitcoin/bitcoin/chain/compact.hpp>
+#include <bitcoin/bitcoin/chain/input_point.hpp>
 #include <bitcoin/bitcoin/chain/script.hpp>
 #include <bitcoin/bitcoin/config/checkpoint.hpp>
 #include <bitcoin/bitcoin/constants.hpp>
@@ -506,7 +508,7 @@ size_t block::total_inputs(bool with_coinbase) const
 }
 
 // True if there is another coinbase other than the first tx.
-// No txs or coinbases also returns true.
+// No txs or coinbases returns false.
 bool block::is_extra_coinbases() const
 {
     if (transactions_.empty())
@@ -580,17 +582,46 @@ hash_digest block::generate_merkle_root() const
     return merkle.front();
 }
 
+size_t block::non_coinbase_input_count() const
+{
+    if (transactions_.empty())
+        return 0;
+
+    const auto counter = [](size_t sum, const transaction& tx)
+    {
+        return sum + tx.inputs().size();
+    };
+
+    const auto& txs = transactions_;
+    return std::accumulate(txs.begin() + 1, txs.end(), size_t(0), counter);
+}
+
+// This is an early check that is redundant with block pool accept checks.
 bool block::is_internal_double_spend() const
 {
-    // TODO: check all inputs for duplicate reference to an output.
-    // It is not necessary to confirm the output is within the block.
-    // This is an early check that is redundant with orphan pool accept checks.
-    return false;
+    if (transactions_.empty())
+        return false;
+
+    point::list outs;
+    outs.reserve(non_coinbase_input_count());
+    const auto& txs = transactions_;
+
+    // Merge the prevouts of all non-coinbase transactions into one set.
+    for (auto tx = txs.begin() + 1; tx != txs.end(); ++tx)
+    {
+        auto out = tx->previous_outputs();
+        std::move(out.begin(), out.end(), std::inserter(outs, outs.end()));
+    }
+
+    std::sort(outs.begin(), outs.end());
+    const auto distinct_end = std::unique(outs.begin(), outs.end());
+    const auto distinct = (distinct_end == outs.end());
+    return !distinct;
 }
 
 bool block::is_valid_merkle_root() const
 {
-    return (generate_merkle_root() == header_.merkle());
+    return generate_merkle_root() == header_.merkle();
 }
 
 // Overflow returns max_uint64.
@@ -695,7 +726,7 @@ code block::check() const
         return error::internal_duplicate;
 
     else if (is_internal_double_spend())
-        return error::internal_double_spend;
+        return error::block_internal_double_spend;
 
     else if (!is_valid_merkle_root())
         return error::merkle_mismatch;

--- a/src/chain/output_point.cpp
+++ b/src/chain/output_point.cpp
@@ -145,14 +145,15 @@ output_point output_point::factory_from_data(reader& source)
 // Validation.
 //-----------------------------------------------------------------------------
 
-// For tx pool validation target_height is that of any candidate block.
-bool output_point::is_mature(size_t target_height) const
+// For tx pool validation height is that of the candidate block.
+bool output_point::is_mature(size_t height) const
 {
+    // validation.height is specified only for coinbase inputs.
     if (validation.height == validation_type::not_specified)
         return true;
 
     // The (non-coinbase) outpoint refers to a coinbase output, measure depth.
-    return (target_height - validation.height) >= coinbase_maturity;
+    return floor_subtract(height, validation.height) >= coinbase_maturity;
 }
 
 } // namespace chain

--- a/src/chain/point.cpp
+++ b/src/chain/point.cpp
@@ -236,6 +236,14 @@ void point::set_index(uint32_t value)
     index_ = value;
 }
 
+// This arbitrary order is produced to support set uniqueness determinations.
+bool point::operator<(const point& other) const
+{
+    // The index is primary only because its comparisons are simpler.
+    return index_ == other.index_ ? hash_ < other.hash_ :
+        index_ < other.index_;
+}
+
 point& point::operator=(point&& other)
 {
     hash_ = std::move(other.hash_);

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -103,7 +103,7 @@ std::string error_category_impl::message(int ev) const BC_NOEXCEPT
         { error::first_not_coinbase, "first transaction not a coinbase" },
         { error::extra_coinbases, "more than one coinbase" },
         { error::internal_duplicate, "matching transaction hashes in block" },
-        { error::internal_double_spend, "double spend internal to block" },
+        { error::block_internal_double_spend, "double spend internal to block" },
         { error::merkle_mismatch, "merkle root mismatch" },
         { error::block_legacy_sigop_limit, "too many block legacy signature operations" },
 
@@ -119,6 +119,7 @@ std::string error_category_impl::message(int ev) const BC_NOEXCEPT
         { error::spend_overflow, "spend outside valid range" },
         { error::invalid_coinbase_script_size, "coinbase script too small or large" },
         { error::coinbase_transaction, "coinbase transaction disallowed in memory pool" },
+        { error::transaction_internal_double_spend, "double spend internal to transaction" },
         { error::transaction_legacy_sigop_limit, "too many transaction legacy signature operations" },
 
         // accept transaction

--- a/test/chain/transaction.cpp
+++ b/test/chain/transaction.cpp
@@ -807,95 +807,27 @@ BOOST_AUTO_TEST_CASE(transaction__is_double_spend__include_unconfirmed_true_with
     BOOST_REQUIRE(instance.is_double_spend(true));
 }
 
-////BOOST_AUTO_TEST_CASE(transaction__double_spends__empty_inputs__returns_empty)
-////{
-////    chain::transaction instance;
-////    BOOST_REQUIRE(instance.double_spends(false).empty());
-////    BOOST_REQUIRE(instance.double_spends(true).empty());
-////}
-////
-////BOOST_AUTO_TEST_CASE(transaction__double_spends__unspent_inputs__returns_empty)
-////{
-////    chain::transaction instance;
-////    instance.inputs().emplace_back();
-////    BOOST_REQUIRE(instance.double_spends(false).empty());
-////    BOOST_REQUIRE(instance.double_spends(true).empty());
-////}
-////
-////BOOST_AUTO_TEST_CASE(transaction__double_spends__include_unconfirmed_false_with_unconfirmed__returns_empty)
-////{
-////    chain::transaction instance;
-////    instance.inputs().emplace_back();
-////    instance.inputs().back().previous_output().validation.spent = true;
-////    BOOST_REQUIRE(!instance.is_double_spend(false));
-////}
-////
-////BOOST_AUTO_TEST_CASE(transaction__double_spends__include_unconfirmed_false_with_confirmed__returns_expected)
-////{
-////    chain::transaction instance;
-////    instance.inputs().emplace_back();
-////    instance.inputs().back().previous_output().validation.spent = true;
-////    instance.inputs().back().previous_output().validation.confirmed = true;
-////    auto result = instance.double_spends(false);
-////    BOOST_REQUIRE_EQUAL(1u, result.size());
-////    BOOST_REQUIRE_EQUAL(0u, result.back());
-////}
-////
-////BOOST_AUTO_TEST_CASE(transaction__double_spends__include_unconfirmed_true_with_unconfirmed__returns_expected)
-////{
-////    chain::transaction instance;
-////    instance.inputs().emplace_back();
-////    instance.inputs().back().previous_output().validation.spent = true;
-////    auto result = instance.double_spends(true);
-////    BOOST_REQUIRE_EQUAL(1u, result.size());
-////    BOOST_REQUIRE_EQUAL(0u, result.back());
-////}
-
-BOOST_AUTO_TEST_CASE(transaction__is_immature__empty_inputs__returns_false)
+BOOST_AUTO_TEST_CASE(transaction__is_mature__empty_inputs__returns_true)
 {
     chain::transaction instance;
-    BOOST_REQUIRE(!instance.is_immature(453u));
+    BOOST_REQUIRE(instance.is_mature(453u));
 }
 
-BOOST_AUTO_TEST_CASE(transaction__is_immature__mature_inputs__returns_false)
+BOOST_AUTO_TEST_CASE(transaction__is_mature__mature_inputs__returns_true)
 {
     chain::transaction instance;
     instance.inputs().emplace_back();
     instance.inputs().back().previous_output().set_index(123u);
-    BOOST_REQUIRE(!instance.is_immature(453u));
+    BOOST_REQUIRE(instance.is_mature(453u));
 }
 
-BOOST_AUTO_TEST_CASE(transaction__is_immature__immature_inputs__returns_true)
+BOOST_AUTO_TEST_CASE(transaction__is_mature__premature_inputs__returns_false)
 {
     chain::transaction instance;
     instance.inputs().emplace_back();
     instance.inputs().back().previous_output().validation.height = 20u;
-    BOOST_REQUIRE(instance.is_immature(50u));
+    BOOST_REQUIRE(!instance.is_mature(50u));
 }
-
-////BOOST_AUTO_TEST_CASE(transaction__immature_inputs__empty_inputs__returns_empty)
-////{
-////    chain::transaction instance;
-////    BOOST_REQUIRE(instance.immature_inputs(453u).empty());
-////}
-////
-////BOOST_AUTO_TEST_CASE(transaction__immature_inputs__mature_inputs__returns_empty)
-////{
-////    chain::transaction instance;
-////    instance.inputs().emplace_back();
-////    instance.inputs().back().previous_output().set_index(123u);
-////    BOOST_REQUIRE(instance.immature_inputs(453u).empty());
-////}
-////
-////BOOST_AUTO_TEST_CASE(transaction__immature_inputs__immature_inputs__returns_input_indexes)
-////{
-////    chain::transaction instance;
-////    instance.inputs().emplace_back();
-////    instance.inputs().back().previous_output().validation.height = 20u;
-////    auto result = instance.immature_inputs(50u);
-////    BOOST_REQUIRE_EQUAL(1u, result.size());
-////    BOOST_REQUIRE_EQUAL(0u, result.back());
-////}
 
 BOOST_AUTO_TEST_CASE(transaction__operator_assign_equals_1__always__matches_equivalent)
 {


### PR DESCRIPTION
This is a performance optimization for blockchain and also implements a stubbed-in utility method. This also moves this part of validation into the context-free block.check, allowing for earlier rejection of invalid blocks and fixes incorrect return in the API (i.e. standalone) use of block.check.

It also provides a tx pool guard against accepting internally-double-spending txs. This was previously guarded only by block validation (which included pre-validated txs). The benefit is in preventing storage and relay of provably invalid (though unconfirmed) txs.