### PR TITLE
Fix bug in Script::is_pay_multisig_pattern that prevents causes the f…

### DIFF
--- a/src/chain/script.cpp
+++ b/src/chain/script.cpp
@@ -762,7 +762,7 @@ bool script::is_pay_multisig_pattern(const operation::list& ops)
     if (op_m < op_1 || op_m > op_n || op_n < op_1 || op_n > op_16)
         return false;
 
-    const auto number = op_n - op_1;
+    const auto number = op_n - op_1 + 1;
     const auto points = op_count - 3u;
 
     if (number != points)


### PR DESCRIPTION
…unction to match only incorrect multisig patterns in which n is too big by 1.

A pay to multisig pattern is supposed to look like 

m (sequence of n pubkeys...) n op_checkmultisig

And that means "at least m signatures of these n pubkeys is required to redeem this output". 

The point of line 768 is to check that the same number of pubkeys are given as the value of n. 'number' is supposed to be the value of n (as opposed to its value as an opcode) and 'points' is the number of pubkeys given. 'points' is defined as op_count - 3, which means that it is equal to the number of pubkeys in the list because the script consists of 3 more ops than the number of pubkeys. However, 'number' is defined as op_n - op_1, which actually makes its value equal to n - 1 rather than n. So the function actually matches patterns like this 

m (sequence of n + 1 pubkeys) n op_checkmultisig

I fixed it by adding 1 to 'number'. 