### PR TITLE
Electrum test updates

### DIFF
--- a/include/bitcoin/bitcoin/wallet/electrum.hpp
+++ b/include/bitcoin/bitcoin/wallet/electrum.hpp
@@ -92,7 +92,7 @@ BC_API word_list create_mnemonic(const data_chunk& entropy,
  * words must have been created using electrum encoding.
  */
 BC_API bool validate_mnemonic(const word_list& mnemonic,
-    const dictionary& lexicon=language::en,
+    const dictionary& lexicon,
     const seed prefix=electrum::seed::standard);
 
 /**

--- a/test/wallet/electrum.cpp
+++ b/test/wallet/electrum.cpp
@@ -30,14 +30,14 @@ BOOST_AUTO_TEST_SUITE(electrum_tests)
 //
 // https://github.com/spesmilo/electrum/blob/master/lib/mnemonic.py
 
-BOOST_AUTO_TEST_CASE(electrum__decode_mnemonic__no_passphrase_1)
+BOOST_AUTO_TEST_CASE(electrum__decode_mnemonic__no_passphrase_1__valid)
 {
     static const word_list mnemonic{ "foo", "bar", "baz" };
     const auto seed = electrum::decode_mnemonic(mnemonic);
     BOOST_REQUIRE_EQUAL(encode_base16(seed), "c4033901dd61ba26cfd0a1cf1ceb4b347606635aa3cb951eb6e819d58beedc04dd400a2e600d783c83c75879d6538abeecc7bb1b292b2a4d775d348d5d686427");
 }
 
-BOOST_AUTO_TEST_CASE(electrum__decode_mnemonic__no_passphrase_2)
+BOOST_AUTO_TEST_CASE(electrum__decode_mnemonic__no_passphrase_2__valid)
 {
     static const word_list mnemonic
     {
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(electrum__decode_mnemonic__no_passphrase_2)
 
 #ifdef WITH_ICU
 
-BOOST_AUTO_TEST_CASE(electrum__decode_mnemonic__passphrase)
+BOOST_AUTO_TEST_CASE(electrum__decode_mnemonic__passphrase__valid)
 {
     static const word_list mnemonic{ "foobar" };
     const auto passphrase = "none";
@@ -57,50 +57,70 @@ BOOST_AUTO_TEST_CASE(electrum__decode_mnemonic__passphrase)
     BOOST_REQUIRE_EQUAL(encode_base16(seed), "741b72fd15effece6bfe5a26a52184f66811bd2be363190e07a42cca442b1a5bb22b3ad0eb338197287e6d314866c7fba863ac65d3f156087a5052ebc7157fce");
 }
 
-BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__dictionary)
+BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__no_dictionary__valid)
 {
     data_chunk entropy;
-    decode_base16(entropy, "05E669B4270F4E25BCE6FC3736170D423C");
+    decode_base16(entropy, "05e669b4270f4e25bce6fc3736170d423c");
+    const auto mnemonic = electrum::create_mnemonic(entropy);
+    BOOST_REQUIRE(!mnemonic.empty());
+    BOOST_REQUIRE_EQUAL(join(mnemonic), "giggle crush argue inflict wear defy combine evolve tiger spatial crumble fury");
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic));
+}
+
+BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__en_dictionary__valid)
+{
+    data_chunk entropy;
+    decode_base16(entropy, "05e669b4270f4e25bce6fc3736170d423c");
     const auto mnemonic = electrum::create_mnemonic(entropy, language::en);
     BOOST_REQUIRE(!mnemonic.empty());
     BOOST_REQUIRE_EQUAL(join(mnemonic), "giggle crush argue inflict wear defy combine evolve tiger spatial crumble fury");
     BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::en));
 }
 
-BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__dictionary_prefix)
+BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__en_dictionary_prefix__valid)
 {
     data_chunk entropy;
-    decode_base16(entropy, "0B0D80F992A51348A89AEB5196FA0BD0D6");
+    decode_base16(entropy, "0b0d80f992a51348a89aeb5196fa0bd0d6");
     const auto mnemonic = electrum::create_mnemonic(entropy, language::en, electrum::seed::standard);
     BOOST_REQUIRE(!mnemonic.empty());
     BOOST_REQUIRE_EQUAL(join(mnemonic), "crawl consider laptop bonus stove chase earn battle feed town scatter radio");
     BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::en, electrum::seed::standard));
 }
 
-BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__large_entropy_1)
+BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__es_dictionary_prefix__valid)
 {
     data_chunk entropy;
-    decode_base16(entropy, "2B18CF24D3C26529B18D733ABADFF49F06E65EBF74263F0BA00D11A9B0CBA8D303");
+    decode_base16(entropy, "05e669b4270f4e25bce6fc3736170d423c");
+    const auto mnemonic = electrum::create_mnemonic(entropy, language::es, electrum::seed::standard);
+    BOOST_REQUIRE(!mnemonic.empty());
+    BOOST_REQUIRE_EQUAL(join(mnemonic), "gigante codo ámbar insecto verbo cráter celoso entrar tarjeta sala coco frito");
+    BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::es, electrum::seed::standard));
+}
+
+BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__large_entropy_1__valid)
+{
+    data_chunk entropy;
+    decode_base16(entropy, "2b18cf24d3c26529b18d733abadff49f06e65ebf74263f0ba00d11a9b0cba8d303");
     const auto mnemonic = electrum::create_mnemonic(entropy);
     BOOST_REQUIRE(!mnemonic.empty());
     BOOST_REQUIRE_EQUAL(join(mnemonic), "icon person grape only cash addict fringe disease luggage worry consider hover dignity wood street deny purpose shiver network chaos pole since shoe climb");
     BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::en, electrum::seed::standard));
 }
 
-BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__large_entropy_2)
+BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__large_entropy_2__valid)
 {
     data_chunk entropy;
-    decode_base16(entropy, "B0756302179E800B182514C729F1D6814C377FF06097569EF540E6C1F1950F08");
+    decode_base16(entropy, "b0756302179e800b182514c729f1d6814c377ff06097569ef540e6c1f1950f08");
     const auto mnemonic = electrum::create_mnemonic(entropy);
     BOOST_REQUIRE(!mnemonic.empty());
     BOOST_REQUIRE_EQUAL(join(mnemonic), "divide february web hire limb run reject nuclear army zone brick below public ladder deer below again cluster divorce ketchup aerobic flee lonely absent");
     BOOST_REQUIRE(electrum::validate_mnemonic(mnemonic, language::en, electrum::seed::standard));
 }
 
-BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__invalid)
+BOOST_AUTO_TEST_CASE(electrum__create_mnemonic__incorrent_mnemonic__invalid)
 {
     data_chunk entropy;
-    decode_base16(entropy, "2B18CF24D3C26529B18D733ABADFF49F06E65EBF74263F0BA00D11A9B0CBA8D303");
+    decode_base16(entropy, "2b18cf24d3c26529b18d733abadff49f06e65ebf74263f0ba00d11a9b0cba8d303");
     auto mnemonic = electrum::create_mnemonic(entropy);
     BOOST_REQUIRE(!mnemonic.empty());
     mnemonic[0] = "invalid";


### PR DESCRIPTION
Require dictionary for electrum mnemonic validation when specific dictionary is used to avoid ambiguous call when any dictionary can be checked

Lowercase electrum entropy test inputs

Add a non-english electrum mnemonic test