### PR TITLE
Revise script address extraction.

### DIFF
--- a/include/bitcoin/bitcoin/chain/script.hpp
+++ b/include/bitcoin/bitcoin/chain/script.hpp
@@ -150,7 +150,7 @@ public:
     static bool is_coinbase_pattern(const operation::list& ops, size_t height);
 
     /// Common output patterns (psh is also consensus).
-    static bool is_null_data_pattern(const operation::list& ops);
+    static bool is_pay_null_data_pattern(const operation::list& ops);
     static bool is_pay_multisig_pattern(const operation::list& ops);
     static bool is_pay_public_key_pattern(const operation::list& ops);
     static bool is_pay_key_hash_pattern(const operation::list& ops);
@@ -163,7 +163,7 @@ public:
     static bool is_sign_script_hash_pattern(const operation::list& ops);
 
     /// Stack factories.
-    static operation::list to_null_data_pattern(data_slice data);
+    static operation::list to_pay_null_data_pattern(data_slice data);
     static operation::list to_pay_public_key_pattern(data_slice point);
     static operation::list to_pay_key_hash_pattern(const short_hash& hash);
     static operation::list to_pay_script_hash_pattern(const short_hash& hash);

--- a/include/bitcoin/bitcoin/impl/machine/interpreter.ipp
+++ b/include/bitcoin/bitcoin/impl/machine/interpreter.ipp
@@ -723,7 +723,7 @@ inline interpreter::result interpreter::op_check_multisig_verify(
         return error::op_check_multisig_verify7;
 
     //*************************************************************************
-    // CONSENSUS: Satoshi bug, discard an extra op/byte, malleability source.
+    // CONSENSUS: Satoshi bug, discard a stack element, malleability source.
     //*************************************************************************
     program.pop();
 

--- a/include/bitcoin/bitcoin/impl/machine/operation.ipp
+++ b/include/bitcoin/bitcoin/impl/machine/operation.ipp
@@ -217,7 +217,7 @@ inline opcode operation::minimal_opcode_from_data(const data_chunk& data)
             return opcode::push_negative_1;
 
         if (value == number::positive_0)
-            return  opcode::push_size_0;
+            return opcode::push_size_0;
 
         if (value >= number::positive_1 && value <= number::positive_16)
             return opcode_from_positive(value);

--- a/include/bitcoin/bitcoin/machine/script_pattern.hpp
+++ b/include/bitcoin/bitcoin/machine/script_pattern.hpp
@@ -29,7 +29,7 @@ enum class script_pattern
     /// Null Data
     /// Pubkey Script: OP_RETURN <0 to 80 bytes of data> (formerly 40 bytes)
     /// Null data scripts cannot be spent, so there's no signature script.
-    null_data,
+    pay_null_data,
 
     /// Pay to Multisig [BIP11]
     /// Pubkey script: <m> <A pubkey>[B pubkey][C pubkey...] <n> OP_CHECKMULTISIG

--- a/include/bitcoin/bitcoin/math/elliptic_curve.hpp
+++ b/include/bitcoin/bitcoin/math/elliptic_curve.hpp
@@ -52,7 +52,8 @@ typedef byte_array<ec_signature_size> ec_signature;
 static BC_CONSTEXPR size_t max_der_signature_size = 72;
 typedef data_chunk der_signature;
 
-/// DER encoded signature with sighash byte for input endorsement:
+/// DER encoded signature with sighash byte for contract endorsement:
+static BC_CONSTEXPR size_t min_endorsement_size = 9;
 static BC_CONSTEXPR size_t max_endorsement_size = 73;
 typedef data_chunk endorsement;
 
@@ -145,6 +146,9 @@ bool is_uncompressed_key(data_slice point);
 
 /// Fast detection of compressed or uncompressed public key structure.
 bool is_public_key(data_slice point);
+
+/// Fast detection of endorsement structure (DER with signature hash type).
+bool is_endorsement(const endorsement& endorsement);
 
 // DER parse/encode
 // ----------------------------------------------------------------------------

--- a/src/chain/script.cpp
+++ b/src/chain/script.cpp
@@ -732,7 +732,7 @@ bool script::is_coinbase_pattern(const operation::list& ops, size_t height)
 
 // The satoshi client tests for 83 bytes total. This allows for the waste of
 // one byte to represent up to 75 bytes using the push_one_size opcode.
-////bool script::is_null_data_pattern(const operation::list& ops)
+////bool script::is_pay_null_data_pattern(const operation::list& ops)
 ////{
 ////    static constexpr auto op_76 = static_cast<uint8_t>(opcode::push_one_size);
 ////
@@ -743,7 +743,7 @@ bool script::is_coinbase_pattern(const operation::list& ops, size_t height)
 ////}
 
 // The satoshi client enables configurable data size for policy.
-bool script::is_null_data_pattern(const operation::list& ops)
+bool script::is_pay_null_data_pattern(const operation::list& ops)
 {
     return ops.size() == 2
         && ops[0].code() == opcode::return_
@@ -845,7 +845,7 @@ bool script::is_sign_script_hash_pattern(const operation::list& ops)
         && !ops.back().data().empty();
 }
 
-operation::list script::to_null_data_pattern(data_slice data)
+operation::list script::to_pay_null_data_pattern(data_slice data)
 {
     if (data.size() > max_null_data_size)
         return{};
@@ -963,8 +963,8 @@ script_pattern script::output_pattern() const
     if (is_pay_script_hash_pattern(operations_))
         return script_pattern::pay_script_hash;
 
-    if (is_null_data_pattern(operations_))
-        return script_pattern::null_data;
+    if (is_pay_null_data_pattern(operations_))
+        return script_pattern::pay_null_data;
 
     if (is_pay_public_key_pattern(operations_))
         return script_pattern::pay_public_key;

--- a/src/chain/script.cpp
+++ b/src/chain/script.cpp
@@ -690,6 +690,11 @@ bool script::create_endorsement(endorsement& out, const ec_secret& secret,
 // Utilities (static).
 //-----------------------------------------------------------------------------
 
+inline bool endorsed(const operation& op)
+{
+    return is_endorsement(op.data());
+};
+
 bool script::is_push_only(const operation::list& ops)
 {
     const auto push = [](const operation& op)
@@ -737,6 +742,7 @@ bool script::is_coinbase_pattern(const operation::list& ops, size_t height)
 ////        && ops[1].data().size() <= max_null_data_size;
 ////}
 
+// The satoshi client enables configurable data size for policy.
 bool script::is_null_data_pattern(const operation::list& ops)
 {
     return ops.size() == 2
@@ -745,7 +751,10 @@ bool script::is_null_data_pattern(const operation::list& ops)
         && ops[1].data().size() <= max_null_data_size;
 }
 
-// TODO: confirm that the type of data opcode is unrestricted for policy.
+// TODO: expand this to the 20 signature op_check_multisig limit.
+// The current 16 (or 20) limit does not affect server indexing because bare
+// multisig is not indexable and p2sh multisig is byte-limited to 15 sigs.
+// The satoshi client policy limit is 3 signatures for bare multisig.
 bool script::is_pay_multisig_pattern(const operation::list& ops)
 {
     static constexpr auto op_1 = static_cast<uint8_t>(opcode::push_positive_1);
@@ -775,7 +784,7 @@ bool script::is_pay_multisig_pattern(const operation::list& ops)
     return true;
 }
 
-// TODO: confirm that the type of data opcode is unrestricted for policy.
+// The satoshi client considers this non-standard for policy.
 bool script::is_pay_public_key_pattern(const operation::list& ops)
 {
     return ops.size() == 2
@@ -783,7 +792,6 @@ bool script::is_pay_public_key_pattern(const operation::list& ops)
         && ops[1].code() == opcode::checksig;
 }
 
-// TODO: confirm that the type of data opcode is unrestricted for policy.
 bool script::is_pay_key_hash_pattern(const operation::list& ops)
 {
     return ops.size() == 5
@@ -806,46 +814,35 @@ bool script::is_pay_script_hash_pattern(const operation::list& ops)
         && ops[2].code() == opcode::equal;
 }
 
-//*****************************************************************************
-// CONSENSUS: the push zero is wacky satoshi behavior we must perpetuate.
-//*****************************************************************************
+// The first push is based on wacky satoshi op_check_multisig behavior that
+// we must perpetuate, though it's appearance here is policy not consensus.
+// Limiting to push_size_0 eliminates pattern ambiguity with little downside.
 bool script::is_sign_multisig_pattern(const operation::list& ops)
 {
     return ops.size() >= 2
         && ops[0].code() == opcode::push_size_0
-        && is_push_only(ops);
+        && std::all_of(ops.begin() + 1, ops.end(), endorsed);
 }
 
 bool script::is_sign_public_key_pattern(const operation::list& ops)
 {
     return ops.size() == 1
-        && is_push_only(ops);
+        && is_endorsement(ops[0].data());
 }
 
 bool script::is_sign_key_hash_pattern(const operation::list& ops)
 {
     return ops.size() == 2
-        && is_push_only(ops)
-        && is_public_key(ops.back().data());
+        && is_endorsement(ops[0].data())
+        && is_public_key(ops[1].data());
 }
 
+// Ambiguous with is_sign_key_hash when second/last op is a valid public key.
 bool script::is_sign_script_hash_pattern(const operation::list& ops)
 {
-    if (ops.size() < 2 || !is_push_only(ops))
-        return false;
-
-    const auto& redeem_data = ops.back().data();
-
-    if (redeem_data.empty())
-        return false;
-
-    script redeem;
-
-    if (!redeem.from_data(redeem_data, false))
-        return false;
-
-    // Is the redeem script a common output script?
-    return redeem.output_pattern() != script_pattern::non_standard;
+    return ops.size() > 1
+        && std::all_of(ops.begin(), ops.end() - 1, endorsed)
+        && !ops.back().data().empty();
 }
 
 operation::list script::to_null_data_pattern(data_slice data)
@@ -907,6 +904,10 @@ operation::list script::to_pay_multisig_pattern(uint8_t signatures,
     return to_pay_multisig_pattern(signatures, chunks);
 }
 
+// TODO: expand this to a 20 signature limit.
+// This supports up to 16 signatures, however check_multisig is limited to 20.
+// The embedded script is limited to 520 bytes, an effective limit of 15 for
+// p2sh multisig, which can be as low as 7 when using all uncompressed keys.
 operation::list script::to_pay_multisig_pattern(uint8_t signatures,
     const data_stack& points)
 {
@@ -943,50 +944,54 @@ operation::list script::to_pay_multisig_pattern(uint8_t signatures,
 
 // Utilities (non-static).
 //-----------------------------------------------------------------------------
-// TODO: implement standardness tests in blockchain (not in system).
 
+// Caller should test for is_sign_script_hash_pattern when sign_key_hash result
+// as it is possible for an input script to match both patterns.
 script_pattern script::pattern() const
 {
-    const auto input = input_pattern();
-    return input == script_pattern::non_standard ? output_pattern() : input;
+    const auto input = output_pattern();
+    return input == script_pattern::non_standard ? input_pattern() : input;
 }
 
+// Output patterns are mutually and input unambiguous.
 script_pattern script::output_pattern() const
 {
     // The first operations access must be method-based to guarantee the cache.
-    if (is_null_data_pattern(operations()))
-        return script_pattern::null_data;
-
-    if (is_pay_key_hash_pattern(operations_))
+    if (is_pay_key_hash_pattern(operations()))
         return script_pattern::pay_key_hash;
 
     if (is_pay_script_hash_pattern(operations_))
         return script_pattern::pay_script_hash;
 
-    if (is_pay_multisig_pattern(operations_))
-        return script_pattern::pay_multisig;
+    if (is_null_data_pattern(operations_))
+        return script_pattern::null_data;
 
     if (is_pay_public_key_pattern(operations_))
         return script_pattern::pay_public_key;
 
+    if (is_pay_multisig_pattern(operations_))
+        return script_pattern::pay_multisig;
+
     return script_pattern::non_standard;
 }
 
-// This excludes the bip34 coinbase pattern, which can be tested independently.
+// A sign_key_hash result always implies sign_script_hash as well.
+// The bip34 coinbase pattern is not tested here, must test independently.
 script_pattern script::input_pattern() const
 {
     // The first operations access must be method-based to guarantee the cache.
     if (is_sign_key_hash_pattern(operations()))
         return script_pattern::sign_key_hash;
 
+    // This must follow is_sign_key_hash_pattern for ambiguity comment to hold.
     if (is_sign_script_hash_pattern(operations_))
         return script_pattern::sign_script_hash;
 
-    if (is_sign_multisig_pattern(operations_))
-        return script_pattern::sign_multisig;
-
     if (is_sign_public_key_pattern(operations_))
         return script_pattern::sign_public_key;
+
+    if (is_sign_multisig_pattern(operations_))
+        return script_pattern::sign_multisig;
 
     return script_pattern::non_standard;
 }

--- a/src/math/elliptic_curve.cpp
+++ b/src/math/elliptic_curve.cpp
@@ -245,6 +245,12 @@ bool is_even_key(const ec_compressed& point)
     return point.front() == ec_even_sign;
 }
 
+bool is_endorsement(const endorsement& endorsement)
+{
+    const auto size = endorsement.size();
+    return size >= min_endorsement_size && size <= max_endorsement_size;
+}
+
 // DER parse/encode
 // ----------------------------------------------------------------------------
 

--- a/src/math/stealth.cpp
+++ b/src/math/stealth.cpp
@@ -36,7 +36,7 @@ using namespace bc::machine;
 
 bool is_stealth_script(const script& script)
 {
-    if (!script::is_null_data_pattern(script.operations()))
+    if (!script::is_pay_null_data_pattern(script.operations()))
         return false;
 
     BITCOIN_ASSERT(script.size() == 2);
@@ -132,7 +132,7 @@ bool create_stealth_script(script& out_null_data, const ec_secret& secret,
         std::copy_n(fill.begin(), sizeof(nonce), data.end() - sizeof(nonce));
 
         // Create the stealth script with the current data.
-        out_null_data = script(script::to_null_data_pattern(data));
+        out_null_data = script(script::to_pay_null_data_pattern(data));
 
         // Test for match of filter to stealth script hash prefix.
         if (to_stealth_prefix(field, out_null_data) &&

--- a/src/wallet/payment_address.cpp
+++ b/src/wallet/payment_address.cpp
@@ -333,7 +333,7 @@ payment_address::list payment_address::extract_output(
 
         // Bare multisig and null data do not associate a payment address.
         case script_pattern::pay_multisig:
-        case script_pattern::null_data:
+        case script_pattern::pay_null_data:
         case script_pattern::non_standard:
         default:
         {

--- a/src/wallet/payment_address.cpp
+++ b/src/wallet/payment_address.cpp
@@ -244,7 +244,7 @@ std::ostream& operator<<(std::ostream& out, const payment_address& of)
 // Static functions.
 // ----------------------------------------------------------------------------
 
-// All returned addresses are valid.
+// Context free input extraction is provably ambiguous (see extract_input).
 payment_address::list payment_address::extract(const chain::script& script,
     uint8_t p2kh_version, uint8_t p2sh_version)
 {
@@ -253,41 +253,45 @@ payment_address::list payment_address::extract(const chain::script& script,
         input;
 }
 
-// All returned addresses are valid.
+// Context free input extraction is provably ambiguous. See inline comments.
 payment_address::list payment_address::extract_input(
     const chain::script& script, uint8_t p2kh_version, uint8_t p2sh_version)
 {
+    // A sign_key_hash result always implies sign_script_hash as well.
     const auto pattern = script.input_pattern();
 
     switch (pattern)
     {
-        case script_pattern::sign_multisig:
-        {
-            // There are no addresses in sign_multisig script, signatures only.
-            // Tracking can obtain addresses by correlating previous output.
-            return{};
-        }
-        case script_pattern::sign_public_key:
-        {
-            // There is no address in sign_public_key script, signature only.
-            // Tracking can obtain the address by correlating previous output.
-            return{};
-        }
+        // Given lack of context (prevout) sign_key_hash is always ambiguous
+        // with sign_script_hash, so return both potentially-correct addresses.
+        // A server can differentiate by extracting from the previous output.
         case script_pattern::sign_key_hash:
         {
             return
             {
-                { ec_public{ script[1].data() }, p2kh_version }
+                { ec_public{ script[1].data() }, p2kh_version },
+                { bitcoin_short_hash(script.back().data()), p2sh_version }
             };
         }
         case script_pattern::sign_script_hash:
         {
-            // P2SH address only, not addresses within the embedded script.
             return
             {
                 { bitcoin_short_hash(script.back().data()), p2sh_version }
             };
         }
+
+        // There is no address in sign_public_key script (signature only)
+        // and the public key cannot be extracted from the signature.
+        // A server can obtain by extracting from the previous output.
+        case script_pattern::sign_public_key:
+
+        // There are no addresses in sign_multisig script, signatures only.
+        // Nonstandard (non-zero) first op sign_multisig may conflict with
+        // sign_key_hash and/or sign_script_hash (or will be non_standard).
+        // A server can obtain the public keys extracting from the previous
+        // output, but bare multisig does not associate a payment address.
+        case script_pattern::sign_multisig:
         case script_pattern::non_standard:
         default:
         {
@@ -296,7 +300,7 @@ payment_address::list payment_address::extract_input(
     }
 }
 
-// All returned addresses are valid.
+// A server should use this against the prevout instead of using extract_input.
 payment_address::list payment_address::extract_output(
     const chain::script& script, uint8_t p2kh_version, uint8_t p2sh_version)
 {
@@ -304,24 +308,6 @@ payment_address::list payment_address::extract_output(
 
     switch (pattern)
     {
-        case script_pattern::pay_multisig:
-        {
-            list addresses;
-            const auto& ops = script.operations();
-
-            // Push 1 to 16 addresses.
-            for (auto op = ops.begin() + 1; op != ops.end() - 2; ++op)
-                addresses.emplace_back(ec_public{ op->data() }, p2kh_version);
-
-            return addresses;
-        }
-        case script_pattern::pay_public_key:
-        {
-            return
-            {
-                { ec_public{ script[0].data() }, p2kh_version }
-            };
-        }
         case script_pattern::pay_key_hash:
         {
             return
@@ -336,6 +322,18 @@ payment_address::list payment_address::extract_output(
                 { to_array<short_hash_size>(script[1].data()), p2sh_version }
             };
         }
+        case script_pattern::pay_public_key:
+        {
+            return
+            {
+                // pay_public_key is not p2kh but we conflate for tracking.
+                { ec_public{ script[0].data() }, p2kh_version }
+            };
+        }
+
+        // Bare multisig and null data do not associate a payment address.
+        case script_pattern::pay_multisig:
+        case script_pattern::null_data:
         case script_pattern::non_standard:
         default:
         {

--- a/test/chain/script.cpp
+++ b/test/chain/script.cpp
@@ -26,6 +26,58 @@ using namespace bc;
 using namespace bc::chain;
 using namespace bc::machine;
 
+#define SCRIPT_RETURN "return"
+#define SCRIPT_RETURN_EMPTY "return []"
+#define SCRIPT_RETURN_80 "return [0001020304050607080900010203040506070809000102030405060708090001020304050607080900010203040506070809000102030405060708090001020304050607080900010203040506070809]"
+#define SCRIPT_RETURN_81 "return [0001020304050607080900010203040506070809000102030405060708090001020304050607080900010203040506070809000102030405060708090001020304050607080900010203040506070809FF]"
+
+#define SCRIPT_0_OF_3_MULTISIG "0 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] [03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] 3 checkmultisig"
+#define SCRIPT_1_OF_3_MULTISIG "1 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] [03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] 3 checkmultisig"
+#define SCRIPT_2_OF_3_MULTISIG "2 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] [03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] 3 checkmultisig"
+#define SCRIPT_3_OF_3_MULTISIG "3 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] [03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] 3 checkmultisig"
+#define SCRIPT_4_OF_3_MULTISIG "4 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] [03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] 3 checkmultisig"
+
+#define SCRIPT_16_OF_16_MULTISIG \
+"16 " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"16 checkmultisig"
+
+#define SCRIPT_17_OF_17_MULTISIG \
+"[17] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] " \
+"[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] " \
+"[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] " \
+"16 checkmultisig"
+
 // Test helpers.
 //------------------------------------------------------------------------------
 
@@ -82,7 +134,6 @@ BOOST_AUTO_TEST_SUITE(script_tests)
 
 // Serialization tests.
 //------------------------------------------------------------------------------
-// TODO: add script parser test cases.
 
 BOOST_AUTO_TEST_CASE(script__one_hash__literal__same)
 {
@@ -192,6 +243,27 @@ BOOST_AUTO_TEST_CASE(script__from_data__internal_invalid_wire_code__success)
     BOOST_REQUIRE(instance.from_data(raw, false));
 }
 
+BOOST_AUTO_TEST_CASE(script__from_string__empty__success)
+{
+    script instance;
+    BOOST_REQUIRE(instance.from_string(""));
+    BOOST_REQUIRE(instance.operations().empty());
+}
+
+BOOST_AUTO_TEST_CASE(script__from_string__two_of_three_multisig__success)
+{
+    script instance;
+    BOOST_REQUIRE(instance.from_string(SCRIPT_2_OF_3_MULTISIG));
+    const auto& ops = instance.operations();
+    BOOST_REQUIRE_EQUAL(ops.size(), 6u);
+    BOOST_REQUIRE(ops[0] == opcode::push_positive_2);
+    BOOST_REQUIRE(ops[1].to_string(rule_fork::no_rules) == "[03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864]");
+    BOOST_REQUIRE(ops[2].to_string(rule_fork::no_rules) == "[02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c]");
+    BOOST_REQUIRE(ops[3].to_string(rule_fork::no_rules) == "[03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934]");
+    BOOST_REQUIRE(ops[4] == opcode::push_positive_3);
+    BOOST_REQUIRE(ops[5] == opcode::checkmultisig);
+}
+
 BOOST_AUTO_TEST_CASE(script__empty__default__true)
 {
     script instance;
@@ -219,16 +291,124 @@ BOOST_AUTO_TEST_CASE(script__clear__non_empty__empty)
     BOOST_REQUIRE(instance.empty());
 }
 
-BOOST_AUTO_TEST_CASE(script__pattern__two_of_three_multisig__match)
+// Pattern matching tests.
+//------------------------------------------------------------------------------
+
+// null_data
+
+BOOST_AUTO_TEST_CASE(script__pattern__null_data_return_only__non_standard)
 {
     script instance;
-    instance.from_string("2 [03dcfd9e580de35d8c2060d76dbf9e5561fe20febd2e64380e860a4d59f15ac864] [02440e0304bf8d32b2012994393c6a477acf238dd6adb4c3cef5bfa72f30c9861c] [03624505c6cc3967352cce480d8550490dd68519cd019066a4c302fdfb7d1c9934] 3 checkmultisig");
+    instance.from_string(SCRIPT_RETURN);
     BOOST_REQUIRE(instance.is_valid());
-    BOOST_REQUIRE(script::is_pay_multisig_pattern(instance.operations()));
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::non_standard);
+}
+
+BOOST_AUTO_TEST_CASE(script__pattern__null_data_empty__null_data)
+{
+    script instance;
+    instance.from_string(SCRIPT_RETURN_EMPTY);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::null_data);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::null_data);
+}
+
+BOOST_AUTO_TEST_CASE(script__pattern__null_data_80_bytes__null_data)
+{
+    script instance;
+    instance.from_string(SCRIPT_RETURN_80);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::null_data);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::null_data);
+}
+
+BOOST_AUTO_TEST_CASE(script__pattern__null_data_81_bytes__non_standard)
+{
+    script instance;
+    instance.from_string(SCRIPT_RETURN_81);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::non_standard);
+}
+
+// pay_multisig
+
+BOOST_AUTO_TEST_CASE(script__pattern__0_of_3_multisig__non_standard)
+{
+    script instance;
+    instance.from_string(SCRIPT_0_OF_3_MULTISIG);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::non_standard);
+}
+
+BOOST_AUTO_TEST_CASE(script__pattern__1_of_3_multisig__pay_multisig)
+{
+    script instance;
+    instance.from_string(SCRIPT_1_OF_3_MULTISIG);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::pay_multisig);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
     BOOST_REQUIRE(instance.pattern() == machine::script_pattern::pay_multisig);
 }
 
-// Data-driven test.
+BOOST_AUTO_TEST_CASE(script__pattern__2_of_3_multisig__pay_multisig)
+{
+    script instance;
+    instance.from_string(SCRIPT_2_OF_3_MULTISIG);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::pay_multisig);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::pay_multisig);
+}
+
+BOOST_AUTO_TEST_CASE(script__pattern__3_of_3_multisig__pay_multisig)
+{
+    script instance;
+    instance.from_string(SCRIPT_3_OF_3_MULTISIG);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::pay_multisig);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::pay_multisig);
+}
+
+BOOST_AUTO_TEST_CASE(script__pattern__4_of_3_multisig__non_standard)
+{
+    script instance;
+    instance.from_string(SCRIPT_4_OF_3_MULTISIG);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::non_standard);
+}
+
+BOOST_AUTO_TEST_CASE(script__pattern__16_of_16_multisig__pay_multisig)
+{
+    script instance;
+    instance.from_string(SCRIPT_16_OF_16_MULTISIG);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::pay_multisig);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::pay_multisig);
+}
+
+BOOST_AUTO_TEST_CASE(script__pattern__17_of_17_multisig__non_standard)
+{
+    script instance;
+    instance.from_string(SCRIPT_17_OF_17_MULTISIG);
+    BOOST_REQUIRE(instance.is_valid());
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::non_standard);
+}
+
+// Data-driven tests.
 //------------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(script__bip16__valid)

--- a/test/chain/script.cpp
+++ b/test/chain/script.cpp
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(script__empty__default__true)
     BOOST_REQUIRE(instance.empty());
 }
 
-BOOST_AUTO_TEST_CASE(script__empty__empty_operations__true)
+BOOST_AUTO_TEST_CASE(script__empty__no_operations__true)
 {
     script instance(operation::list{});
     BOOST_REQUIRE(instance.empty());
@@ -278,13 +278,13 @@ BOOST_AUTO_TEST_CASE(script__empty__empty_operations__true)
 
 BOOST_AUTO_TEST_CASE(script__empty__non_empty__false)
 {
-    script instance(script::to_null_data_pattern(data_chunk{ 42u }));
+    script instance(script::to_pay_null_data_pattern(data_chunk{ 42u }));
     BOOST_REQUIRE(!instance.empty());
 }
 
 BOOST_AUTO_TEST_CASE(script__clear__non_empty__empty)
 {
-    script instance(script::to_null_data_pattern(data_chunk{ 42u }));
+    script instance(script::to_pay_null_data_pattern(data_chunk{ 42u }));
     BOOST_REQUIRE(!instance.empty());
 
     instance.clear();
@@ -294,9 +294,9 @@ BOOST_AUTO_TEST_CASE(script__clear__non_empty__empty)
 // Pattern matching tests.
 //------------------------------------------------------------------------------
 
-// null_data
+// pay_null_data
 
-BOOST_AUTO_TEST_CASE(script__pattern__null_data_return_only__non_standard)
+BOOST_AUTO_TEST_CASE(script__pattern__pay_null_data_return_only__non_standard)
 {
     script instance;
     instance.from_string(SCRIPT_RETURN);
@@ -306,27 +306,27 @@ BOOST_AUTO_TEST_CASE(script__pattern__null_data_return_only__non_standard)
     BOOST_REQUIRE(instance.pattern() == machine::script_pattern::non_standard);
 }
 
-BOOST_AUTO_TEST_CASE(script__pattern__null_data_empty__null_data)
+BOOST_AUTO_TEST_CASE(script__pattern__pay_null_data_empty__null_data)
 {
     script instance;
     instance.from_string(SCRIPT_RETURN_EMPTY);
     BOOST_REQUIRE(instance.is_valid());
-    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::null_data);
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::pay_null_data);
     BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
-    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::null_data);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::pay_null_data);
 }
 
-BOOST_AUTO_TEST_CASE(script__pattern__null_data_80_bytes__null_data)
+BOOST_AUTO_TEST_CASE(script__pattern__pay_null_data_80_bytes__null_data)
 {
     script instance;
     instance.from_string(SCRIPT_RETURN_80);
     BOOST_REQUIRE(instance.is_valid());
-    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::null_data);
+    BOOST_REQUIRE(instance.output_pattern() == machine::script_pattern::pay_null_data);
     BOOST_REQUIRE(instance.input_pattern() == machine::script_pattern::non_standard);
-    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::null_data);
+    BOOST_REQUIRE(instance.pattern() == machine::script_pattern::pay_null_data);
 }
 
-BOOST_AUTO_TEST_CASE(script__pattern__null_data_81_bytes__non_standard)
+BOOST_AUTO_TEST_CASE(script__pattern__pay_null_data_81_bytes__non_standard)
 {
     script instance;
     instance.from_string(SCRIPT_RETURN_81);


### PR DESCRIPTION
This revises script address extraction and adds detailed comments regarding the limitations of context-free address extraction from input scripts. It also reverts keys->addresses extraction from bare multisig. Finally null_data is renamed to pay_null_data in order to match the existing naming conventions for output scripts.