### PR TITLE
CONSENSUS: patch sighash type extraction.

### DIFF
--- a/include/bitcoin/bitcoin/machine/sighash_algorithm.hpp
+++ b/include/bitcoin/bitcoin/machine/sighash_algorithm.hpp
@@ -64,7 +64,10 @@ enum sighash_algorithm : uint32_t
 
     /// Signs this one input and its corresponding output. Allows anyone to
     /// add or remove other inputs.
-    single_anyone_can_pay = single | anyone_can_pay
+    single_anyone_can_pay = single | anyone_can_pay,
+
+    /// Used to mask unused bits in the signature hash byte.
+    mask = 0x1f
 };
 
 } // namespace machine

--- a/src/chain/script.cpp
+++ b/src/chain/script.cpp
@@ -51,11 +51,6 @@ namespace chain {
 
 using namespace bc::machine;
 
-static const auto sighash_all = sighash_algorithm::all;
-static const auto sighash_none = sighash_algorithm::none;
-static const auto sighash_single = sighash_algorithm::single;
-static const auto anyone_flag = sighash_algorithm::anyone_can_pay;
-
 // bit.ly/2cPazSa
 static const auto one_hash = hash_literal(
     "0000000000000000000000000000000000000000000000000000000000000001");
@@ -488,8 +483,15 @@ const operation::list& script::operations() const
 
 inline sighash_algorithm to_sighash_enum(uint8_t sighash_type)
 {
-    return static_cast<sighash_algorithm>(
-        sighash_type & ~sighash_algorithm::anyone_can_pay);
+    switch (sighash_type & sighash_algorithm::mask)
+    {
+        case sighash_algorithm::single:
+            return sighash_algorithm::single;
+        case sighash_algorithm::none:
+            return sighash_algorithm::none;
+        default:
+            return sighash_algorithm::all;
+    }
 }
 
 inline uint8_t is_sighash_enum(uint8_t sighash_type, sighash_algorithm value)
@@ -497,22 +499,18 @@ inline uint8_t is_sighash_enum(uint8_t sighash_type, sighash_algorithm value)
     return to_sighash_enum(sighash_type) == value;
 }
 
-inline bool is_sighash_flag(uint8_t sighash_type, sighash_algorithm value)
-{
-    return (sighash_type & value) != 0;
-}
-
 static hash_digest sign_none(const transaction& tx, uint32_t input_index,
-    const script& script_code, uint8_t sighash_type, bool anyone)
+    const script& script_code, uint8_t sighash_type)
 {
     input::list ins;
     const auto& inputs = tx.inputs();
-    ins.reserve(anyone ? 1 : inputs.size());
+    const auto any = (sighash_type & sighash_algorithm::anyone_can_pay) != 0;
+    ins.reserve(any ? 1 : inputs.size());
 
     BITCOIN_ASSERT(input_index < inputs.size());
     const auto& self = inputs[input_index];
 
-    if (anyone)
+    if (any)
     {
         // Retain only self.
         ins.emplace_back(self.previous_output(), script_code, self.sequence());
@@ -534,16 +532,17 @@ static hash_digest sign_none(const transaction& tx, uint32_t input_index,
 }
 
 static hash_digest sign_single(const transaction& tx, uint32_t input_index,
-    const script& script_code, uint8_t sighash_type, bool anyone)
+    const script& script_code, uint8_t sighash_type)
 {
     input::list ins;
     const auto& inputs = tx.inputs();
-    ins.reserve(anyone ? 1 : inputs.size());
+    const auto any = (sighash_type & sighash_algorithm::anyone_can_pay) != 0;
+    ins.reserve(any ? 1 : inputs.size());
 
     BITCOIN_ASSERT(input_index < inputs.size());
     const auto& self = inputs[input_index];
 
-    if (anyone)
+    if (any)
     {
         // Retain only self.
         ins.emplace_back(self.previous_output(), script_code, self.sequence());
@@ -572,16 +571,17 @@ static hash_digest sign_single(const transaction& tx, uint32_t input_index,
 }
 
 static hash_digest sign_all(const transaction& tx, uint32_t input_index,
-    const script& script_code, uint8_t sighash_type, bool anyone)
+    const script& script_code, uint8_t sighash_type)
 {
     input::list ins;
     const auto& inputs = tx.inputs();
-    ins.reserve(anyone ? 1 : inputs.size());
+    const auto any = (sighash_type & sighash_algorithm::anyone_can_pay) != 0;
+    ins.reserve(any ? 1 : inputs.size());
 
     BITCOIN_ASSERT(input_index < inputs.size());
     const auto& self = inputs[input_index];
 
-    if (anyone)
+    if (any)
     {
         // Retain only self.
         ins.emplace_back(self.previous_output(), script_code, self.sequence());
@@ -616,14 +616,15 @@ static script strip_code_seperators(const script& script_code)
 }
 
 // static
+// Use bool for version && bip143.
 hash_digest script::generate_signature_hash(const transaction& tx,
     uint32_t input_index, const script& script_code, uint8_t sighash_type)
 {
-    const auto any = is_sighash_flag(sighash_type, anyone_flag);
-    const auto single = is_sighash_enum(sighash_type, sighash_single);
+    const auto sighash = to_sighash_enum(sighash_type);
 
     if (input_index >= tx.inputs().size() ||
-        (input_index >= tx.outputs().size() && single))
+        (input_index >= tx.outputs().size() &&
+            sighash == sighash_algorithm::single))
     {
         //*********************************************************************
         // CONSENSUS: wacky satoshi behavior we must perpetuate.
@@ -637,15 +638,15 @@ hash_digest script::generate_signature_hash(const transaction& tx,
     const auto stripped = strip_code_seperators(script_code);
 
     // The sighash serializations are isolated for clarity and optimization.
-    switch (to_sighash_enum(sighash_type))
+    switch (sighash)
     {
-        case sighash_none:
-            return sign_none(tx, input_index, stripped, sighash_type, any);
-        case sighash_single:
-            return sign_single(tx, input_index, stripped, sighash_type, any);
+        case sighash_algorithm::none:
+            return sign_none(tx, input_index, stripped, sighash_type);
+        case sighash_algorithm::single:
+            return sign_single(tx, input_index, stripped, sighash_type);
         default:
-        case sighash_all:
-            return sign_all(tx, input_index, stripped, sighash_type, any);
+        case sighash_algorithm::all:
+            return sign_all(tx, input_index, stripped, sighash_type);
     }
 }
 


### PR DESCRIPTION
The existing implementation fails to mask the sighash byte when extracting the enumeration.