### PR TITLE
Fix/remove chain_state checkpoint use, allow promotion in all cases.

### DIFF
--- a/include/bitcoin/bitcoin/chain/chain_state.hpp
+++ b/include/bitcoin/bitcoin/chain/chain_state.hpp
@@ -75,7 +75,7 @@ public:
         /// (block - 0)
         size_t timestamp_self;
 
-        /// (block - 2016) | map::unrequested
+        /// (block - (block % 2016 == 0 ? 2016 : block % 2016))
         size_t timestamp_retarget;
 
         /// mainnet: 227931, testnet: 21111 (or map::unrequested)
@@ -171,13 +171,10 @@ protected:
 
 private:
     static size_t bits_count(size_t height, uint32_t forks);
-    static size_t version_count(size_t height, uint32_t forks,
-        const checkpoints& checkpoints);
-    static size_t timestamp_count(size_t height,
-        const checkpoints& checkpoints);
-    static size_t retarget_height(size_t height);
-    static size_t collision_height(size_t height, uint32_t forks,
-        const checkpoints& checkpoints);
+    static size_t version_count(size_t height, uint32_t forks);
+    static size_t timestamp_count(size_t height, uint32_t forks);
+    static size_t retarget_height(size_t height, uint32_t forks);
+    static size_t collision_height(size_t height, uint32_t forks);
 
     static data to_pool(const chain_state& top);
     static data to_block(const chain_state& pool, const block& block);
@@ -191,15 +188,16 @@ private:
     static uint32_t easy_time_limit(const chain_state::data& values);
     static bool is_retarget_or_non_limit(size_t height, uint32_t bits);
     static bool is_retarget_height(size_t height);
+    static size_t retarget_distance(size_t height);
 
     // This is retained as an optimization for other constructions.
     // A similar height clone can be partially computed, reducing query cost.
     const data data_;
 
-    // Forks are saved for state transitions.
+    // Configured forks are saved for state transitions.
     const uint32_t forks_;
 
-    // Configured checkpoints are used to answer is_checkpoint_failure.
+    // Checkpoints do not affect the data that is collected or promoted.
     const config::checkpoint::list& checkpoints_;
 
     // These are computed on construct from sample and checkpoints.

--- a/include/bitcoin/bitcoin/chain/chain_state.hpp
+++ b/include/bitcoin/bitcoin/chain/chain_state.hpp
@@ -34,6 +34,7 @@ namespace libbitcoin {
 namespace chain {
 
 class block;
+class header;
 
 class BC_API chain_state
 {
@@ -122,11 +123,14 @@ public:
 
     static uint32_t signal_version(uint32_t forks);
 
-    /// Create pool state from top block chain state.
+    /// Create pool state from top chain top block state.
     chain_state(const chain_state& top);
 
-    /// Create block state from pool chain state of same height.
+    /// Create block state from tx pool chain state of same height.
     chain_state(const chain_state& pool, const chain::block& block);
+
+    /// Create header state from header pool chain state of previous height.
+    chain_state(const chain_state& parent, const chain::header& header);
 
     /// Checkpoints must be ordered by height with greatest at back.
     /// Forks and checkpoints must match those provided for map creation.
@@ -176,7 +180,8 @@ private:
         const checkpoints& checkpoints);
 
     static data to_pool(const chain_state& top);
-    static data to_block(const chain_state& pool_state, const block& block);
+    static data to_block(const chain_state& pool, const block& block);
+    static data to_header(const chain_state& parent, const header& header);
 
     static uint32_t work_required_retarget(const data& values);
     static uint32_t retarget_timespan(const chain_state::data& values);

--- a/include/bitcoin/bitcoin/constants.hpp
+++ b/include/bitcoin/bitcoin/constants.hpp
@@ -156,12 +156,12 @@ static const config::checkpoint mainnet_bip30_exception_checkpoint2
     "00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721", 91880
 };
 
-// Hard fork to stop checking unspent duplicates above fixed bip34 activation.
-static const config::checkpoint mainnet_allow_collisions_checkpoint
+// Because bip90 stops checking unspent duplicates above this bip34 activation.
+static const config::checkpoint mainnet_bip34_activation_checkpoint
 {
     "000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8", 227931
 };
-static const config::checkpoint testnet_allow_collisions_checkpoint
+static const config::checkpoint testnet_bip34_activation_checkpoint
 {
     "0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8", 21111
 };


### PR DESCRIPTION
This is a consensus bug in the case where a final checkpoint precedes a soft fork activation height by less than potentially 2016 blocks (testnet) or 1000 blocks (mainnet).