### PR TITLE
[linux] log startup does not display local date/times. #788

### DIFF
--- a/include/bitcoin/bitcoin/utility/timer.hpp
+++ b/include/bitcoin/bitcoin/utility/timer.hpp
@@ -40,7 +40,7 @@ inline std::time_t zulu_time()
 /// Standard date-time string, e.g. Sun Oct 17 04:41:13 2010, locale dependent.
 inline std::string local_time()
 {
-    static BC_CONSTEXPR size_t size = 24;
+    static BC_CONSTEXPR size_t size = 25;
     char buffer[size];
     const auto time = zulu_time();
 


### PR DESCRIPTION
Changed buffer size to 25, to include the terminating null-character.