### PR TITLE
Regtest network support

### DIFF
--- a/include/bitcoin/bitcoin/chain/block.hpp
+++ b/include/bitcoin/bitcoin/chain/block.hpp
@@ -138,6 +138,7 @@ public:
 
     static block genesis_mainnet();
     static block genesis_testnet();
+    static block genesis_regtestnet();
     static size_t locator_size(size_t top);
     static indexes locator_heights(size_t top);
 

--- a/include/bitcoin/bitcoin/constants.hpp
+++ b/include/bitcoin/bitcoin/constants.hpp
@@ -102,7 +102,11 @@ BC_CONSTEXPR uint32_t easy_spacing_seconds = 20 * 60;
 BC_CONSTEXPR uint32_t target_spacing_seconds = 10 * 60;
 BC_CONSTEXPR uint32_t target_timespan_seconds = 2 * 7 * 24 * 60 * 60;
 BC_CONSTEXPR uint32_t timestamp_future_seconds = 2 * 60 * 60;
+#ifdef WITH_REGTEST
+BC_CONSTEXPR uint32_t proof_of_work_limit = 0x207fffff;
+#else
 BC_CONSTEXPR uint32_t proof_of_work_limit = 0x1d00ffff;
+#endif
 
 // The upper and lower bounds for the retargeting timespan.
 BC_CONSTEXPR uint32_t min_timespan =

--- a/src/chain/block.cpp
+++ b/src/chain/block.cpp
@@ -98,6 +98,26 @@ static const std::string encoded_testnet_genesis_block =
     "4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"
     "00000000";
 
+static const std::string encoded_regtestnet_genesis_block =
+    "01000000"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+    "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
+    "dae5494d"
+    "ffff7f20"
+    "02000000"
+    "01"
+    "01000000"
+    "01"
+    "0000000000000000000000000000000000000000000000000000000000000000ffffffff"
+    "4d"
+    "04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"
+    "ffffffff"
+    "01"
+    "00f2052a01000000"
+    "43"
+    "4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"
+    "00000000";
+
 // Constructors.
 //-----------------------------------------------------------------------------
 
@@ -363,6 +383,18 @@ chain::block block::genesis_testnet()
 {
     data_chunk data;
     decode_base16(data, encoded_testnet_genesis_block);
+    const auto genesis = chain::block::factory_from_data(data);
+
+    BITCOIN_ASSERT(genesis.is_valid());
+    BITCOIN_ASSERT(genesis.transactions().size() == 1);
+    BITCOIN_ASSERT(genesis.generate_merkle_root() == genesis.header().merkle());
+    return genesis;
+}
+
+chain::block block::genesis_regtestnet()
+{
+    data_chunk data;
+    decode_base16(data, encoded_regtestnet_genesis_block);
     const auto genesis = chain::block::factory_from_data(data);
 
     BITCOIN_ASSERT(genesis.is_valid());

--- a/src/chain/chain_state.cpp
+++ b/src/chain/chain_state.cpp
@@ -316,6 +316,18 @@ uint32_t chain_state::median_time_past(const data& values, uint32_t)
 // work_required
 //-----------------------------------------------------------------------------
 
+#ifdef WITH_REGTEST
+
+uint32_t chain_state::work_required(const data& values, uint32_t forks)
+{
+    if (values.height == 0)
+        return{};
+
+    return bits_high(values);
+}
+
+#else
+
 uint32_t chain_state::work_required(const data& values, uint32_t forks)
 {
     // Invalid parameter via public interface, test is_valid for results.
@@ -330,6 +342,8 @@ uint32_t chain_state::work_required(const data& values, uint32_t forks)
 
     return bits_high(values);
 }
+
+#endif
 
 uint32_t chain_state::work_required_retarget(const data& values)
 {


### PR DESCRIPTION
This PR adds everything required to run libbitcoin on the regtest network as described by @evoskuil in the issue https://github.com/libbitcoin/libbitcoin-server/issues/404. This includes adding the encoded regtestnet genesis block, updated proof of work limit, and work required calculation. 

All of these changed are protected by the `WITH_REGTEST` flag, except `encoded_regtestnet_genesis_block` and `genesis_regtestnet ` which are namespaced.

This PR doesn't implement any makefile changes. Adding `#define WITH_REGTEST` near the top of `include/bitcoin/bitcoin/constants.hpp` works as a temporary workaround.