### PR TITLE
added new function to math/ called ec_sum. Adds a list of provided ec points together.

### DIFF
--- a/include/bitcoin/bitcoin/math/elliptic_curve.hpp
+++ b/include/bitcoin/bitcoin/math/elliptic_curve.hpp
@@ -105,6 +105,10 @@ BC_API bool ec_multiply(ec_uncompressed& point, const ec_secret& secret);
 /// return false on failure (such as a zero result).
 BC_API bool ec_multiply(ec_secret& left, const ec_secret& right);
 
+/// Compute the addition of EC curve points.
+/// return false on failure (such as infinity or zero).
+BC_API bool ec_sum(ec_compressed& result, const point_list& values);
+
 // Convert keys
 // ----------------------------------------------------------------------------
 

--- a/test/math/elliptic_curve.cpp
+++ b/test/math/elliptic_curve.cpp
@@ -21,6 +21,19 @@
 
 using namespace bc;
 
+const ec_compressed derive_generator_point()
+{
+    ec_compressed result;
+
+    ec_secret value_one;
+    std::fill(value_one.begin(), value_one.end(), 0);
+    value_one.back() = 1;
+
+    secret_to_public(result, value_one);
+
+    return result;
+}
+
 BOOST_AUTO_TEST_SUITE(elliptic_curve_tests)
 
 // Scenario 1
@@ -38,6 +51,9 @@ BOOST_AUTO_TEST_SUITE(elliptic_curve_tests)
 #define SIGHASH3 "f89572635651b2e4f89778350616989183c98d1a721c911324bf9f17a0cf5bf0"
 #define EC_SIGNATURE3 "4832febef8b31c7c922a15cb4063a43ab69b099bba765e24facef50dfbb4d057928ed5c6b6886562c2fe6972fd7c7f462e557129067542cce6b37d72e5ea5037"
 #define DER_SIGNATURE3 "3044022057d0b4fb0df5cefa245e76ba9b099bb63aa46340cb152a927c1cb3f8befe324802203750eae5727db3e6cc4275062971552e467f7cfd7269fec2626588b6c6d58e92"
+
+// EC_SUM
+#define GENERATOR_POINT_MULT_4 "02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13"
 
 BOOST_AUTO_TEST_CASE(elliptic_curve__secret_to_public__positive__test)
 {
@@ -170,6 +186,25 @@ BOOST_AUTO_TEST_CASE(elliptic_curve__ec_multiply_test)
     ec_compressed public2;
     BOOST_REQUIRE(secret_to_public(public2, secret1));
     BOOST_REQUIRE(std::equal(public1.begin(), public1.end(), public2.begin()));
+}
+
+BOOST_AUTO_TEST_CASE(elliptic_curve__ec_sum_test)
+{
+    const ec_compressed generator_point = derive_generator_point();
+
+    point_list points{
+        generator_point,
+        generator_point,
+        generator_point,
+        generator_point
+    };
+
+    bc::ec_compressed output;
+
+    bool rc = ec_sum(output, points);
+    BOOST_REQUIRE(rc);
+    BOOST_REQUIRE_EQUAL(encode_base16(output),
+        "02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/math/elliptic_curve.cpp
+++ b/test/math/elliptic_curve.cpp
@@ -203,8 +203,7 @@ BOOST_AUTO_TEST_CASE(elliptic_curve__ec_sum_test)
 
     bool rc = ec_sum(output, points);
     BOOST_REQUIRE(rc);
-    BOOST_REQUIRE_EQUAL(encode_base16(output),
-        "02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13");
+    BOOST_REQUIRE_EQUAL(encode_base16(output), GENERATOR_POINT_MULT_4);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Provided unit test.

Neccessary for modern privacy schemes which hide sharing amounts. They involve summing points from different curves together: A + B + C. This function provides that functionality.