### PR TITLE
Avoid suppressing errors when converting json strings

### DIFF
--- a/include/bitcoin/bitcoin/utility/property_tree.hpp
+++ b/include/bitcoin/bitcoin/utility/property_tree.hpp
@@ -232,10 +232,11 @@ BC_API pt::ptree property_tree(uint64_t height, uint32_t sequence);
 /**
  * Create a property tree from a json-string.
  * @param[in]  json   A string containing json data.
- * @returns           A new property tree containing the json equivalent
- *                    fields. An empty property tree if the json is ill-formed.
+ * @param[out] out    A new property tree containing the json equivalent
+ *                    fields on success.
+ * @returns           True on success. False on error.
  */
-BC_API pt::ptree property_tree(const std::string& json);
+BC_API bool property_tree(pt::ptree& out, const std::string& json);
 
 } // namespace libbitcoin
 

--- a/src/utility/property_tree.cpp
+++ b/src/utility/property_tree.cpp
@@ -317,19 +317,18 @@ ptree property_tree(const std::error_code& code, uint32_t sequence)
 
 // safe json input parsing
 
-ptree property_tree(const std::string& json)
+bool property_tree(ptree& out, const std::string& json)
 {
-    ptree tree;
-    stream<array_source> json_stream(json.c_str(), json.size());
     try
     {
-        read_json(json_stream, tree);
+        stream<array_source> json_stream(json.c_str(), json.size());
+        read_json(json_stream, out);
+        return true;
     }
     catch (const std::exception& error)
     {
-        tree.clear();
     }
-    return tree;
+    return false;
 }
 
 } // namespace libbitcoin

--- a/test/utility/property_tree.cpp
+++ b/test/utility/property_tree.cpp
@@ -31,12 +31,12 @@ BOOST_AUTO_TEST_CASE(property_tree__property_tree__value__expected_json)
     {
         "{\"sequence\":\"101\",\"command\":\"query fetch-tx\",\"arguments\":\"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b\"}"
     };
-    const auto input = bc::property_tree(json);
-    BOOST_REQUIRE_EQUAL(input.get<uint32_t>("sequence"), 101u);
-    BOOST_REQUIRE_EQUAL(input.get<std::string>("command"),
-        std::string("query fetch-tx"));
-    BOOST_REQUIRE_EQUAL(input.get<std::string>("arguments"),
-        std::string("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+    boost::property_tree::ptree tree;
+    const auto result = bc::property_tree(tree, json);
+    BOOST_REQUIRE_EQUAL(result, true);
+    BOOST_REQUIRE_EQUAL(tree.get<uint32_t>("sequence"), 101u);
+    BOOST_REQUIRE_EQUAL(tree.get<std::string>("command"), std::string("query fetch-tx"));
+    BOOST_REQUIRE_EQUAL(tree.get<std::string>("arguments"), std::string("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 }
 
 BOOST_AUTO_TEST_CASE(property_tree__property_tree__value__expected_empty)
@@ -45,8 +45,9 @@ BOOST_AUTO_TEST_CASE(property_tree__property_tree__value__expected_empty)
     {
         "{\"sequence\":\"101\" \"arguments\";\"test\"}"
     };
-    const auto input = bc::property_tree(invalid_json);
-    BOOST_REQUIRE_EQUAL(input.empty(), true);
+    boost::property_tree::ptree tree;
+    const auto result = bc::property_tree(tree, invalid_json);
+    BOOST_REQUIRE_EQUAL(result, false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Avoid suppressing errors when converting json strings to property trees by returning a bool to indicate success/failure.