### PR TITLE
Complete and parameterize regtest implementation.

### DIFF
--- a/include/bitcoin/bitcoin/chain/block.hpp
+++ b/include/bitcoin/bitcoin/chain/block.hpp
@@ -138,14 +138,14 @@ public:
 
     static block genesis_mainnet();
     static block genesis_testnet();
-    static block genesis_regtestnet();
+    static block genesis_regtest();
     static size_t locator_size(size_t top);
     static indexes locator_heights(size_t top);
 
     // Validation.
     //-------------------------------------------------------------------------
 
-    static uint64_t subsidy(size_t height);
+    static uint64_t subsidy(size_t height, bool retarget=true);
     static uint256_t proof(uint32_t bits);
 
     uint64_t fees() const;

--- a/include/bitcoin/bitcoin/chain/header.hpp
+++ b/include/bitcoin/bitcoin/chain/header.hpp
@@ -138,9 +138,9 @@ public:
     //-----------------------------------------------------------------------------
 
     bool is_valid_timestamp() const;
-    bool is_valid_proof_of_work() const;
+    bool is_valid_proof_of_work(bool retarget=true) const;
 
-    code check() const;
+    code check(bool retarget=false) const;
     code accept(const chain_state& state) const;
 
     // THIS IS FOR LIBRARY USE ONLY, DO NOT CREATE A DEPENDENCY ON IT.

--- a/include/bitcoin/bitcoin/chain/transaction.hpp
+++ b/include/bitcoin/bitcoin/chain/transaction.hpp
@@ -168,7 +168,7 @@ public:
     bool is_locked(size_t block_height, uint32_t median_time_past) const;
     bool is_locktime_conflict() const;
 
-    code check(bool transaction_pool=true) const;
+    code check(bool transaction_pool=true, bool retarget=true) const;
     code accept(bool transaction_pool=true) const;
     code accept(const chain_state& state, bool transaction_pool=true) const;
     code connect() const;

--- a/include/bitcoin/bitcoin/config/settings.hpp
+++ b/include/bitcoin/bitcoin/config/settings.hpp
@@ -27,7 +27,8 @@ enum class settings
 {
     none,
     mainnet,
-    testnet
+    testnet,
+    regtest
 };
 
 } // namespace config

--- a/include/bitcoin/bitcoin/constants.hpp
+++ b/include/bitcoin/bitcoin/constants.hpp
@@ -102,11 +102,12 @@ BC_CONSTEXPR uint32_t easy_spacing_seconds = 20 * 60;
 BC_CONSTEXPR uint32_t target_spacing_seconds = 10 * 60;
 BC_CONSTEXPR uint32_t target_timespan_seconds = 2 * 7 * 24 * 60 * 60;
 BC_CONSTEXPR uint32_t timestamp_future_seconds = 2 * 60 * 60;
-#ifdef WITH_REGTEST
-BC_CONSTEXPR uint32_t proof_of_work_limit = 0x207fffff;
-#else
-BC_CONSTEXPR uint32_t proof_of_work_limit = 0x1d00ffff;
-#endif
+BC_CONSTEXPR uint32_t retarget_proof_of_work_limit = 0x1d00ffff;
+BC_CONSTEXPR uint32_t no_retarget_proof_of_work_limit = 0x207fffff;
+BC_CONSTFUNC uint32_t work_limit(bool retarget=true)
+{
+    return retarget ? retarget_proof_of_work_limit : no_retarget_proof_of_work_limit;
+}
 
 // The upper and lower bounds for the retargeting timespan.
 BC_CONSTEXPR uint32_t min_timespan =
@@ -149,6 +150,11 @@ BC_CONSTEXPR size_t testnet_bip65_freeze = 581885;
 BC_CONSTEXPR size_t testnet_bip66_freeze = 330776;
 BC_CONSTEXPR size_t testnet_bip34_freeze = 21111;
 
+// Regtest (arbitrary) frozen activation heights (frozen_activations).
+BC_CONSTEXPR size_t regtest_bip65_freeze = 1351;
+BC_CONSTEXPR size_t regtest_bip66_freeze = 1251;
+BC_CONSTEXPR size_t regtest_bip34_freeze = 0;
+
 // Block 514 is the first testnet block after date-based activation.
 // Block 173805 is the first mainnet block after date-based activation.
 BC_CONSTEXPR uint32_t bip16_activation_time = 0x4f779a80;
@@ -179,6 +185,11 @@ static const config::checkpoint testnet_bip34_active_checkpoint
 {
     "0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8", 21111
 };
+static const config::checkpoint regtest_bip34_active_checkpoint
+{
+    // Since bip90 assumes a historical bip34 activation block, use genesis.
+    "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f", 0
+};
 
 // These cannot be reactivated in a future branch due to window expiration.
 static const config::checkpoint mainnet_bip9_bit0_active_checkpoint
@@ -188,6 +199,11 @@ static const config::checkpoint mainnet_bip9_bit0_active_checkpoint
 static const config::checkpoint testnet_bip9_bit0_active_checkpoint
 {
     "00000000025e930139bac5c6c31a403776da130831ab85be56578f3fa75369bb", 770112
+};
+static const config::checkpoint regtest_bip9_bit0_active_checkpoint
+{
+    // The activation window is fixed and closed, so assume genesis activation.
+    "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f", 0
 };
 
 // Network protocol constants.
@@ -237,15 +253,21 @@ BC_CONSTFUNC uint64_t initial_block_subsidy_satoshi()
     return bitcoin_to_satoshi(initial_block_subsidy_bitcoin);
 }
 
-BC_CONSTEXPR uint64_t subsidy_interval = 210000;
 BC_CONSTEXPR uint64_t recursive_money = 0x02540be3f5;
-BC_CONSTFUNC uint64_t max_money()
+BC_CONSTEXPR uint64_t retarget_subsidy_interval = 210000;
+BC_CONSTEXPR uint64_t no_retarget_subsidy_interval = 150;
+BC_CONSTFUNC uint64_t subsidy_interval(bool retarget=true)
+{
+    return retarget ? retarget_subsidy_interval : no_retarget_subsidy_interval;
+}
+
+BC_CONSTFUNC uint64_t max_money(bool retarget=true)
 {
     ////// Optimize out the derivation of recursive_money.
     ////BITCOIN_ASSERT(recursive_money == max_money_recursive(
     ////    initial_block_subsidy_satoshi()));
 
-    return subsidy_interval * recursive_money;
+    return recursive_money * subsidy_interval(retarget);
 }
 
 } // namespace libbitcoin

--- a/include/bitcoin/bitcoin/machine/rule_fork.hpp
+++ b/include/bitcoin/bitcoin/machine/rule_fork.hpp
@@ -61,6 +61,9 @@ enum rule_fork : uint32_t
     /// Use median time past for locktime (soft fork, feature).
     bip113_rule = 1u << 10,
 
+    /// Perform difficulty retargeting (hard fork, regtest).
+    retarget = 1u << 30,
+
     /// Sentinel bit to indicate tx has not been validated.
     unverified = 1u << 31,
 

--- a/src/chain/chain_state.cpp
+++ b/src/chain/chain_state.cpp
@@ -43,80 +43,96 @@ using namespace bc::machine;
 // Inlines.
 //-----------------------------------------------------------------------------
 
-inline size_t version_sample_size(bool testnet)
+inline size_t version_sample_size(bool mainnet)
 {
-    return testnet ? testnet_sample : mainnet_sample;
+    return mainnet ? mainnet_sample : testnet_sample;
 }
 
-inline bool is_active(size_t count, bool testnet)
+inline bool is_active(size_t count, bool mainnet)
 {
-    return count >= (testnet ? testnet_active : mainnet_active);
+    return count >= (mainnet ? mainnet_active : testnet_active);
 }
 
-inline bool is_enforced(size_t count, bool testnet)
+inline bool is_enforced(size_t count, bool mainnet)
 {
-    return count >= (testnet ? testnet_enforce : mainnet_enforce);
+    return count >= (mainnet ? mainnet_enforce : testnet_enforce);
 }
 
-inline bool is_bip16_exception(const checkpoint& check, bool testnet)
+inline bool is_bip16_exception(const checkpoint& check, bool mainnet)
 {
-    return !testnet && check == mainnet_bip16_exception_checkpoint;
+    return mainnet && check == mainnet_bip16_exception_checkpoint;
 }
 
-inline bool is_bip30_exception(const checkpoint& check, bool testnet)
+inline bool is_bip30_exception(const checkpoint& check, bool mainnet)
 {
-    return !testnet &&
+    return mainnet &&
         ((check == mainnet_bip30_exception_checkpoint1) ||
          (check == mainnet_bip30_exception_checkpoint2));
 }
 
-inline bool allow_collisions(const hash_digest& hash, bool testnet)
+inline bool allow_collisions(const hash_digest& hash, bool mainnet,
+    bool testnet)
 {
+    const auto regtest = !mainnet && !testnet;
     return
-        ((testnet && hash == testnet_bip34_active_checkpoint.hash()) ||
-        (!testnet && hash == mainnet_bip34_active_checkpoint.hash()));
+        (mainnet && hash == mainnet_bip34_active_checkpoint.hash()) ||
+        (testnet && hash == testnet_bip34_active_checkpoint.hash()) ||
+        (regtest && hash == regtest_bip34_active_checkpoint.hash());
 }
 
-inline bool allow_collisions(size_t height, bool testnet)
+inline bool allow_collisions(size_t height, bool mainnet, bool testnet)
 {
+    const auto regtest = !mainnet && !testnet;
     return
-        ((testnet && height == testnet_bip34_active_checkpoint.height()) ||
-        (!testnet && height == mainnet_bip34_active_checkpoint.height()));
+        (mainnet && height == mainnet_bip34_active_checkpoint.height()) ||
+        (testnet && height == testnet_bip34_active_checkpoint.height()) ||
+        (regtest && height == regtest_bip34_active_checkpoint.height());
 }
 
-inline bool bip9_bit0_active(const hash_digest& hash, bool testnet)
+inline bool bip9_bit0_active(const hash_digest& hash, bool mainnet,
+    bool testnet)
 {
+    const auto regtest = !mainnet && !testnet;
     return
-        ((testnet && hash == testnet_bip9_bit0_active_checkpoint.hash()) ||
-        (!testnet && hash == mainnet_bip9_bit0_active_checkpoint.hash()));
+        (mainnet && hash == mainnet_bip9_bit0_active_checkpoint.hash()) ||
+        (testnet && hash == testnet_bip9_bit0_active_checkpoint.hash()) ||
+        (regtest && hash == regtest_bip9_bit0_active_checkpoint.hash());
 }
 
-inline bool bip9_bit0_active(size_t height, bool testnet)
+inline bool bip9_bit0_active(size_t height, bool mainnet, bool testnet)
 {
+    const auto regtest = !mainnet && !testnet;
     return
-        ((testnet && height == testnet_bip9_bit0_active_checkpoint.height()) ||
-        (!testnet && height == mainnet_bip9_bit0_active_checkpoint.height()));
+        (mainnet && height == mainnet_bip9_bit0_active_checkpoint.height()) ||
+        (testnet && height == testnet_bip9_bit0_active_checkpoint.height()) ||
+        (regtest && height == regtest_bip9_bit0_active_checkpoint.height());
 }
 
-inline bool bip34(size_t height, bool frozen, bool testnet)
+inline bool bip34(size_t height, bool frozen, bool mainnet, bool testnet)
 {
+    const auto regtest = !mainnet && !testnet;
     return frozen &&
-        ((testnet && height >= testnet_bip34_freeze) ||
-        (!testnet && height >= mainnet_bip34_freeze));
+        ((mainnet && height >= mainnet_bip34_freeze) ||
+         (testnet && height >= testnet_bip34_freeze) ||
+         (regtest && height >= regtest_bip34_freeze));
 }
 
-inline bool bip66(size_t height, bool frozen, bool testnet)
+inline bool bip66(size_t height, bool frozen, bool mainnet, bool testnet)
 {
+    const auto regtest = !mainnet && !testnet;
     return frozen &&
-        ((testnet && height >= testnet_bip66_freeze) ||
-        (!testnet && height >= mainnet_bip66_freeze));
+        ((mainnet && height >= mainnet_bip66_freeze) ||
+         (testnet && height >= testnet_bip66_freeze) ||
+         (regtest && height >= regtest_bip66_freeze));
 }
 
-inline bool bip65(size_t height, bool frozen, bool testnet)
+inline bool bip65(size_t height, bool frozen, bool mainnet, bool testnet)
 {
+    const auto regtest = !mainnet && !testnet;
     return frozen &&
-        ((testnet && height >= testnet_bip65_freeze) ||
-        (!testnet && height >= mainnet_bip65_freeze));
+        ((mainnet && height >= mainnet_bip65_freeze) ||
+         (testnet && height >= testnet_bip65_freeze) ||
+         (regtest && height >= regtest_bip65_freeze));
 }
 
 inline uint32_t timestamp_high(const chain_state::data& values)
@@ -140,6 +156,8 @@ chain_state::activations chain_state::activation(const data& values,
     const auto& history = values.version.ordered;
     const auto frozen = script::is_enabled(forks, rule_fork::bip90_rule);
     const auto testnet = script::is_enabled(forks, rule_fork::easy_blocks);
+    const auto retarget = script::is_enabled(forks, rule_fork::retarget);
+    const auto mainnet = retarget && !testnet;
 
     //*************************************************************************
     // CONSENSUS: Though unspecified in bip34, the satoshi implementation
@@ -161,9 +179,9 @@ chain_state::activations chain_state::activation(const data& values,
     const auto count_4 = std::count_if(history.begin(), history.end(), ge_4);
 
     // Frozen activations (require version and enforce above freeze height).
-    const auto bip34_ice = bip34(height, frozen, testnet);
-    const auto bip66_ice = bip66(height, frozen, testnet);
-    const auto bip65_ice = bip65(height, frozen, testnet);
+    const auto bip34_ice = bip34(height, frozen, mainnet, testnet);
+    const auto bip66_ice = bip66(height, frozen, mainnet, testnet);
+    const auto bip65_ice = bip65(height, frozen, mainnet, testnet);
 
     // Initialize activation results with genesis values.
     activations result{ rule_fork::no_rules, first_version };
@@ -177,7 +195,7 @@ chain_state::activations chain_state::activation(const data& values,
     // bip16 is activated with a one-time test on mainnet/testnet (~55% rule).
     // There was one invalid p2sh tx mined after that time (code shipped late).
     if (values.timestamp.self >= bip16_activation_time &&
-        !is_bip16_exception({ values.hash, height }, testnet))
+        !is_bip16_exception({ values.hash, height }, mainnet))
     {
         result.forks |= (rule_fork::bip16_rule & forks);
     }
@@ -185,51 +203,51 @@ chain_state::activations chain_state::activation(const data& values,
     // bip30 is active for all but two mainnet blocks that violate the rule.
     // These two blocks each have a coinbase transaction that exctly duplicates
     // another that is not spent by the arrival of the corresponding duplicate.
-    if (!is_bip30_exception({ values.hash, height }, testnet))
+    if (!is_bip30_exception({ values.hash, height }, mainnet))
     {
         result.forks |= (rule_fork::bip30_rule & forks);
     }
 
     // bip34 is activated based on 75% of preceding 1000 mainnet blocks.
-    if (bip34_ice || (is_active(count_2, testnet) && version >= bip34_version))
+    if (bip34_ice || (is_active(count_2, mainnet) && version >= bip34_version))
     {
         result.forks |= (rule_fork::bip34_rule & forks);
     }
 
     // bip66 is activated based on 75% of preceding 1000 mainnet blocks.
-    if (bip66_ice || (is_active(count_3, testnet) && version >= bip66_version))
+    if (bip66_ice || (is_active(count_3, mainnet) && version >= bip66_version))
     {
         result.forks |= (rule_fork::bip66_rule & forks);
     }
 
     // bip65 is activated based on 75% of preceding 1000 mainnet blocks.
-    if (bip65_ice || (is_active(count_4, testnet) && version >= bip65_version))
+    if (bip65_ice || (is_active(count_4, mainnet) && version >= bip65_version))
     {
         result.forks |= (rule_fork::bip65_rule & forks);
     }
 
     // allow_collisions is active above the bip34 checkpoint only.
-    if (allow_collisions(values.allow_collisions_hash, testnet))
+    if (allow_collisions(values.allow_collisions_hash, mainnet, testnet))
     {
         result.forks |= (rule_fork::allow_collisions & forks);
     }
 
     // bip9_bit0 forks are enforced above the bip9_bit0 checkpoint.
-    if (bip9_bit0_active(values.bip9_bit0_hash, testnet))
+    if (bip9_bit0_active(values.bip9_bit0_hash, mainnet, testnet))
     {
         result.forks |= (rule_fork::bip9_bit0_group & forks);
     }
 
     // version 4/3/2 enforced based on 95% of preceding 1000 mainnet blocks.
-    if (bip65_ice || is_enforced(count_4, testnet))
+    if (bip65_ice || is_enforced(count_4, mainnet))
     {
         result.minimum_version = bip65_version;
     }
-    else if (bip66_ice || is_enforced(count_3, testnet))
+    else if (bip66_ice || is_enforced(count_3, mainnet))
     {
         result.minimum_version = bip66_version;
     }
-    else if (bip34_ice || is_enforced(count_2, testnet))
+    else if (bip34_ice || is_enforced(count_2, mainnet))
     {
         result.minimum_version = bip34_version;
     }
@@ -244,7 +262,8 @@ chain_state::activations chain_state::activation(const data& values,
 size_t chain_state::bits_count(size_t height, uint32_t forks)
 {
     const auto testnet = script::is_enabled(forks, rule_fork::easy_blocks);
-    const auto easy_work = testnet && !is_retarget_height(height);
+    const auto retarget = script::is_enabled(forks, rule_fork::retarget);
+    const auto easy_work = testnet && retarget && !is_retarget_height(height);
     return easy_work ? std::min(height, retargeting_interval) : 1;
 }
 
@@ -256,8 +275,10 @@ size_t chain_state::version_count(size_t height, uint32_t forks)
         return 0;
     }
 
+    // Regtest and testnet both use bip34 test activation.
     const auto testnet = script::is_enabled(forks, rule_fork::easy_blocks);
-    return std::min(height, version_sample_size(testnet));
+    const auto retarget = script::is_enabled(forks, rule_fork::retarget);
+    return std::min(height, version_sample_size(retarget && !testnet));
 }
 
 size_t chain_state::timestamp_count(size_t height, uint32_t)
@@ -265,21 +286,26 @@ size_t chain_state::timestamp_count(size_t height, uint32_t)
     return std::min(height, median_time_past_interval);
 }
 
-size_t chain_state::retarget_height(size_t height, uint32_t)
+size_t chain_state::retarget_height(size_t height, uint32_t forks)
 {
+    const auto retarget = script::is_enabled(forks, rule_fork::retarget);
+
     // Height must be a positive multiple of interval, so underflow safe.
     // If not retarget height get most recent so that it may be promoted.
-    return height - (is_retarget_height(height) ? retargeting_interval :
-        retarget_distance(height));
+    return retarget ?
+        (height - (is_retarget_height(height) ? retargeting_interval :
+            retarget_distance(height))) : map::unrequested;
 }
 
 size_t chain_state::collision_height(size_t height, uint32_t forks)
 {
     const auto testnet = script::is_enabled(forks, rule_fork::easy_blocks);
+    const auto regtest = !script::is_enabled(forks, rule_fork::retarget);
 
-    const auto bip34_height = testnet ?
-        testnet_bip34_active_checkpoint.height() :
-        mainnet_bip34_active_checkpoint.height();
+    const auto bip34_height =
+        testnet ? testnet_bip34_active_checkpoint.height() :
+        regtest ? regtest_bip34_active_checkpoint.height() :
+            mainnet_bip34_active_checkpoint.height();
 
     // Require collision hash at heights above historical bip34 activation.
     return height > bip34_height ? bip34_height : map::unrequested;
@@ -288,10 +314,12 @@ size_t chain_state::collision_height(size_t height, uint32_t forks)
 size_t chain_state::bip9_bit0_height(size_t height, uint32_t forks)
 {
     const auto testnet = script::is_enabled(forks, rule_fork::easy_blocks);
+    const auto regtest = !script::is_enabled(forks, rule_fork::retarget);
 
-    const auto activation_height = testnet ?
-        testnet_bip9_bit0_active_checkpoint.height() :
-        mainnet_bip9_bit0_active_checkpoint.height();
+    const auto activation_height =
+        testnet ? testnet_bip9_bit0_active_checkpoint.height() :
+        regtest ? regtest_bip9_bit0_active_checkpoint.height() :
+            mainnet_bip9_bit0_active_checkpoint.height();
 
     // Require bip9_bit0 hash at heights above historical bip9_bit0 activation.
     return height > activation_height ? activation_height : map::unrequested;
@@ -316,23 +344,15 @@ uint32_t chain_state::median_time_past(const data& values, uint32_t)
 // work_required
 //-----------------------------------------------------------------------------
 
-#ifdef WITH_REGTEST
-
-uint32_t chain_state::work_required(const data& values, uint32_t forks)
-{
-    if (values.height == 0)
-        return{};
-
-    return bits_high(values);
-}
-
-#else
-
 uint32_t chain_state::work_required(const data& values, uint32_t forks)
 {
     // Invalid parameter via public interface, test is_valid for results.
     if (values.height == 0)
-        return{};
+        return 0;
+
+    // Regtest bypasses all retargeting.
+    if (!script::is_enabled(forks, rule_fork::retarget))
+        return bits_high(values);
 
     if (is_retarget_height(values.height))
         return work_required_retarget(values);
@@ -343,11 +363,9 @@ uint32_t chain_state::work_required(const data& values, uint32_t forks)
     return bits_high(values);
 }
 
-#endif
-
 uint32_t chain_state::work_required_retarget(const data& values)
 {
-    static const uint256_t pow_limit(compact{ proof_of_work_limit });
+    static const uint256_t pow_limit(compact{ retarget_proof_of_work_limit });
 
     const compact bits(bits_high(values));
     BITCOIN_ASSERT_MSG(!bits.is_overflowed(), "previous block has bad bits");
@@ -357,7 +375,8 @@ uint32_t chain_state::work_required_retarget(const data& values)
     target /= target_timespan_seconds;
 
     // The proof_of_work_limit constant is pre-normalized.
-    return target > pow_limit ? proof_of_work_limit : compact(target).normal();
+    return target > pow_limit ? retarget_proof_of_work_limit :
+        compact(target).normal();
 }
 
 // Get the bounded total time spanning the highest 2016 blocks.
@@ -380,7 +399,7 @@ uint32_t chain_state::easy_work_required(const data& values)
 
     // If the time limit has passed allow a minimum difficulty block.
     if (values.timestamp.self > easy_time_limit(values))
-        return proof_of_work_limit;
+        return retarget_proof_of_work_limit;
 
     auto height = values.height;
     auto& bits = values.bits.ordered;
@@ -393,7 +412,7 @@ uint32_t chain_state::easy_work_required(const data& values)
     // Since the set of heights is either a full retarget range or ends at
     // zero this is not reachable unless the data set is invalid.
     BITCOIN_ASSERT(false);
-    return proof_of_work_limit;
+    return retarget_proof_of_work_limit;
 }
 
 uint32_t chain_state::easy_time_limit(const chain_state::data& values)
@@ -415,7 +434,7 @@ bool chain_state::is_retarget_or_non_limit(size_t height, uint32_t bits)
     // This is guaranteed, just asserting here to document the safeguard.
     BITCOIN_ASSERT_MSG(is_retarget_height(0), "loop overflow potential");
 
-    return bits != proof_of_work_limit || is_retarget_height(height);
+    return bits != retarget_proof_of_work_limit || is_retarget_height(height);
 }
 
 // Determine if height is a multiple of retargeting_interval.
@@ -491,6 +510,8 @@ uint32_t chain_state::signal_version(uint32_t forks)
 // This is promotion from a preceding height to the next.
 chain_state::data chain_state::to_pool(const chain_state& top)
 {
+    auto retarget = script::is_enabled(top.forks_, rule_fork::retarget);
+
     // Copy data from presumed previous-height block state.
     auto data = top.data_;
 
@@ -517,8 +538,9 @@ chain_state::data chain_state::to_pool(const chain_state& top)
     if (data.timestamp.ordered.size() > timestamp_count(height, forks))
         data.timestamp.ordered.pop_front();
 
+    // Regtest does not perform retargeting.
     // If promoting from retarget height, move that timestamp into retarget.
-    if (is_retarget_height(height - 1u))
+    if (retarget && is_retarget_height(height - 1u))
         data.timestamp.retarget = data.timestamp.self;
 
     // Replace previous block state with tx pool chain state for next height.
@@ -527,7 +549,7 @@ chain_state::data chain_state::to_pool(const chain_state& top)
     // Preserve data.bip9_bit0_hash promotion.
     data.height = height;
     data.hash = null_hash;
-    data.bits.self = proof_of_work_limit;
+    data.bits.self = work_limit(retarget);
     data.version.self = signal_version(forks);
     data.timestamp.self = max_uint32;
     return data;
@@ -549,6 +571,8 @@ chain_state::data chain_state::to_block(const chain_state& pool,
     const block& block)
 {
     auto testnet = script::is_enabled(pool.forks_, rule_fork::easy_blocks);
+    auto retarget = script::is_enabled(pool.forks_, rule_fork::retarget);
+    auto mainnet = retarget && !testnet;
 
     // Copy data from presumed same-height pool state.
     auto data = pool.data_;
@@ -562,11 +586,11 @@ chain_state::data chain_state::to_block(const chain_state& pool,
     data.timestamp.self = header.timestamp();
 
     // Cache hash of bip34 height block, otherwise use preceding state.
-    if (allow_collisions(data.height, testnet))
+    if (allow_collisions(data.height, mainnet, testnet))
         data.allow_collisions_hash = data.hash;
 
     // Cache hash of bip9 bit0 height block, otherwise use preceding state.
-    if (bip9_bit0_active(data.height, testnet))
+    if (bip9_bit0_active(data.height, mainnet, testnet))
         data.bip9_bit0_hash = data.hash;
 
     return data;
@@ -588,6 +612,8 @@ chain_state::data chain_state::to_header(const chain_state& parent,
     const header& header)
 {
     auto testnet = script::is_enabled(parent.forks_, rule_fork::easy_blocks);
+    auto retarget = script::is_enabled(parent.forks_, rule_fork::retarget);
+    auto mainnet = retarget && !testnet;
 
     // Copy and promote data from presumed parent-height header/block state.
     auto data = to_pool(parent);
@@ -600,11 +626,11 @@ chain_state::data chain_state::to_header(const chain_state& parent,
     data.timestamp.self = header.timestamp();
 
     // Cache hash of bip34 height block, otherwise use preceding state.
-    if (allow_collisions(data.height, testnet))
+    if (allow_collisions(data.height, mainnet, testnet))
         data.allow_collisions_hash = data.hash;
 
     // Cache hash of bip9 bit0 height block, otherwise use preceding state.
-    if (bip9_bit0_active(data.height, testnet))
+    if (bip9_bit0_active(data.height, mainnet, testnet))
         data.bip9_bit0_hash = data.hash;
 
     return data;

--- a/src/chain/header.cpp
+++ b/src/chain/header.cpp
@@ -430,10 +430,10 @@ bool header::is_valid_timestamp() const
 }
 
 // [CheckProofOfWork]
-bool header::is_valid_proof_of_work() const
+bool header::is_valid_proof_of_work(bool retarget) const
 {
-    static const uint256_t pow_limit(compact{ proof_of_work_limit });
     const auto bits = compact(bits_);
+    static const uint256_t pow_limit(compact{ work_limit(retarget) });
 
     if (bits.is_overflowed())
         return false;
@@ -451,9 +451,9 @@ bool header::is_valid_proof_of_work() const
 // Validation.
 //-----------------------------------------------------------------------------
 
-code header::check() const
+code header::check(bool retarget) const
 {
-    if (!is_valid_proof_of_work())
+    if (!is_valid_proof_of_work(retarget))
         return error::invalid_proof_of_work;
 
     else if (!is_valid_timestamp())

--- a/src/chain/transaction.cpp
+++ b/src/chain/transaction.cpp
@@ -768,7 +768,7 @@ code transaction::connect_input(const chain_state& state,
 //-----------------------------------------------------------------------------
 
 // These checks are self-contained; blockchain (and so version) independent.
-code transaction::check(bool transaction_pool) const
+code transaction::check(bool transaction_pool, bool retarget) const
 {
     if (inputs_.empty() || outputs_.empty())
         return error::empty_transaction;
@@ -776,7 +776,7 @@ code transaction::check(bool transaction_pool) const
     else if (is_null_non_coinbase())
         return error::previous_output_null;
 
-    else if (total_output_value() > max_money())
+    else if (total_output_value() > max_money(retarget))
         return error::spend_overflow;
 
     else if (!transaction_pool && is_oversized_coinbase())

--- a/test/chain/block.cpp
+++ b/test/chain/block.cpp
@@ -288,6 +288,15 @@ BOOST_AUTO_TEST_CASE(block__genesis__testnet__valid_structure)
     BOOST_REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
 }
 
+BOOST_AUTO_TEST_CASE(block__genesis__regtest__valid_structure)
+{
+    const auto genesis = bc::chain::block::genesis_regtest();
+    BOOST_REQUIRE(genesis.is_valid());
+    BOOST_REQUIRE_EQUAL(genesis.transactions().size(), 1u);
+    BOOST_REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
+}
+
+
 BOOST_AUTO_TEST_CASE(block__factory_from_data_1__genesis_mainnet__success)
 {
     const auto genesis = bc::chain::block::genesis_mainnet();

--- a/test/chain/compact.cpp
+++ b/test/chain/compact.cpp
@@ -46,7 +46,12 @@ static uint32_t factory(int32_t logical_exponent, bool negative, uint32_t mantis
 
 BOOST_AUTO_TEST_CASE(compact__constructor1__proof_of_work_limit__normalizes_unchanged)
 {
-    BOOST_REQUIRE_EQUAL(compact(proof_of_work_limit).normal(), proof_of_work_limit);
+    BOOST_REQUIRE_EQUAL(compact(retarget_proof_of_work_limit).normal(), retarget_proof_of_work_limit);
+}
+
+BOOST_AUTO_TEST_CASE(compact__constructor1__no_retarget_proof_of_work_limit__normalizes_unchanged)
+{
+    BOOST_REQUIRE_EQUAL(compact(no_retarget_proof_of_work_limit).normal(), no_retarget_proof_of_work_limit);
 }
 
 // constructor1/normal

--- a/test/chain/header.cpp
+++ b/test/chain/header.cpp
@@ -388,8 +388,15 @@ BOOST_AUTO_TEST_CASE(header__is_valid_timestamp__timestamp_greater_than_2_hours_
 BOOST_AUTO_TEST_CASE(header__is_valid_proof_of_work__bits_exceeds_maximum__returns_false)
 {
     chain::header instance;
-    instance.set_bits(proof_of_work_limit + 1);
+    instance.set_bits(retarget_proof_of_work_limit + 1);
     BOOST_REQUIRE(!instance.is_valid_proof_of_work());
+}
+
+BOOST_AUTO_TEST_CASE(header__is_valid_proof_of_work__retarget_bits_exceeds_maximum__returns_false)
+{
+    chain::header instance;
+    instance.set_bits(no_retarget_proof_of_work_limit + 1);
+    BOOST_REQUIRE(!instance.is_valid_proof_of_work(false));
 }
 
 BOOST_AUTO_TEST_CASE(header__is_valid_proof_of_work__hash_greater_bits__returns_false)

--- a/test/formats/base_10.cpp
+++ b/test/formats/base_10.cpp
@@ -50,9 +50,13 @@ BOOST_AUTO_TEST_CASE(format_amount_##NAME##_test) \
 TEST_AMOUNT(zero, 0, "0")
 TEST_AMOUNT(max_uint64, max_uint64, "18446744073709551615")
 
-// Max money:
-TEST_AMOUNT(max_money, max_money(), "20999999.9769", btc_decimal_places)
-TEST_AMOUNT(overflow_max_money, max_money() + 1, "20999999.97690001", btc_decimal_places)
+// Max money (mainnet, testnet):
+TEST_AMOUNT(max_money_retarget, max_money(), "20999999.9769", btc_decimal_places)
+TEST_AMOUNT(overflow_max_money_retarget, max_money() + 1, "20999999.97690001", btc_decimal_places)
+
+// Max money (regtest):
+TEST_AMOUNT(max_money, max_money(false), "14999.99998350", btc_decimal_places)
+TEST_AMOUNT(overflow_max_money, max_money(false) + 1, "14999.99998351", btc_decimal_places)
 
 // Decimal points:
 TEST_AMOUNT(pure_integer, 42, "42.0", 0)
@@ -84,9 +88,13 @@ TEST_AMOUNT_NEGATIVE(fractional_amount, "0.999999999", btc_decimal_places)
 TEST_FORMAT(zero, "0", 0)
 TEST_FORMAT(max_uint64, "18446744073709551615", max_uint64)
 
-// Max money:
-TEST_FORMAT(max_money, "20999999.9769", max_money(), btc_decimal_places)
-TEST_FORMAT(overflow_max_money, "20999999.97690001", max_money() + 1, btc_decimal_places)
+// Max money (mainnet, testnet):
+TEST_FORMAT(max_money_retarget, "20999999.9769", max_money(), btc_decimal_places)
+TEST_FORMAT(overflow_max_money_retarget, "20999999.97690001", max_money() + 1, btc_decimal_places)
+
+// Max money (regtest):
+TEST_FORMAT(max_money, "14999.9999835", max_money(false), btc_decimal_places)
+TEST_FORMAT(overflow_max_money, "14999.99998351", max_money(false) + 1, btc_decimal_places)
 
 // Decimal points:
 TEST_FORMAT(pure_integer, "42", 42, 0)


### PR DESCRIPTION
The ~`retarget` (regtest) flag takes precedence for proof of work in the case of conflict with the `easy_blocks` (testnet) flag.