### PR TITLE
Update homebrew section to use libbitcoin formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ $ ./install.sh
 
 Libbitcoin is now installed in `/usr/local/`.
 
+##### Installing from Formula
+
+Instead of building, libbitcoin can be installed from a formula:
+```sh
+$ brew install libbitcoin
+```
+
 #### Using MacPorts
 
 First install [MacPorts](https://www.macports.org/install.php).


### PR DESCRIPTION
Homebrew now has a libbitcoin formula. libbitcoin can be installed simply by calling `brew install libbitcoin`. By default, Homebrew installs libbitcoin from a "bottle" without building. It can also be built from source if desired.

The forumla installs boost as a dependency. The formula also builds libbitcoin/secp256k1 as a "resource." Because this repo is a fork, homebrew will not allow it to be added as a formula. This installs secp256k1 in libbitcoin's "cellar" at `/usr/local/Cellar/libbitcoin/3.3.0/libexec`, but not in the system at `/usr/local/lib`. Until the upstream repo adds a tagged release, we have to use this workaround.

Feel free to review the [formula pull request](https://github.com/Homebrew/homebrew-core/pull/16771) and provide feedback.

```
==> Installing dependencies for libbitcoin: boost
==> Installing libbitcoin dependency: boost
==> Downloading https://homebrew.bintray.com/bottles/boost-1.64.0_1.sierra.bottle.tar.gz
==> Pouring boost-1.64.0_1.sierra.bottle.tar.gz
🍺  /usr/local/Cellar/boost/1.64.0_1: 12,628 files, 395.7MB
==> Installing libbitcoin
==> Downloading https://homebrew.bintray.com/bottles/libbitcoin-3.3.0.sierra.bottle.tar.gz
==> Pouring libbitcoin-3.3.0.sierra.bottle.tar.gz
🍺  /usr/local/Cellar/libbitcoin/3.3.0: 234 files, 15.2MB
```
```
$ brew test --verbose libbitcoin
Testing libbitcoin
/usr/bin/sandbox-exec -f /tmp/homebrew20170820-47225-wi5qun.sb /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby -W0 -I /usr/local/Homebrew/Library/Homebrew -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/libbitcoin.rb --verbose
==> /usr/bin/clang++ -std=c++11 test.cpp -L/usr/local/Cellar/libbitcoin/3.3.0/lib -lbitcoin -lboost_system -o test
==> ./test
The Times 03/Jan/2009 Chancellor on brink of second bailout for banks
```