### PR TITLE
Parametrize timespan constants.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ src_libbitcoin_la_LDFLAGS = ${boost_LDFLAGS}
 src_libbitcoin_la_LIBADD = ${boost_chrono_LIBS} ${boost_date_time_LIBS} ${boost_filesystem_LIBS} ${boost_iostreams_LIBS} ${boost_locale_LIBS} ${boost_log_LIBS} ${boost_program_options_LIBS} ${boost_regex_LIBS} ${boost_system_LIBS} ${boost_thread_LIBS} ${pthread_LIBS} ${rt_LIBS} ${icu_i18n_LIBS} ${dl_LIBS} ${png_LIBS} ${qrencode_LIBS} ${secp256k1_LIBS}
 src_libbitcoin_la_SOURCES = \
     src/error.cpp \
+    src/settings.cpp \
     src/chain/block.cpp \
     src/chain/chain_state.cpp \
     src/chain/compact.cpp \
@@ -241,6 +242,7 @@ test_libbitcoin_test_LDFLAGS = ${boost_LDFLAGS}
 test_libbitcoin_test_LDADD = src/libbitcoin.la ${boost_unit_test_framework_LIBS} ${boost_chrono_LIBS} ${boost_date_time_LIBS} ${boost_filesystem_LIBS} ${boost_iostreams_LIBS} ${boost_locale_LIBS} ${boost_log_LIBS} ${boost_program_options_LIBS} ${boost_regex_LIBS} ${boost_system_LIBS} ${boost_thread_LIBS} ${pthread_LIBS} ${rt_LIBS} ${icu_i18n_LIBS} ${dl_LIBS} ${png_LIBS} ${qrencode_LIBS} ${secp256k1_LIBS}
 test_libbitcoin_test_SOURCES = \
     test/main.cpp \
+    test/settings.cpp \
     test/chain/block.cpp \
     test/chain/compact.cpp \
     test/chain/header.cpp \
@@ -363,6 +365,7 @@ include_bitcoin_bitcoin_HEADERS = \
     include/bitcoin/bitcoin/define.hpp \
     include/bitcoin/bitcoin/error.hpp \
     include/bitcoin/bitcoin/handlers.hpp \
+    include/bitcoin/bitcoin/settings.hpp \
     include/bitcoin/bitcoin/version.hpp
 
 include_bitcoin_bitcoin_chaindir = ${includedir}/bitcoin/bitcoin/chain

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -45,7 +45,7 @@ int bc::main(int argc, char* argv[])
 #endif
 
     // Extracting Satoshi's words from genesis block.
-    const auto block = bc::chain::block::genesis_mainnet();
+    const auto block = bc::chain::block::genesis_mainnet(bc::settings());
     const auto& coinbase = block.transactions().front();
     const auto& input = coinbase.inputs().front();
 	BITCOIN_ASSERT_MSG(input.script().size() > 2u, "unexpected genesis");

--- a/include/bitcoin/bitcoin/chain/block.hpp
+++ b/include/bitcoin/bitcoin/chain/block.hpp
@@ -66,7 +66,7 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
-    block();
+    block(const settings& settings);
 
     block(block&& other);
     block(const block& other);
@@ -87,9 +87,12 @@ public:
     // Deserialization.
     //-------------------------------------------------------------------------
 
-    static block factory(const data_chunk& data, bool witness=false);
-    static block factory(std::istream& stream, bool witness=false);
-    static block factory(reader& source, bool witness=false);
+    static block factory(const data_chunk& data, const settings& settings,
+        bool witness=false);
+    static block factory(std::istream& stream, const settings& settings,
+        bool witness=false);
+    static block factory(reader& source, const settings& settings,
+        bool witness=false);
 
     bool from_data(const data_chunk& data, bool witness=false);
     bool from_data(std::istream& stream, bool witness=false);
@@ -124,9 +127,9 @@ public:
     // Utilities.
     //-------------------------------------------------------------------------
 
-    static block genesis_mainnet();
-    static block genesis_testnet();
-    static block genesis_regtest();
+    static block genesis_mainnet(const settings& settings);
+    static block genesis_testnet(const settings& settings);
+    static block genesis_regtest(const settings& settings);
     static size_t locator_size(size_t top);
     static indexes locator_heights(size_t top);
 

--- a/include/bitcoin/bitcoin/chain/chain_state.hpp
+++ b/include/bitcoin/bitcoin/chain/chain_state.hpp
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <memory>
 #include <deque>
+#include <bitcoin/bitcoin/settings.hpp>
 #include <bitcoin/bitcoin/config/checkpoint.hpp>
 #include <bitcoin/bitcoin/constants.hpp>
 #include <bitcoin/bitcoin/define.hpp>
@@ -125,23 +126,25 @@ public:
 
     /// Checkpoints must be ordered by height with greatest at back.
     static map get_map(size_t height, const checkpoints& checkpoints,
-        uint32_t forks);
+        uint32_t forks, size_t retargeting_interval);
 
     static uint32_t signal_version(uint32_t forks);
 
     /// Create pool state from top chain top block state.
-    chain_state(const chain_state& top);
+    chain_state(const chain_state& top, const settings& settings);
 
     /// Create block state from tx pool chain state of same height.
-    chain_state(const chain_state& pool, const chain::block& block);
+    chain_state(const chain_state& pool, const chain::block& block,
+        const settings& settings);
 
     /// Create header state from header pool chain state of parent block.
-    chain_state(const chain_state& parent, const chain::header& header);
+    chain_state(const chain_state& parent, const chain::header& header,
+        const settings& settings);
 
     /// Checkpoints must be ordered by height with greatest at back.
     /// Forks and checkpoints must match those provided for map creation.
     chain_state(data&& values, const checkpoints& checkpoints, uint32_t forks,
-        uint32_t stale_seconds);
+        uint32_t stale_seconds, const settings& settings);
 
     /// Properties.
     const hash_digest& hash() const;
@@ -182,29 +185,40 @@ protected:
 
     static activations activation(const data& values, uint32_t forks);
     static uint32_t median_time_past(const data& values, uint32_t forks);
-    static uint32_t work_required(const data& values, uint32_t forks);
+    static uint32_t work_required(const data& values, uint32_t forks,
+        const settings& settings);
 
 private:
-    static size_t bits_count(size_t height, uint32_t forks);
+    static size_t bits_count(size_t height, uint32_t forks,
+        size_t retargeting_interval);
     static size_t version_count(size_t height, uint32_t forks);
     static size_t timestamp_count(size_t height, uint32_t forks);
-    static size_t retarget_height(size_t height, uint32_t forks);
+    static size_t retarget_height(size_t height, uint32_t forks,
+        size_t retargeting_interval);
     static size_t bip9_bit0_height(size_t height, uint32_t forks);
     static size_t bip9_bit1_height(size_t height, uint32_t forks);
 
-    static data to_pool(const chain_state& top);
+    static data to_pool(const chain_state& top, const settings& settings);
     static data to_block(const chain_state& pool, const block& block);
-    static data to_header(const chain_state& parent, const header& header);
+    data to_header(const chain_state& parent, const header& header,
+        const settings& settings);
 
-    static uint32_t work_required_retarget(const data& values);
-    static uint32_t retarget_timespan(const chain_state::data& values);
+    static uint32_t work_required_retarget(const data& values,
+        uint32_t retarget_proof_of_work_limit, uint32_t min_timespan,
+        uint32_t max_timespan, uint32_t target_timespan_seconds);
+    static uint32_t retarget_timespan(const chain_state::data& values,
+        uint32_t min_timespan, uint32_t max_timespan);
 
     // easy blocks
-    static uint32_t easy_work_required(const data& values);
-    static uint32_t easy_time_limit(const chain_state::data& values);
-    static bool is_retarget_or_non_limit(size_t height, uint32_t bits);
-    static bool is_retarget_height(size_t height);
-    static size_t retarget_distance(size_t height);
+    static uint32_t easy_work_required(const data& values,
+        size_t retargeting_interval, uint32_t retarget_proof_of_work_limit,
+        uint32_t easy_spacing_seconds);
+    static uint32_t easy_time_limit(const chain_state::data& values,
+        int64_t spacing);
+    static bool is_retarget_or_non_limit(size_t height, uint32_t bits,
+        size_t retargeting_interval, uint32_t retarget_proof_of_work_limit);
+    static bool is_retarget_height(size_t height, size_t retargeting_interval);
+    static size_t retarget_distance(size_t height, size_t retargeting_interval);
 
     // This is retained as an optimization for other constructions.
     // A similar height clone can be partially computed, reducing query cost.

--- a/include/bitcoin/bitcoin/chain/header.hpp
+++ b/include/bitcoin/bitcoin/chain/header.hpp
@@ -28,6 +28,7 @@
 #include <bitcoin/bitcoin/chain/chain_state.hpp>
 #include <bitcoin/bitcoin/define.hpp>
 #include <bitcoin/bitcoin/error.hpp>
+#include <bitcoin/bitcoin/settings.hpp>
 #include <bitcoin/bitcoin/math/hash.hpp>
 #include <bitcoin/bitcoin/utility/data.hpp>
 #include <bitcoin/bitcoin/utility/reader.hpp>
@@ -74,17 +75,17 @@ public:
     // Constructors.
     //-------------------------------------------------------------------------
 
-    header();
+    header(const settings& settings);
 
     header(header&& other);
     header(const header& other);
 
     header(uint32_t version, const hash_digest& previous_block_hash,
         const hash_digest& merkle, uint32_t timestamp, uint32_t bits,
-        uint32_t nonce);
+        uint32_t nonce, const settings& settings);
     header(uint32_t version, hash_digest&& previous_block_hash,
         hash_digest&& merkle, uint32_t timestamp, uint32_t bits,
-        uint32_t nonce);
+        uint32_t nonce, const settings& settings);
 
     // Operators.
     //-------------------------------------------------------------------------
@@ -98,12 +99,16 @@ public:
     // Deserialization.
     //-------------------------------------------------------------------------
 
-    static header factory(const data_chunk& data, bool wire=true);
-    static header factory(std::istream& stream, bool wire=true);
-    static header factory(reader& source, bool wire=true);
-    static header factory(reader& source, hash_digest&& hash, bool wire=true);
-    static header factory(reader& source, const hash_digest& hash,
+    static header factory(const data_chunk& data, const settings& settings,
         bool wire=true);
+    static header factory(std::istream& stream, const settings& settings,
+        bool wire=true);
+    static header factory(reader& source, const settings& settings,
+        bool wire=true);
+    static header factory(reader& source, hash_digest&& hash,
+        const settings& settings, bool wire=true);
+    static header factory(reader& source, const hash_digest& hash,
+        const settings& settings, bool wire=true);
 
     bool from_data(const data_chunk& data, bool wire=true);
     bool from_data(std::istream& stream, bool wire=true);
@@ -186,6 +191,7 @@ private:
     uint32_t timestamp_;
     uint32_t bits_;
     uint32_t nonce_;
+    const settings& settings_;
 };
 
 } // namespace chain

--- a/include/bitcoin/bitcoin/config/header.hpp
+++ b/include/bitcoin/bitcoin/config/header.hpp
@@ -38,13 +38,13 @@ public:
     /**
      * Default constructor.
      */
-    header();
+    header(const libbitcoin::settings& settings);
 
     /**
      * Initialization constructor.
      * @param[in]  hexcode  The value to initialize with.
      */
-    header(const std::string& hexcode);
+    header(const std::string& hexcode, const libbitcoin::settings& settings);
 
     /**
      * Initialization constructor.

--- a/include/bitcoin/bitcoin/constants.hpp
+++ b/include/bitcoin/bitcoin/constants.hpp
@@ -95,31 +95,6 @@ BC_CONSTEXPR uint32_t relative_locktime_mask = 0x0000ffff;
 BC_CONSTEXPR uint32_t relative_locktime_disabled = 0x80000000;
 BC_CONSTEXPR uint32_t relative_locktime_time_locked = 0x00400000;
 
-// Timespan constants.
-//-----------------------------------------------------------------------------
-
-BC_CONSTEXPR uint32_t retargeting_factor = 4;
-BC_CONSTEXPR uint32_t easy_spacing_seconds = 20 * 60;
-BC_CONSTEXPR uint32_t target_spacing_seconds = 10 * 60;
-BC_CONSTEXPR uint32_t target_timespan_seconds = 2 * 7 * 24 * 60 * 60;
-BC_CONSTEXPR uint32_t timestamp_future_seconds = 2 * 60 * 60;
-BC_CONSTEXPR uint32_t retarget_proof_of_work_limit = 0x1d00ffff;
-BC_CONSTEXPR uint32_t no_retarget_proof_of_work_limit = 0x207fffff;
-BC_CONSTFUNC uint32_t work_limit(bool retarget=true)
-{
-    return retarget ? retarget_proof_of_work_limit : no_retarget_proof_of_work_limit;
-}
-
-// The upper and lower bounds for the retargeting timespan.
-BC_CONSTEXPR uint32_t min_timespan =
-    target_timespan_seconds / retargeting_factor;
-BC_CONSTEXPR uint32_t max_timespan =
-    target_timespan_seconds * retargeting_factor;
-
-// The target number of blocks for 2 weeks of work (2016 blocks).
-BC_CONSTEXPR size_t retargeting_interval =
-    target_timespan_seconds / target_spacing_seconds;
-
 // Fork constants.
 //-----------------------------------------------------------------------------
 

--- a/include/bitcoin/bitcoin/message/block.hpp
+++ b/include/bitcoin/bitcoin/message/block.hpp
@@ -45,11 +45,14 @@ public:
     typedef std::shared_ptr<const_ptr_list> const_ptr_list_ptr;
     typedef std::shared_ptr<const const_ptr_list> const_ptr_list_const_ptr;
 
-    static block factory(uint32_t version, const data_chunk& data);
-    static block factory(uint32_t version, std::istream& stream);
-    static block factory(uint32_t version, reader& source);
+    static block factory(uint32_t version, const data_chunk& data,
+        const settings& settings);
+    static block factory(uint32_t version, std::istream& stream,
+        const settings& settings);
+    static block factory(uint32_t version, reader& source,
+        const settings& settings);
 
-    block();
+    block(const settings& settings);
 
     block(block&& other);
     block(const block& other);

--- a/include/bitcoin/bitcoin/message/compact_block.hpp
+++ b/include/bitcoin/bitcoin/message/compact_block.hpp
@@ -39,11 +39,14 @@ public:
     typedef mini_hash short_id;
     typedef mini_hash_list short_id_list;
 
-    static compact_block factory(uint32_t version, const data_chunk& data);
-    static compact_block factory(uint32_t version, std::istream& stream);
-    static compact_block factory(uint32_t version, reader& source);
+    static compact_block factory(uint32_t version, const data_chunk& data,
+        const settings& settings);
+    static compact_block factory(uint32_t version, std::istream& stream,
+        const settings& settings);
+    static compact_block factory(uint32_t version, reader& source,
+        const settings& settings);
 
-    compact_block();
+    compact_block(const settings& settings);
     compact_block(const chain::header& header, uint64_t nonce,
         const short_id_list& short_ids,
         const prefilled_transaction::list& transactions);
@@ -71,14 +74,16 @@ public:
     void set_transactions(const prefilled_transaction::list& value);
     void set_transactions(prefilled_transaction::list&& value);
 
-    bool from_data(uint32_t version, const data_chunk& data);
-    bool from_data(uint32_t version, std::istream& stream);
-    bool from_data(uint32_t version, reader& source);
+    bool from_data(uint32_t version, const data_chunk& data,
+        const settings& settings);
+    bool from_data(uint32_t version, std::istream& stream,
+        const settings& settings);
+    bool from_data(uint32_t version, reader& source, const settings& settings);
     data_chunk to_data(uint32_t version) const;
     void to_data(uint32_t version, std::ostream& stream) const;
     void to_data(uint32_t version, writer& sink) const;
     bool is_valid() const;
-    void reset();
+    void reset(const settings& settings);
     size_t serialized_size(uint32_t version) const;
 
     // This class is move assignable but not copy assignable.

--- a/include/bitcoin/bitcoin/message/header.hpp
+++ b/include/bitcoin/bitcoin/message/header.hpp
@@ -44,18 +44,21 @@ public:
     typedef std::shared_ptr<const_ptr_list> const_ptr_list_ptr;
     typedef std::shared_ptr<const const_ptr_list> const_ptr_list_const_ptr;
 
-    static header factory(uint32_t version, const data_chunk& data);
-    static header factory(uint32_t version, std::istream& stream);
-    static header factory(uint32_t version, reader& source);
+    static header factory(uint32_t version, const data_chunk& data,
+        const settings& settings);
+    static header factory(uint32_t version, std::istream& stream,
+        const settings& settings);
+    static header factory(uint32_t version, reader& source,
+        const settings& settings);
     static size_t satoshi_fixed_size(uint32_t version);
 
-    header();
+    header(const settings& settings);
     header(uint32_t version, const hash_digest& previous_block_hash,
         const hash_digest& merkle, uint32_t timestamp, uint32_t bits,
-        uint32_t nonce);
+        uint32_t nonce, const settings& settings);
     header(uint32_t version, hash_digest&& previous_block_hash,
         hash_digest&& merkle, uint32_t timestamp, uint32_t bits,
-        uint32_t nonce);
+        uint32_t nonce, const settings& settings);
     header(const chain::header& other);
     header(chain::header&& other);
     header(const header& other);

--- a/include/bitcoin/bitcoin/message/headers.hpp
+++ b/include/bitcoin/bitcoin/message/headers.hpp
@@ -42,9 +42,12 @@ public:
     typedef std::shared_ptr<headers> ptr;
     typedef std::shared_ptr<const headers> const_ptr;
 
-    static headers factory(uint32_t version, const data_chunk& data);
-    static headers factory(uint32_t version, std::istream& stream);
-    static headers factory(uint32_t version, reader& source);
+    static headers factory(uint32_t version, const data_chunk& data,
+        const settings& settings);
+    static headers factory(uint32_t version, std::istream& stream,
+        const settings& settings);
+    static headers factory(uint32_t version, reader& source,
+        const settings& settings);
 
     headers();
     headers(const header::list& values);
@@ -63,9 +66,11 @@ public:
     void to_inventory(inventory_vector::list& out,
         inventory::type_id type) const;
 
-    bool from_data(uint32_t version, const data_chunk& data);
-    bool from_data(uint32_t version, std::istream& stream);
-    bool from_data(uint32_t version, reader& source);
+    bool from_data(uint32_t version, const data_chunk& data,
+        const settings& settings);
+    bool from_data(uint32_t version, std::istream& stream,
+        const settings& settings);
+    bool from_data(uint32_t version, reader& source, const settings& settings);
     data_chunk to_data(uint32_t version) const;
     void to_data(uint32_t version, std::ostream& stream) const;
     void to_data(uint32_t version, writer& sink) const;

--- a/include/bitcoin/bitcoin/message/merkle_block.hpp
+++ b/include/bitcoin/bitcoin/message/merkle_block.hpp
@@ -39,11 +39,14 @@ public:
     typedef std::shared_ptr<merkle_block> ptr;
     typedef std::shared_ptr<const merkle_block> const_ptr;
 
-    static merkle_block factory(uint32_t version, const data_chunk& data);
-    static merkle_block factory(uint32_t version, std::istream& stream);
-    static merkle_block factory(uint32_t version, reader& source);
+    static merkle_block factory(uint32_t version, const data_chunk& data,
+        const settings& settings);
+    static merkle_block factory(uint32_t version, std::istream& stream,
+        const settings& settings);
+    static merkle_block factory(uint32_t version, reader& source,
+        const settings& settings);
 
-    merkle_block();
+    merkle_block(const settings& settings);
     merkle_block(const chain::header& header, size_t total_transactions,
         const hash_list& hashes, const data_chunk& flags);
     merkle_block(chain::header&& header, size_t total_transactions,
@@ -70,14 +73,16 @@ public:
     void set_flags(const data_chunk& value);
     void set_flags(data_chunk&& value);
 
-    bool from_data(uint32_t version, const data_chunk& data);
-    bool from_data(uint32_t version, std::istream& stream);
-    bool from_data(uint32_t version, reader& source);
+    bool from_data(uint32_t version, const data_chunk& data,
+        const settings& settings);
+    bool from_data(uint32_t version, std::istream& stream,
+        const settings& settings);
+    bool from_data(uint32_t version, reader& source, const settings& settings);
     data_chunk to_data(uint32_t version) const;
     void to_data(uint32_t version, std::ostream& stream) const;
     void to_data(uint32_t version, writer& sink) const;
     bool is_valid() const;
-    void reset();
+    void reset(const settings& settings);
     size_t serialized_size(uint32_t version) const;
 
     // This class is move assignable but not copy assignable.

--- a/include/bitcoin/bitcoin/settings.hpp
+++ b/include/bitcoin/bitcoin/settings.hpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2011-2018 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_SETTINGS_HPP
+#define LIBBITCOIN_SETTINGS_HPP
+
+#include <bitcoin/bitcoin/define.hpp>
+
+#include <cstdint>
+#include <cstddef>
+
+namespace libbitcoin {
+
+/// Common database configuration settings, properties not thread safe.
+class BC_API settings
+{
+public:
+    settings();
+
+    uint32_t work_limit(bool retarget=true) const;
+
+    uint32_t retargeting_factor;
+    uint32_t target_spacing_seconds;
+    uint32_t easy_spacing_seconds;
+    uint32_t timestamp_future_seconds;
+    uint32_t target_timespan_seconds;
+    uint32_t retarget_proof_of_work_limit;
+    uint32_t no_retarget_proof_of_work_limit;
+
+    // The upper and lower bounds for the retargeting timespan.
+    uint32_t min_timespan;
+    uint32_t max_timespan;
+
+    // The target number of blocks for 2 weeks of work (2016 blocks).
+    size_t retargeting_interval;
+};
+
+} // namespace libbitcoin
+
+#endif

--- a/src/chain/block.cpp
+++ b/src/chain/block.cpp
@@ -121,8 +121,8 @@ static const std::string encoded_regtest_genesis_block =
 // Constructors.
 //-----------------------------------------------------------------------------
 
-block::block()
-  : header_{},
+block::block(const settings& settings)
+  : header_(settings),
     metadata{}
 {
 }
@@ -199,25 +199,27 @@ bool block::operator!=(const block& other) const
 //-----------------------------------------------------------------------------
 
 // static
-block block::factory(const data_chunk& data, bool witness)
+block block::factory(const data_chunk& data, const settings& settings,
+    bool witness)
 {
-    block instance;
+    block instance(settings);
     instance.from_data(data, witness);
     return instance;
 }
 
 // static
-block block::factory(std::istream& stream, bool witness)
+block block::factory(std::istream& stream, const settings& settings,
+    bool witness)
 {
-    block instance;
+    block instance(settings);
     instance.from_data(stream, witness);
     return instance;
 }
 
 // static
-block block::factory(reader& source, bool witness)
+block block::factory(reader& source, const settings& settings, bool witness)
 {
-    block instance;
+    block instance(settings);
     instance.from_data(source, witness);
     return instance;
 }
@@ -435,11 +437,11 @@ hash_digest block::hash() const
 // Utilities.
 //-----------------------------------------------------------------------------
 
-chain::block block::genesis_mainnet()
+chain::block block::genesis_mainnet(const settings& settings)
 {
     data_chunk data;
     decode_base16(data, encoded_mainnet_genesis_block);
-    const auto genesis = chain::block::factory(data);
+    const auto genesis = chain::block::factory(data, settings);
 
     BITCOIN_ASSERT(genesis.is_valid());
     BITCOIN_ASSERT(genesis.transactions().size() == 1);
@@ -447,11 +449,11 @@ chain::block block::genesis_mainnet()
     return genesis;
 }
 
-chain::block block::genesis_testnet()
+chain::block block::genesis_testnet(const settings& settings)
 {
     data_chunk data;
     decode_base16(data, encoded_testnet_genesis_block);
-    const auto genesis = chain::block::factory(data);
+    const auto genesis = chain::block::factory(data, settings);
 
     BITCOIN_ASSERT(genesis.is_valid());
     BITCOIN_ASSERT(genesis.transactions().size() == 1);
@@ -459,11 +461,11 @@ chain::block block::genesis_testnet()
     return genesis;
 }
 
-chain::block block::genesis_regtest()
+chain::block block::genesis_regtest(const settings& settings)
 {
     data_chunk data;
     decode_base16(data, encoded_regtest_genesis_block);
-    const auto genesis = chain::block::factory(data);
+    const auto genesis = chain::block::factory(data, settings);
 
     BITCOIN_ASSERT(genesis.is_valid());
     BITCOIN_ASSERT(genesis.transactions().size() == 1);

--- a/src/config/header.cpp
+++ b/src/config/header.cpp
@@ -30,12 +30,13 @@ namespace config {
 
 using namespace boost::program_options;
 
-header::header()
-  : value_()
+header::header(const libbitcoin::settings& settings)
+  : value_(settings)
 {
 }
 
-header::header(const std::string& hexcode)
+header::header(const std::string& hexcode, const libbitcoin::settings& settings)
+  : value_(settings)
 {
     std::stringstream(hexcode) >> *this;
 }

--- a/src/message/block.cpp
+++ b/src/message/block.cpp
@@ -35,29 +35,32 @@ const std::string block::command = "block";
 const uint32_t block::version_minimum = version::level::minimum;
 const uint32_t block::version_maximum = version::level::maximum;
 
-block block::factory(uint32_t version, const data_chunk& data)
+block block::factory(uint32_t version, const data_chunk& data,
+    const settings& settings)
 {
-    block instance;
+    block instance(settings);
     instance.from_data(version, data);
     return instance;
 }
 
-block block::factory(uint32_t version, std::istream& stream)
+block block::factory(uint32_t version, std::istream& stream,
+    const settings& settings)
 {
-    block instance;
+    block instance(settings);
     instance.from_data(version, stream);
     return instance;
 }
 
-block block::factory(uint32_t version, reader& source)
+block block::factory(uint32_t version, reader& source,
+    const settings& settings)
 {
-    block instance;
+    block instance(settings);
     instance.from_data(version, source);
     return instance;
 }
 
-block::block()
-  : chain::block()
+block::block(const settings& settings)
+  : chain::block(settings)
 {
 }
 

--- a/src/message/compact_block.cpp
+++ b/src/message/compact_block.cpp
@@ -35,31 +35,31 @@ const uint32_t compact_block::version_minimum = version::level::bip152;
 const uint32_t compact_block::version_maximum = version::level::bip152;
 
 compact_block compact_block::factory(uint32_t version,
-    const data_chunk& data)
+    const data_chunk& data, const settings& settings)
 {
-    compact_block instance;
-    instance.from_data(version, data);
+    compact_block instance(settings);
+    instance.from_data(version, data, settings);
     return instance;
 }
 
 compact_block compact_block::factory(uint32_t version,
-    std::istream& stream)
+    std::istream& stream, const settings& settings)
 {
-    compact_block instance;
-    instance.from_data(version, stream);
+    compact_block instance(settings);
+    instance.from_data(version, stream, settings);
     return instance;
 }
 
 compact_block compact_block::factory(uint32_t version,
-    reader& source)
+    reader& source, const settings& settings)
 {
-    compact_block instance;
-    instance.from_data(version, source);
+    compact_block instance(settings);
+    instance.from_data(version, source, settings);
     return instance;
 }
 
-compact_block::compact_block()
-  : header_(), nonce_(0), short_ids_(), transactions_()
+compact_block::compact_block(const settings& settings)
+  : header_(settings), nonce_(0), short_ids_(), transactions_()
 {
 }
 
@@ -99,9 +99,9 @@ bool compact_block::is_valid() const
     return header_.is_valid() && !short_ids_.empty() && !transactions_.empty();
 }
 
-void compact_block::reset()
+void compact_block::reset(const settings& settings)
 {
-    header_ = chain::header{};
+    header_ = chain::header(settings);
     nonce_ = 0;
     short_ids_.clear();
     short_ids_.shrink_to_fit();
@@ -109,21 +109,24 @@ void compact_block::reset()
     transactions_.shrink_to_fit();
 }
 
-bool compact_block::from_data(uint32_t version, const data_chunk& data)
+bool compact_block::from_data(uint32_t version, const data_chunk& data,
+    const settings& settings)
 {
     data_source istream(data);
-    return from_data(version, istream);
+    return from_data(version, istream, settings);
 }
 
-bool compact_block::from_data(uint32_t version, std::istream& stream)
+bool compact_block::from_data(uint32_t version, std::istream& stream,
+    const settings& settings)
 {
     istream_reader source(stream);
-    return from_data(version, source);
+    return from_data(version, source, settings);
 }
 
-bool compact_block::from_data(uint32_t version, reader& source)
+bool compact_block::from_data(uint32_t version, reader& source,
+    const settings& settings)
 {
-    reset();
+    reset(settings);
 
     if (!header_.from_data(source))
         return false;
@@ -158,7 +161,7 @@ bool compact_block::from_data(uint32_t version, reader& source)
         source.invalidate();
 
     if (!source)
-        reset();
+        reset(settings);
 
     return source;
 }

--- a/src/message/header.cpp
+++ b/src/message/header.cpp
@@ -38,23 +38,26 @@ const std::string header::command = "headers";
 const uint32_t header::version_minimum = version::level::minimum;
 const uint32_t header::version_maximum = version::level::maximum;
 
-header header::factory(uint32_t version, const data_chunk& data)
+header header::factory(uint32_t version, const data_chunk& data,
+    const settings& settings)
 {
-    header instance;
+    header instance(settings);
     instance.from_data(version, data);
     return instance;
 }
 
-header header::factory(uint32_t version, std::istream& stream)
+header header::factory(uint32_t version, std::istream& stream,
+    const settings& settings)
 {
-    header instance;
+    header instance(settings);
     instance.from_data(version, stream);
     return instance;
 }
 
-header header::factory(uint32_t version, reader& source)
+header header::factory(uint32_t version, reader& source,
+    const settings& settings)
 {
-    header instance;
+    header instance(settings);
     instance.from_data(version, source);
     return instance;
 }
@@ -66,23 +69,24 @@ size_t header::satoshi_fixed_size(uint32_t version)
         (canonical ? 0 : message::variable_uint_size(0));
 }
 
-header::header()
-  : chain::header()
+header::header(const settings& settings)
+  : chain::header(settings)
 {
 }
 
 header::header(uint32_t version,
     const hash_digest& previous_block_hash, const hash_digest& merkle,
-    uint32_t timestamp, uint32_t bits, uint32_t nonce)
-  : chain::header(version, previous_block_hash, merkle, timestamp, bits, nonce)
+    uint32_t timestamp, uint32_t bits, uint32_t nonce, const settings& settings)
+  : chain::header(version, previous_block_hash, merkle, timestamp, bits, nonce,
+      settings)
 {
 }
 
 header::header(uint32_t version,
     hash_digest&& previous_block_hash, hash_digest&& merkle,
-    uint32_t timestamp, uint32_t bits, uint32_t nonce)
+    uint32_t timestamp, uint32_t bits, uint32_t nonce, const settings& settings)
   : chain::header(version, std::move(previous_block_hash), std::move(merkle),
-      timestamp, bits, nonce)
+      timestamp, bits, nonce, settings)
 {
 }
 

--- a/src/message/headers.cpp
+++ b/src/message/headers.cpp
@@ -41,26 +41,26 @@ const uint32_t headers::version_minimum = version::level::headers;
 const uint32_t headers::version_maximum = version::level::maximum;
 
 headers headers::factory(uint32_t version,
-    const data_chunk& data)
+    const data_chunk& data, const settings& settings)
 {
     headers instance;
-    instance.from_data(version, data);
+    instance.from_data(version, data, settings);
     return instance;
 }
 
 headers headers::factory(uint32_t version,
-    std::istream& stream)
+    std::istream& stream, const settings& settings)
 {
     headers instance;
-    instance.from_data(version, stream);
+    instance.from_data(version, stream, settings);
     return instance;
 }
 
 headers headers::factory(uint32_t version,
-    reader& source)
+    reader& source, const settings& settings)
 {
     headers instance;
-    instance.from_data(version, source);
+    instance.from_data(version, source, settings);
     return instance;
 }
 
@@ -106,19 +106,22 @@ void headers::reset()
     elements_.shrink_to_fit();
 }
 
-bool headers::from_data(uint32_t version, const data_chunk& data)
+bool headers::from_data(uint32_t version, const data_chunk& data,
+    const settings& settings)
 {
     data_source istream(data);
-    return from_data(version, istream);
+    return from_data(version, istream, settings);
 }
 
-bool headers::from_data(uint32_t version, std::istream& stream)
+bool headers::from_data(uint32_t version, std::istream& stream,
+    const settings& settings)
 {
     istream_reader source(stream);
-    return from_data(version, source);
+    return from_data(version, source, settings);
 }
 
-bool headers::from_data(uint32_t version, reader& source)
+bool headers::from_data(uint32_t version, reader& source,
+    const settings& settings)
 {
     reset();
 
@@ -128,7 +131,7 @@ bool headers::from_data(uint32_t version, reader& source)
     if (count > max_get_headers)
         source.invalidate();
     else
-        elements_.resize(count);
+        elements_.resize(count, header(settings));
 
     // Order is required.
     for (auto& element: elements_)

--- a/src/message/merkle_block.cpp
+++ b/src/message/merkle_block.cpp
@@ -37,31 +37,31 @@ const uint32_t merkle_block::version_minimum = version::level::bip37;
 const uint32_t merkle_block::version_maximum = version::level::maximum;
 
 merkle_block merkle_block::factory(uint32_t version,
-    const data_chunk& data)
+    const data_chunk& data, const settings& settings)
 {
-    merkle_block instance;
-    instance.from_data(version, data);
+    merkle_block instance(settings);
+    instance.from_data(version, data, settings);
     return instance;
 }
 
 merkle_block merkle_block::factory(uint32_t version,
-    std::istream& stream)
+    std::istream& stream, const settings& settings)
 {
-    merkle_block instance;
-    instance.from_data(version, stream);
+    merkle_block instance(settings);
+    instance.from_data(version, stream, settings);
     return instance;
 }
 
 merkle_block merkle_block::factory(uint32_t version,
-    reader& source)
+    reader& source, const settings& settings)
 {
-    merkle_block instance;
-    instance.from_data(version, source);
+    merkle_block instance(settings);
+    instance.from_data(version, source, settings);
     return instance;
 }
 
-merkle_block::merkle_block()
-  : header_(), total_transactions_(0), hashes_(), flags_()
+merkle_block::merkle_block(const settings& settings)
+  : header_(settings), total_transactions_(0), hashes_(), flags_()
 {
 }
 
@@ -106,9 +106,9 @@ bool merkle_block::is_valid() const
     return !hashes_.empty() || !flags_.empty() || header_.is_valid();
 }
 
-void merkle_block::reset()
+void merkle_block::reset(const settings& settings)
 {
-    header_ = chain::header{};
+    header_ = chain::header(settings);
     total_transactions_ = 0;
     hashes_.clear();
     hashes_.shrink_to_fit();
@@ -116,21 +116,24 @@ void merkle_block::reset()
     flags_.shrink_to_fit();
 }
 
-bool merkle_block::from_data(uint32_t version, const data_chunk& data)
+bool merkle_block::from_data(uint32_t version, const data_chunk& data,
+    const settings& settings)
 {
     data_source istream(data);
-    return from_data(version, istream);
+    return from_data(version, istream, settings);
 }
 
-bool merkle_block::from_data(uint32_t version, std::istream& stream)
+bool merkle_block::from_data(uint32_t version, std::istream& stream,
+    const settings& settings)
 {
     istream_reader source(stream);
-    return from_data(version, source);
+    return from_data(version, source, settings);
 }
 
-bool merkle_block::from_data(uint32_t version, reader& source)
+bool merkle_block::from_data(uint32_t version, reader& source,
+    const settings& settings)
 {
-    reset();
+    reset(settings);
 
     if (!header_.from_data(source))
         return false;
@@ -153,7 +156,7 @@ bool merkle_block::from_data(uint32_t version, reader& source)
         source.invalidate();
 
     if (!source)
-        reset();
+        reset(settings);
 
     return source;
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2011-2018 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <cstdint>
+#include <bitcoin/bitcoin/settings.hpp>
+
+namespace libbitcoin {
+
+// Common default values (no settings context).
+settings::settings()
+  : retargeting_factor(4),
+    target_spacing_seconds(10 * 60),
+    easy_spacing_seconds(20 * 60),
+    timestamp_future_seconds(2 * 60 * 60),
+    target_timespan_seconds(2 * 7 * 24 * 60 * 60),
+    retarget_proof_of_work_limit(0x1d00ffff),
+    no_retarget_proof_of_work_limit(0x207fffff),
+    min_timespan(target_timespan_seconds / retargeting_factor),
+    max_timespan(target_timespan_seconds * retargeting_factor),
+    retargeting_interval(target_timespan_seconds / target_spacing_seconds)
+{
+}
+
+uint32_t settings::work_limit(bool retarget) const
+{
+    return retarget ? retarget_proof_of_work_limit :
+        no_retarget_proof_of_work_limit;
+}
+
+} // namespace libbitcoin

--- a/test/chain/block.cpp
+++ b/test/chain/block.cpp
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(block__locator_heights__positive_backoff__returns_top_plus_
 
 BOOST_AUTO_TEST_CASE(block__constructor_1__always__invalid)
 {
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(!instance.is_valid());
 }
 
@@ -102,7 +102,8 @@ BOOST_AUTO_TEST_CASE(block__constructor_2__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -124,7 +125,8 @@ BOOST_AUTO_TEST_CASE(block__constructor_3__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -151,7 +153,8 @@ BOOST_AUTO_TEST_CASE(block__constructor_4__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -175,7 +178,8 @@ BOOST_AUTO_TEST_CASE(block__constructor_5__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -195,19 +199,19 @@ BOOST_AUTO_TEST_CASE(block__constructor_5__always__equals_params)
 
 BOOST_AUTO_TEST_CASE(block__hash__always__returns_header_hash)
 {
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(instance.header().hash() == instance.hash());
 }
 
 BOOST_AUTO_TEST_CASE(block__is_valid_merkle_root__uninitialized__returns_true)
 {
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(instance.is_valid_merkle_root());
 }
 
 BOOST_AUTO_TEST_CASE(block__is_valid_merkle_root__non_empty_tx_invalid_block__returns_false)
 {
-    chain::block instance;
+    chain::block instance(settings{});
     instance.set_transactions(chain::transaction::list{ chain::transaction{} });
     BOOST_REQUIRE(!instance.is_valid_merkle_root());
 }
@@ -238,7 +242,7 @@ BOOST_AUTO_TEST_CASE(block__is_valid_merkle_root__valid__returns_true)
         "f5349388ac00743ba40b0000001976a914eb675c349c474bec8dea2d79d12cff6f330"
         "ab48788ac00000000"));
 
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(instance.from_data(raw_block));
     BOOST_REQUIRE(instance.is_valid_merkle_root());
 }
@@ -248,7 +252,7 @@ BOOST_AUTO_TEST_SUITE(block_serialization_tests)
 BOOST_AUTO_TEST_CASE(block__from_data__insufficient_bytes__failure)
 {
     data_chunk data(10);
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(!instance.from_data(data));
     BOOST_REQUIRE(!instance.is_valid());
 }
@@ -262,14 +266,14 @@ BOOST_AUTO_TEST_CASE(block__from_data__insufficient_transaction_bytes__failure)
         "00000000000000000000000000000000000000000000ffffffff07049d8e2f1b"
         "0114ffffffff0100f2052a0100000043410437b36a7221bc977dce712728a954"));
 
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(!instance.from_data(data));
     BOOST_REQUIRE(!instance.is_valid());
 }
 
 BOOST_AUTO_TEST_CASE(block__genesis__mainnet__valid_structure)
 {
-    const auto genesis = bc::chain::block::genesis_mainnet();
+    const auto genesis = bc::chain::block::genesis_mainnet(settings());
     BOOST_REQUIRE(genesis.is_valid());
     BOOST_REQUIRE_EQUAL(genesis.transactions().size(), 1u);
     BOOST_REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
@@ -277,7 +281,7 @@ BOOST_AUTO_TEST_CASE(block__genesis__mainnet__valid_structure)
 
 BOOST_AUTO_TEST_CASE(block__genesis__testnet__valid_structure)
 {
-    const auto genesis = bc::chain::block::genesis_testnet();
+    const auto genesis = bc::chain::block::genesis_testnet(settings());
     BOOST_REQUIRE(genesis.is_valid());
     BOOST_REQUIRE_EQUAL(genesis.transactions().size(), 1u);
     BOOST_REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
@@ -285,7 +289,7 @@ BOOST_AUTO_TEST_CASE(block__genesis__testnet__valid_structure)
 
 BOOST_AUTO_TEST_CASE(block__genesis__regtest__valid_structure)
 {
-    const auto genesis = bc::chain::block::genesis_regtest();
+    const auto genesis = bc::chain::block::genesis_regtest(settings());
     BOOST_REQUIRE(genesis.is_valid());
     BOOST_REQUIRE_EQUAL(genesis.transactions().size(), 1u);
     BOOST_REQUIRE(genesis.header().merkle() == genesis.generate_merkle_root());
@@ -294,7 +298,7 @@ BOOST_AUTO_TEST_CASE(block__genesis__regtest__valid_structure)
 
 BOOST_AUTO_TEST_CASE(block__factory_1__genesis_mainnet__success)
 {
-    const auto genesis = bc::chain::block::genesis_mainnet();
+    const auto genesis = bc::chain::block::genesis_mainnet(settings());
     BOOST_REQUIRE_EQUAL(genesis.serialized_size(), 285u);
     BOOST_REQUIRE_EQUAL(genesis.header().serialized_size(), 80u);
 
@@ -303,7 +307,7 @@ BOOST_AUTO_TEST_CASE(block__factory_1__genesis_mainnet__success)
     BOOST_REQUIRE_EQUAL(raw_block.size(), 285u);
 
     // Reload genesis block.
-    const auto block = chain::block::factory(raw_block);
+    const auto block = chain::block::factory(raw_block, settings());
 
     BOOST_REQUIRE(block.is_valid());
     BOOST_REQUIRE(genesis.header() == block.header());
@@ -314,7 +318,7 @@ BOOST_AUTO_TEST_CASE(block__factory_1__genesis_mainnet__success)
 
 BOOST_AUTO_TEST_CASE(block__factory_2__genesis_mainnet__success)
 {
-    const auto genesis = bc::chain::block::genesis_mainnet();
+    const auto genesis = bc::chain::block::genesis_mainnet(settings());
     BOOST_REQUIRE_EQUAL(genesis.serialized_size(), 285u);
     BOOST_REQUIRE_EQUAL(genesis.header().serialized_size(), 80u);
 
@@ -324,7 +328,7 @@ BOOST_AUTO_TEST_CASE(block__factory_2__genesis_mainnet__success)
 
     // Reload genesis block.
     data_source stream(raw_block);
-    const auto block = chain::block::factory(stream);
+    const auto block = chain::block::factory(stream, settings());
 
     BOOST_REQUIRE(block.is_valid());
     BOOST_REQUIRE(genesis.header() == block.header());
@@ -335,7 +339,7 @@ BOOST_AUTO_TEST_CASE(block__factory_2__genesis_mainnet__success)
 
 BOOST_AUTO_TEST_CASE(block__factory_3__genesis_mainnet__success)
 {
-    const auto genesis = bc::chain::block::genesis_mainnet();
+    const auto genesis = bc::chain::block::genesis_mainnet(settings());
     BOOST_REQUIRE_EQUAL(genesis.serialized_size(), 285u);
     BOOST_REQUIRE_EQUAL(genesis.header().serialized_size(), 80u);
 
@@ -346,7 +350,7 @@ BOOST_AUTO_TEST_CASE(block__factory_3__genesis_mainnet__success)
     // Reload genesis block.
     data_source stream(raw_block);
     istream_reader reader(stream);
-    const auto block = chain::block::factory(reader);
+    const auto block = chain::block::factory(reader, settings());
 
     BOOST_REQUIRE(block.is_valid());
     BOOST_REQUIRE(genesis.header() == block.header());
@@ -361,7 +365,7 @@ BOOST_AUTO_TEST_SUITE(block_generate_merkle_root_tests)
 
 BOOST_AUTO_TEST_CASE(block__generate_merkle_root__block_with_zero_transactions__matches_null_hash)
 {
-    chain::block empty;
+    chain::block empty(settings{});
     BOOST_REQUIRE(empty.generate_merkle_root() == null_hash);
 }
 
@@ -393,7 +397,7 @@ BOOST_AUTO_TEST_CASE(block__generate_merkle_root__block_with_multiple_transactio
         "14b9a2c9700ff9519516b21af338d28d53ddf5349388ac00743ba40b00000019"
         "76a914eb675c349c474bec8dea2d79d12cff6f330ab48788ac00000000"));
 
-    chain::block block100k;
+    chain::block block100k(settings{});
     BOOST_REQUIRE(block100k.from_data(raw));
     BOOST_REQUIRE(block100k.is_valid());
 
@@ -413,7 +417,8 @@ BOOST_AUTO_TEST_CASE(block__header_accessor__always__returns_initialized_value)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -433,9 +438,10 @@ BOOST_AUTO_TEST_CASE(block__header_setter_1__roundtrip__success)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(header != instance.header());
     instance.set_header(header);
     BOOST_REQUIRE(header == instance.header());
@@ -448,12 +454,13 @@ BOOST_AUTO_TEST_CASE(block__header_setter_2__roundtrip__success)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     // This must be non-const.
     chain::header dup_header(header);
 
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(header != instance.header());
     instance.set_header(std::move(dup_header));
     BOOST_REQUIRE(header == instance.header());
@@ -466,7 +473,8 @@ BOOST_AUTO_TEST_CASE(block__transactions_accessor__always__returns_initialized_v
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -488,7 +496,7 @@ BOOST_AUTO_TEST_CASE(block__transactions_setter_1__roundtrip__success)
         chain::transaction(4, 16, {}, {})
     };
 
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(transactions != instance.transactions());
     instance.set_transactions(transactions);
     BOOST_REQUIRE(transactions == instance.transactions());
@@ -506,7 +514,7 @@ BOOST_AUTO_TEST_CASE(block__transactions_setter_2__roundtrip__success)
     // This must be non-const.
     chain::transaction::list dup_transactions(transactions);
 
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(transactions != instance.transactions());
     instance.set_transactions(std::move(dup_transactions));
     BOOST_REQUIRE(transactions == instance.transactions());
@@ -519,7 +527,8 @@ BOOST_AUTO_TEST_CASE(block__operator_assign_equals__always__matches_equivalent)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -532,7 +541,7 @@ BOOST_AUTO_TEST_CASE(block__operator_assign_equals__always__matches_equivalent)
     chain::block value(header, transactions);
 
     BOOST_REQUIRE(value.is_valid());
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(!instance.is_valid());
     instance = std::move(value);
     BOOST_REQUIRE(instance.is_valid());
@@ -548,7 +557,8 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_equals__duplicates__returns_true)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -567,7 +577,8 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_equals__differs__returns_false)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -575,7 +586,7 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_equals__differs__returns_false)
         });
 
 
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(!(instance == expected));
 }
 
@@ -587,7 +598,8 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_not_equals__duplicates__returns_fal
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -606,14 +618,15 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_not_equals__differs__returns_true)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
             chain::transaction(4, 16, {}, {})
         });
 
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(instance != expected);
 }
 
@@ -623,41 +636,41 @@ BOOST_AUTO_TEST_SUITE(block_is_distinct_transaction_set_tests)
 
 BOOST_AUTO_TEST_CASE(block__distinct_transactions__empty__true)
 {
-    chain::block value;
+    chain::block value(settings{});
     BOOST_REQUIRE(value.is_distinct_transaction_set());
 }
 
 BOOST_AUTO_TEST_CASE(validate_block__is_distinct_tx_set__single__true)
 {
-    chain::block value;
+    chain::block value(settings{});
     value.set_transactions({ { 1, 0, {}, {} } });
     BOOST_REQUIRE(value.is_distinct_transaction_set());
 }
 
 BOOST_AUTO_TEST_CASE(validate_block__is_distinct_tx_set__duplicate__false)
 {
-    chain::block value;
+    chain::block value(settings{});
     value.set_transactions({ { 1, 0, {}, {} }, { 1, 0, {}, {} } });
     BOOST_REQUIRE(!value.is_distinct_transaction_set());
 }
 
 BOOST_AUTO_TEST_CASE(validate_block__is_distinct_tx_set__distinct_by_version__true)
 {
-    chain::block value;
+    chain::block value(settings{});
     value.set_transactions({ { 1, 0, {}, {} }, { 2, 0, {}, {} }, { 3, 0, {}, {} } });
     BOOST_REQUIRE(value.is_distinct_transaction_set());
 }
 
 BOOST_AUTO_TEST_CASE(validate_block__is_distinct_tx_set__partialy_distinct_by_version__false)
 {
-    chain::block value;
+    chain::block value(settings{});
     value.set_transactions({ { 1, 0, {}, {} }, { 2, 0, {}, {} }, { 2, 0, {}, {} } });
     BOOST_REQUIRE(!value.is_distinct_transaction_set());
 }
 
 BOOST_AUTO_TEST_CASE(validate_block__is_distinct_tx_set__partialy_distinct_not_adjacent_by_version__false)
 {
-    chain::block value;
+    chain::block value(settings{});
     value.set_transactions({ { 1, 0, {}, {} }, { 2, 0, {}, {} }, { 1, 0, {}, {} } });
     BOOST_REQUIRE(!value.is_distinct_transaction_set());
 }
@@ -668,20 +681,20 @@ BOOST_AUTO_TEST_SUITE(block_is_forward_reference_tests)
 
 BOOST_AUTO_TEST_CASE(block__is_forward_reference__no_transactions__false)
 {
-    chain::block value;
+    chain::block value(settings{});
     BOOST_REQUIRE(!value.is_forward_reference());
 }
 
 BOOST_AUTO_TEST_CASE(block__is_forward_reference__multiple_empty_transactions__false)
 {
-    chain::block value;
+    chain::block value(settings{});
     value.set_transactions({ { 1, 0, {}, {} }, { 2, 0, {}, {} } });
     BOOST_REQUIRE(!value.is_forward_reference());
 }
 
 BOOST_AUTO_TEST_CASE(block__is_forward_reference__backward_reference__false)
 {
-    chain::block value;
+    chain::block value(settings{});
     chain::transaction before{ 2, 0, {}, {} };
     chain::transaction after{ 1, 0, { { { before.hash(), 0 }, {}, 0 } }, {} };
     value.set_transactions({ before, after });
@@ -690,14 +703,14 @@ BOOST_AUTO_TEST_CASE(block__is_forward_reference__backward_reference__false)
 
 BOOST_AUTO_TEST_CASE(block__is_forward_reference__duplicate_transactions__false)
 {
-    chain::block value;
+    chain::block value(settings{});
     value.set_transactions({ { 1, 0, {}, {} }, { 1, 0, {}, {} } });
     BOOST_REQUIRE(!value.is_forward_reference());
 }
 
 BOOST_AUTO_TEST_CASE(block__is_forward_reference__coinbase_and_multiple_empty_transactions__false)
 {
-    chain::block value;
+    chain::block value(settings{});
     chain::transaction coinbase{ 1, 0, { { { null_hash, chain::point::null_index }, {}, 0 } }, {} };
     value.set_transactions({ coinbase, { 2, 0, {}, {} }, { 3, 0, {}, {} } });
     BOOST_REQUIRE(!value.is_forward_reference());
@@ -705,7 +718,7 @@ BOOST_AUTO_TEST_CASE(block__is_forward_reference__coinbase_and_multiple_empty_tr
 
 BOOST_AUTO_TEST_CASE(block__is_forward_reference__forward_reference__true)
 {
-    chain::block value;
+    chain::block value(settings{});
     chain::transaction after{ 2, 0, {}, {} };
     chain::transaction before{ 1, 0, { { { after.hash(), 0 }, {}, 0 } }, {} };
     value.set_transactions({ before, after });

--- a/test/chain/compact.cpp
+++ b/test/chain/compact.cpp
@@ -46,12 +46,14 @@ static uint32_t factory(int32_t logical_exponent, bool negative, uint32_t mantis
 
 BOOST_AUTO_TEST_CASE(compact__constructor1__proof_of_work_limit__normalizes_unchanged)
 {
-    BOOST_REQUIRE_EQUAL(compact(retarget_proof_of_work_limit).normal(), retarget_proof_of_work_limit);
+    const auto pow_limit = settings().retarget_proof_of_work_limit;
+    BOOST_REQUIRE_EQUAL(compact(pow_limit).normal(), pow_limit);
 }
 
 BOOST_AUTO_TEST_CASE(compact__constructor1__no_retarget_proof_of_work_limit__normalizes_unchanged)
 {
-    BOOST_REQUIRE_EQUAL(compact(no_retarget_proof_of_work_limit).normal(), no_retarget_proof_of_work_limit);
+    const auto no_pow_limit = settings().no_retarget_proof_of_work_limit;
+    BOOST_REQUIRE_EQUAL(compact(no_pow_limit).normal(), no_pow_limit);
 }
 
 // constructor1/normal

--- a/test/chain/header.cpp
+++ b/test/chain/header.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_SUITE(chain_header_tests)
 
 BOOST_AUTO_TEST_CASE(header__constructor_1__always__initialized_invalid)
 {
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(!instance.is_valid());
 }
 
@@ -39,7 +39,8 @@ BOOST_AUTO_TEST_CASE(header__constructor_2__always__equals_params)
     const uint32_t bits = 6523454u;
     const uint32_t nonce = 68644u;
 
-    chain::header instance(version, previous, merkle, timestamp, bits, nonce);
+    chain::header instance(version, previous, merkle, timestamp, bits, nonce,
+        settings());
     BOOST_REQUIRE(instance.is_valid());
     BOOST_REQUIRE_EQUAL(version, instance.version());
     BOOST_REQUIRE_EQUAL(timestamp, instance.timestamp());
@@ -60,7 +61,8 @@ BOOST_AUTO_TEST_CASE(header__constructor_3__always__equals_params)
     auto previous = hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
     auto merkle = hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
 
-    chain::header instance(version, std::move(previous), std::move(merkle), timestamp, bits, nonce);
+    chain::header instance(version, std::move(previous), std::move(merkle),
+        timestamp, bits, nonce, settings());
     BOOST_REQUIRE(instance.is_valid());
     BOOST_REQUIRE_EQUAL(version, instance.version());
     BOOST_REQUIRE_EQUAL(timestamp, instance.timestamp());
@@ -78,7 +80,8 @@ BOOST_AUTO_TEST_CASE(header__constructor_4__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     chain::header instance(expected);
     BOOST_REQUIRE(instance.is_valid());
@@ -94,7 +97,8 @@ BOOST_AUTO_TEST_CASE(header__constructor_5__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     chain::header instance(std::move(expected));
     BOOST_REQUIRE(instance.is_valid());
@@ -105,7 +109,7 @@ BOOST_AUTO_TEST_CASE(header__from_data__insufficient_bytes__failure)
 {
     data_chunk data(10);
 
-    chain::header header;
+    chain::header header(settings{});
 
     BOOST_REQUIRE(!header.from_data(data));
     BOOST_REQUIRE(!header.is_valid());
@@ -120,12 +124,13 @@ BOOST_AUTO_TEST_CASE(header__factory_1__valid_input__success)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234,
         6523454,
-        68644
+        68644,
+        settings(),
     };
 
     const auto data = expected.to_data();
 
-    const auto result = chain::header::factory(data);
+    const auto result = chain::header::factory(data, settings());
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -140,13 +145,14 @@ BOOST_AUTO_TEST_CASE(header__factory_2__valid_input__success)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234,
         6523454,
-        68644
+        68644,
+        settings()
     };
 
     const auto data = expected.to_data();
     data_source istream(data);
 
-    const auto result = chain::header::factory(istream);
+    const auto result = chain::header::factory(istream, settings());
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -161,14 +167,15 @@ BOOST_AUTO_TEST_CASE(header__factory_3__valid_input__success)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234,
         6523454,
-        68644
+        68644,
+        settings()
     };
 
     const auto data = expected.to_data();
     data_source istream(data);
     istream_reader source(istream);
 
-    const auto result = chain::header::factory(source);
+    const auto result = chain::header::factory(source, settings());
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -183,7 +190,8 @@ BOOST_AUTO_TEST_CASE(header__version_accessor__always__returns_initialized_value
         hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
         753234u,
         4356344u,
-        34564u);
+        34564u,
+        settings());
 
     BOOST_REQUIRE_EQUAL(value, instance.version());
 }
@@ -191,7 +199,7 @@ BOOST_AUTO_TEST_CASE(header__version_accessor__always__returns_initialized_value
 BOOST_AUTO_TEST_CASE(header__version_setter__roundtrip__success)
 {
     uint32_t expected = 4521u;
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(expected != instance.version());
     instance.set_version(expected);
     BOOST_REQUIRE(expected == instance.version());
@@ -206,7 +214,8 @@ BOOST_AUTO_TEST_CASE(header__previous_block_hash_accessor_1__always__returns_ini
         hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
         753234u,
         4356344u,
-        34564u);
+        34564u,
+        settings());
 
     BOOST_REQUIRE(value == instance.previous_block_hash());
 }
@@ -220,7 +229,8 @@ BOOST_AUTO_TEST_CASE(header__previous_block_hash_accessor_2__always__returns_ini
         hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
         753234u,
         4356344u,
-        34564u);
+        34564u,
+        settings());
 
     BOOST_REQUIRE(value == instance.previous_block_hash());
 }
@@ -228,7 +238,7 @@ BOOST_AUTO_TEST_CASE(header__previous_block_hash_accessor_2__always__returns_ini
 BOOST_AUTO_TEST_CASE(header__previous_block_hash_setter_1__roundtrip__success)
 {
     const auto expected = hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe");
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(expected != instance.previous_block_hash());
     instance.set_previous_block_hash(expected);
     BOOST_REQUIRE(expected == instance.previous_block_hash());
@@ -241,7 +251,7 @@ BOOST_AUTO_TEST_CASE(header__previous_block_hash_setter_2__roundtrip__success)
     // This must be non-const.
     auto duplicate = expected;
 
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(expected != instance.previous_block_hash());
     instance.set_previous_block_hash(std::move(duplicate));
     BOOST_REQUIRE(expected == instance.previous_block_hash());
@@ -256,7 +266,8 @@ BOOST_AUTO_TEST_CASE(header__merkle_accessor_1__always__returns_initialized_valu
         value,
         753234u,
         4356344u,
-        34564u);
+        34564u,
+        settings());
 
     BOOST_REQUIRE(value == instance.merkle());
 }
@@ -270,7 +281,8 @@ BOOST_AUTO_TEST_CASE(header__merkle_accessor_2__always__returns_initialized_valu
         value,
         753234u,
         4356344u,
-        34564u);
+        34564u,
+        settings());
 
     BOOST_REQUIRE(value == instance.merkle());
 }
@@ -278,7 +290,7 @@ BOOST_AUTO_TEST_CASE(header__merkle_accessor_2__always__returns_initialized_valu
 BOOST_AUTO_TEST_CASE(header__merkle_setter_1__roundtrip__success)
 {
     const auto expected = hash_literal("abababababababababababababababababababababababababababababababab");
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(expected != instance.merkle());
     instance.set_merkle(expected);
     BOOST_REQUIRE(expected == instance.merkle());
@@ -291,7 +303,7 @@ BOOST_AUTO_TEST_CASE(header__merkle_setter_2__roundtrip__success)
     // This must be non-const.
     hash_digest duplicate = expected;
 
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(expected != instance.merkle());
     instance.set_merkle(std::move(duplicate));
     BOOST_REQUIRE(expected == instance.merkle());
@@ -306,7 +318,8 @@ BOOST_AUTO_TEST_CASE(header__timestamp_accessor__always__returns_initialized_val
         hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
         value,
         4356344u,
-        34564u);
+        34564u,
+        settings());
 
     BOOST_REQUIRE_EQUAL(value, instance.timestamp());
 }
@@ -314,7 +327,7 @@ BOOST_AUTO_TEST_CASE(header__timestamp_accessor__always__returns_initialized_val
 BOOST_AUTO_TEST_CASE(header__timestamp_setter__roundtrip__success)
 {
     uint32_t expected = 4521u;
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(expected != instance.timestamp());
     instance.set_timestamp(expected);
     BOOST_REQUIRE(expected == instance.timestamp());
@@ -329,7 +342,8 @@ BOOST_AUTO_TEST_CASE(header__bits_accessor__always__returns_initialized_value)
         hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
         753234u,
         value,
-        34564u);
+        34564u,
+        settings());
 
     BOOST_REQUIRE_EQUAL(value, instance.bits());
 }
@@ -337,7 +351,7 @@ BOOST_AUTO_TEST_CASE(header__bits_accessor__always__returns_initialized_value)
 BOOST_AUTO_TEST_CASE(header__bits_setter__roundtrip__success)
 {
     uint32_t expected = 4521u;
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(expected != instance.bits());
     instance.set_bits(expected);
     BOOST_REQUIRE(expected == instance.bits());
@@ -352,7 +366,8 @@ BOOST_AUTO_TEST_CASE(header__nonce_accessor__always__returns_initialized_value)
         hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
         753234u,
         4356344u,
-        value);
+        value,
+        settings());
 
     BOOST_REQUIRE_EQUAL(value, instance.nonce());
 }
@@ -360,7 +375,7 @@ BOOST_AUTO_TEST_CASE(header__nonce_accessor__always__returns_initialized_value)
 BOOST_AUTO_TEST_CASE(header__nonce_setter__roundtrip__success)
 {
     uint32_t expected = 4521u;
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(expected != instance.nonce());
     instance.set_nonce(expected);
     BOOST_REQUIRE(expected == instance.nonce());
@@ -368,7 +383,8 @@ BOOST_AUTO_TEST_CASE(header__nonce_setter__roundtrip__success)
 
 BOOST_AUTO_TEST_CASE(header__is_valid_timestamp__timestamp_less_than_2_hours_from_now__returns_true)
 {
-    chain::header instance;
+    const settings settings;
+    chain::header instance(settings);
     const auto now = std::chrono::system_clock::now();
     const auto now_time = std::chrono::system_clock::to_time_t(now);
     instance.set_timestamp(static_cast<uint32_t>(now_time));
@@ -377,7 +393,8 @@ BOOST_AUTO_TEST_CASE(header__is_valid_timestamp__timestamp_less_than_2_hours_fro
 
 BOOST_AUTO_TEST_CASE(header__is_valid_timestamp__timestamp_greater_than_2_hours_from_now__returns_false)
 {
-    chain::header instance;
+    const settings settings;
+    chain::header instance(settings);
     const auto now = std::chrono::system_clock::now();
     const auto duration = std::chrono::hours(3);
     const auto future = std::chrono::system_clock::to_time_t(now + duration);
@@ -387,15 +404,17 @@ BOOST_AUTO_TEST_CASE(header__is_valid_timestamp__timestamp_greater_than_2_hours_
 
 BOOST_AUTO_TEST_CASE(header__is_valid_proof_of_work__bits_exceeds_maximum__returns_false)
 {
-    chain::header instance;
-    instance.set_bits(retarget_proof_of_work_limit + 1);
+    const settings settings{};
+    chain::header instance(settings);
+    instance.set_bits(settings.retarget_proof_of_work_limit + 1);
     BOOST_REQUIRE(!instance.is_valid_proof_of_work(true));
 }
 
 BOOST_AUTO_TEST_CASE(header__is_valid_proof_of_work__no_retarget_bits_exceeds_maximum__returns_false)
 {
-    chain::header instance;
-    instance.set_bits(no_retarget_proof_of_work_limit + 1);
+    const settings settings{};
+    chain::header instance(settings);
+    instance.set_bits(settings.no_retarget_proof_of_work_limit + 1);
     BOOST_REQUIRE(!instance.is_valid_proof_of_work(false));
 }
 
@@ -407,7 +426,8 @@ BOOST_AUTO_TEST_CASE(header__is_valid_proof_of_work__hash_greater_bits__returns_
         hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
         753234u,
         0u,
-        34564u);
+        34564u,
+        settings());
 
     BOOST_REQUIRE(!instance.is_valid_proof_of_work(true));
 }
@@ -420,7 +440,8 @@ BOOST_AUTO_TEST_CASE(header__is_valid_proof_of_work__hash_less_than_bits__return
         hash_literal("a6cb0b0d6531a71abe2daaa4a991e5498e1b6b0b51549568d0f9d55329b905df"),
         1474388414u,
         402972254u,
-        2842832236u);
+        2842832236u,
+        settings());
 
     BOOST_REQUIRE(instance.is_valid_proof_of_work(true));
 }
@@ -432,7 +453,7 @@ BOOST_AUTO_TEST_CASE(header__proof1__genesis_mainnet__expected)
 
 BOOST_AUTO_TEST_CASE(header__proof2__genesis_mainnet__expected)
 {
-    const auto block = chain::block::genesis_mainnet();
+    const auto block = chain::block::genesis_mainnet(settings());
     BOOST_REQUIRE_EQUAL(block.header().proof(), 0x0000000100010001);
 }
 
@@ -445,11 +466,12 @@ BOOST_AUTO_TEST_CASE(header__operator_assign_equals__always__matches_equivalent)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     BOOST_REQUIRE(value.is_valid());
 
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(!instance.is_valid());
 
     instance = std::move(value);
@@ -464,7 +486,8 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_equals__duplicates__returns_true)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     chain::header instance(expected);
     BOOST_REQUIRE(instance == expected);
@@ -478,9 +501,10 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_equals__differs__returns_false)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE_EQUAL(false, instance == expected);
 }
 
@@ -492,7 +516,8 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_not_equals__duplicates__returns_fa
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     chain::header instance(expected);
     BOOST_REQUIRE_EQUAL(false, instance != expected);
@@ -506,9 +531,10 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_not_equals__differs__returns_true)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
-    chain::header instance;
+    chain::header instance(settings{});
     BOOST_REQUIRE(instance != expected);
 }
 

--- a/test/chain/satoshi_words.cpp
+++ b/test/chain/satoshi_words.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_SUITE(satoshi_words)
 BOOST_AUTO_TEST_CASE(satoshi_words_mainnet)
 {
     // Create mainnet genesis block (contains a single coinbase transaction).
-    const auto block = chain::block::genesis_mainnet();
+    const auto block = chain::block::genesis_mainnet(settings());
     const auto& transactions = block.transactions();
     BOOST_REQUIRE_EQUAL(transactions.size(), 1u);
 

--- a/test/message/block.cpp
+++ b/test/message/block.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_SUITE(message_block_tests)
 
 BOOST_AUTO_TEST_CASE(block__constructor_1__always__invalid)
 {
-    block instance;
+    block instance(settings{});
     BOOST_REQUIRE_EQUAL(false, instance.is_valid());
 }
 
@@ -37,7 +37,8 @@ BOOST_AUTO_TEST_CASE(block__constructor_2__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -59,7 +60,8 @@ BOOST_AUTO_TEST_CASE(block__constructor_3__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -84,7 +86,8 @@ BOOST_AUTO_TEST_CASE(block__constructor_4__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -108,7 +111,8 @@ BOOST_AUTO_TEST_CASE(block__constructor_5__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -131,7 +135,8 @@ BOOST_AUTO_TEST_CASE(block__constructor_6__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -155,7 +160,8 @@ BOOST_AUTO_TEST_CASE(block__constructor_7__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -173,7 +179,7 @@ BOOST_AUTO_TEST_CASE(block__constructor_7__always__equals_params)
 
 BOOST_AUTO_TEST_CASE(block__factory_data_1__genesis_mainnet__success)
 {
-    const auto genesis = chain::block::genesis_mainnet();
+    const auto genesis = chain::block::genesis_mainnet(settings());
     BOOST_REQUIRE_EQUAL(genesis.serialized_size(), 285u);
     BOOST_REQUIRE_EQUAL(genesis.header().serialized_size(), 80u);
 
@@ -182,7 +188,8 @@ BOOST_AUTO_TEST_CASE(block__factory_data_1__genesis_mainnet__success)
     BOOST_REQUIRE_EQUAL(raw_block.size(), 285u);
 
     // Reload genesis block.
-    const auto block = block::factory(version::level::minimum, raw_block);
+    const auto block = block::factory(version::level::minimum, raw_block,
+        settings());
 
     BOOST_REQUIRE(block.is_valid());
     BOOST_REQUIRE(genesis.header() == block.header());
@@ -197,7 +204,7 @@ BOOST_AUTO_TEST_CASE(block__factory_data_1__genesis_mainnet__success)
 
 BOOST_AUTO_TEST_CASE(block__factory_data_2__genesis_mainnet__success)
 {
-    const auto genesis = chain::block::genesis_mainnet();
+    const auto genesis = chain::block::genesis_mainnet(settings());
     BOOST_REQUIRE_EQUAL(genesis.serialized_size(), 285u);
     BOOST_REQUIRE_EQUAL(genesis.header().serialized_size(), 80u);
 
@@ -207,7 +214,8 @@ BOOST_AUTO_TEST_CASE(block__factory_data_2__genesis_mainnet__success)
 
     // Reload genesis block.
     data_source stream(raw_block);
-    const auto block = block::factory(version::level::minimum, stream);
+    const auto block = block::factory(version::level::minimum, stream,
+        settings());
 
     BOOST_REQUIRE(block.is_valid());
     BOOST_REQUIRE(genesis.header() == block.header());
@@ -225,7 +233,7 @@ BOOST_AUTO_TEST_CASE(block__factory_data_2__genesis_mainnet__success)
 
 BOOST_AUTO_TEST_CASE(block__factory_data_3__genesis_mainnet__success)
 {
-    const auto genesis = chain::block::genesis_mainnet();
+    const auto genesis = chain::block::genesis_mainnet(settings());
     BOOST_REQUIRE_EQUAL(genesis.serialized_size(), 285u);
     BOOST_REQUIRE_EQUAL(genesis.header().serialized_size(), 80u);
 
@@ -236,7 +244,8 @@ BOOST_AUTO_TEST_CASE(block__factory_data_3__genesis_mainnet__success)
     // Reload genesis block.
     data_source stream(raw_block);
     istream_reader reader(stream);
-    const auto block = block::factory(version::level::minimum + 1, reader);
+    const auto block = block::factory(version::level::minimum + 1, reader,
+        settings());
 
     BOOST_REQUIRE(block.is_valid());
     BOOST_REQUIRE(genesis.header() == block.header());
@@ -260,7 +269,8 @@ BOOST_AUTO_TEST_CASE(block__operator_assign_equals_1__always__matches_equivalent
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -272,7 +282,7 @@ BOOST_AUTO_TEST_CASE(block__operator_assign_equals_1__always__matches_equivalent
     chain::block value(header, transactions);
     BOOST_REQUIRE(value.is_valid());
 
-    message::block instance;
+    message::block instance(settings{});
     BOOST_REQUIRE_EQUAL(false, instance.is_valid());
 
     instance = std::move(value);
@@ -288,7 +298,8 @@ BOOST_AUTO_TEST_CASE(block__operator_assign_equals_2__always__matches_equivalent
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     const chain::transaction::list transactions
     {
@@ -301,7 +312,7 @@ BOOST_AUTO_TEST_CASE(block__operator_assign_equals_2__always__matches_equivalent
 
     BOOST_REQUIRE(value.is_valid());
 
-    message::block instance;
+    message::block instance(settings{});
     BOOST_REQUIRE_EQUAL(false, instance.is_valid());
 
     instance = std::move(value);
@@ -318,7 +329,8 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_equals_1__duplicates__returns_true)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -337,7 +349,8 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_equals_1__differs__returns_false)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -345,7 +358,7 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_equals_1__differs__returns_false)
         });
 
 
-    message::block instance;
+    message::block instance(settings{});
     BOOST_REQUIRE_EQUAL(false, instance == expected);
 }
 
@@ -357,7 +370,8 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_not_equals_1__duplicates__returns_f
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -376,7 +390,8 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_not_equals_1__differs__returns_true
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -384,7 +399,7 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_not_equals_1__differs__returns_true
         });
 
 
-    chain::block instance;
+    chain::block instance(settings{});
     BOOST_REQUIRE(instance != expected);
 }
 
@@ -396,7 +411,8 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_equals_2__duplicates__returns_true)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -415,7 +431,8 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_equals_2__differs__returns_false)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -423,7 +440,7 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_equals_2__differs__returns_false)
         });
 
 
-    message::block instance;
+    message::block instance(settings{});
     BOOST_REQUIRE_EQUAL(false, instance == expected);
 }
 
@@ -435,7 +452,8 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_not_equals_2__duplicates__returns_f
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -448,13 +466,15 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_not_equals_2__duplicates__returns_f
 
 BOOST_AUTO_TEST_CASE(block__operator_boolean_not_equals_2__differs__returns_true)
 {
+    const settings settings;
     const message::block expected(
         chain::header(10u,
             hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         {
             chain::transaction(1, 48, {}, {}),
             chain::transaction(2, 32, {}, {}),
@@ -462,7 +482,7 @@ BOOST_AUTO_TEST_CASE(block__operator_boolean_not_equals_2__differs__returns_true
         });
 
 
-    message::block instance;
+    message::block instance(settings);
     BOOST_REQUIRE(instance != expected);
 }
 

--- a/test/message/compact_block.cpp
+++ b/test/message/compact_block.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_SUITE(compact_block_tests)
 
 BOOST_AUTO_TEST_CASE(compact_block__constructor_1__always__invalid)
 {
-    message::compact_block instance;
+    message::compact_block instance(settings{});
     BOOST_REQUIRE_EQUAL(false, instance.is_valid());
 }
 
@@ -36,7 +36,8 @@ BOOST_AUTO_TEST_CASE(compact_block__constructor_2__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list& short_ids = {
@@ -67,7 +68,8 @@ BOOST_AUTO_TEST_CASE(compact_block__constructor_3__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
     chain::header dup_header(header);
 
     uint64_t nonce = 453245u;
@@ -103,7 +105,8 @@ BOOST_AUTO_TEST_CASE(compact_block__constructor_4__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list short_ids = {
@@ -137,7 +140,8 @@ BOOST_AUTO_TEST_CASE(compact_block__constructor_5__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list short_ids = {
@@ -165,9 +169,11 @@ BOOST_AUTO_TEST_CASE(compact_block__constructor_5__always__equals_params)
 
 BOOST_AUTO_TEST_CASE(compact_block__from_data__insufficient_bytes__failure)
 {
+    const settings settings;
     const data_chunk raw{ 0xab, 0xcd };
-    message::compact_block instance{};
-    BOOST_REQUIRE_EQUAL(false, instance.from_data(message::compact_block::version_minimum, raw));
+    message::compact_block instance(settings);
+    BOOST_REQUIRE_EQUAL(false, instance.from_data(
+        message::compact_block::version_minimum, raw, settings));
 }
 
 BOOST_AUTO_TEST_CASE(compact_block__from_data__insufficient_bytes_mid_transaction__failure)
@@ -178,8 +184,10 @@ BOOST_AUTO_TEST_CASE(compact_block__from_data__insufficient_bytes_mid_transactio
         "221b08003e8a6300240c0100d2040000000000000400000012121212121234343434"
         "3434565656565678789a9a02010000000100000000000001000000010000000"));
 
-    message::compact_block instance{};
-    BOOST_REQUIRE_EQUAL(false, instance.from_data(message::compact_block::version_minimum, raw));
+    const settings settings;
+    message::compact_block instance(settings);
+    BOOST_REQUIRE_EQUAL(false, instance.from_data(
+        message::compact_block::version_minimum, raw, settings));
 }
 
 BOOST_AUTO_TEST_CASE(compact_block__from_data__insufficient_version__failure)
@@ -190,14 +198,15 @@ BOOST_AUTO_TEST_CASE(compact_block__from_data__insufficient_version__failure)
         "221b08003e8a6300240c0100d2040000000000000400000012121212121234343434"
         "3434565656565678789a9a0201000000010000000000000100000001000000000000"));
 
-    message::compact_block expected;
-    expected.from_data(message::compact_block::version_minimum, raw);
+    const settings settings;
+    message::compact_block expected(settings);
+    expected.from_data(message::compact_block::version_minimum, raw, settings);
     const auto data = expected.to_data(message::compact_block::version_minimum);
     BOOST_REQUIRE(raw == data);
 
-    message::compact_block instance{};
+    message::compact_block instance(settings);
     BOOST_REQUIRE_EQUAL(false, instance.from_data(
-        message::compact_block::version_minimum - 1, data));
+        message::compact_block::version_minimum - 1, data, settings));
 }
 
 BOOST_AUTO_TEST_CASE(compact_block__factory_1__valid_input__success)
@@ -208,13 +217,14 @@ BOOST_AUTO_TEST_CASE(compact_block__factory_1__valid_input__success)
         "221b08003e8a6300240c0100d2040000000000000400000012121212121234343434"
         "3434565656565678789a9a0201000000010000000000000100000001000000000000"));
 
-    message::compact_block expected;
-    expected.from_data(message::compact_block::version_minimum, raw);
+    const settings settings;
+    message::compact_block expected(settings);
+    expected.from_data(message::compact_block::version_minimum, raw, settings);
     const auto data = expected.to_data(message::compact_block::version_minimum);
     BOOST_REQUIRE(raw == data);
 
     const auto result = message::compact_block::factory(
-        message::compact_block::version_minimum, data);
+        message::compact_block::version_minimum, data, settings);
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -233,14 +243,15 @@ BOOST_AUTO_TEST_CASE(compact_block__factory_2__valid_input__success)
         "221b08003e8a6300240c0100d2040000000000000400000012121212121234343434"
         "3434565656565678789a9a0201000000010000000000000100000001000000000000"));
 
-    message::compact_block expected;
-    expected.from_data(message::compact_block::version_minimum, raw);
+    const settings settings;
+    message::compact_block expected(settings);
+    expected.from_data(message::compact_block::version_minimum, raw, settings);
     const auto data = expected.to_data(message::compact_block::version_minimum);
     BOOST_REQUIRE(raw == data);
 
     data_source istream(data);
     auto result = message::compact_block::factory(
-        message::compact_block::version_minimum, istream);
+        message::compact_block::version_minimum, istream, settings);
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -259,15 +270,16 @@ BOOST_AUTO_TEST_CASE(compact_block__factory_3__valid_input__success)
         "221b08003e8a6300240c0100d2040000000000000400000012121212121234343434"
         "3434565656565678789a9a0201000000010000000000000100000001000000000000"));
 
-    message::compact_block expected;
-    expected.from_data(message::compact_block::version_minimum, raw);
+    const settings settings;
+    message::compact_block expected(settings);
+    expected.from_data(message::compact_block::version_minimum, raw, settings);
     const auto data = expected.to_data(message::compact_block::version_minimum);
     BOOST_REQUIRE(raw == data);
 
     data_source istream(data);
     istream_reader source(istream);
     const auto result = message::compact_block::factory(
-        message::compact_block::version_minimum, source);
+        message::compact_block::version_minimum, source, settings);
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -285,7 +297,8 @@ BOOST_AUTO_TEST_CASE(compact_block__header_accessor_1__always__returns_initializ
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list short_ids = {
@@ -312,7 +325,8 @@ BOOST_AUTO_TEST_CASE(compact_block__header_accessor_2__always__returns_initializ
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list short_ids = {
@@ -334,14 +348,16 @@ BOOST_AUTO_TEST_CASE(compact_block__header_accessor_2__always__returns_initializ
 
 BOOST_AUTO_TEST_CASE(compact_block__header_setter_1__roundtrip__success)
 {
+    const settings settings;
     const chain::header value(10u,
         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings);
 
-    message::compact_block instance;
+    message::compact_block instance(settings);
     BOOST_REQUIRE(value != instance.header());
     instance.set_header(value);
     BOOST_REQUIRE(value == instance.header());
@@ -349,15 +365,17 @@ BOOST_AUTO_TEST_CASE(compact_block__header_setter_1__roundtrip__success)
 
 BOOST_AUTO_TEST_CASE(compact_block__header_setter_2__roundtrip__success)
 {
+    const settings settings;
     const chain::header value(10u,
         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings);
     chain::header dup(value);
 
-    message::compact_block instance;
+    message::compact_block instance(settings);
     BOOST_REQUIRE(value != instance.header());
     instance.set_header(std::move(dup));
     BOOST_REQUIRE(value == instance.header());
@@ -370,7 +388,8 @@ BOOST_AUTO_TEST_CASE(compact_block__nonce_accessor__always__returns_initialized_
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list short_ids = {
@@ -394,7 +413,7 @@ BOOST_AUTO_TEST_CASE(compact_block__nonce_setter__roundtrip__success)
 {
     uint64_t value = 123356u;
 
-    message::compact_block instance;
+    message::compact_block instance(settings{});
     BOOST_REQUIRE(value != instance.nonce());
     instance.set_nonce(value);
     BOOST_REQUIRE(value == instance.nonce());
@@ -407,7 +426,8 @@ BOOST_AUTO_TEST_CASE(compact_block__short_ids_accessor_1__always__returns_initia
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list short_ids = {
@@ -434,7 +454,8 @@ BOOST_AUTO_TEST_CASE(compact_block__short_ids_accessor_2__always__returns_initia
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list short_ids = {
@@ -463,7 +484,7 @@ BOOST_AUTO_TEST_CASE(compact_block__short_ids_setter_1__roundtrip__success)
         base16_literal("f0f0f0f0f0f0")
     };
 
-    message::compact_block instance;
+    message::compact_block instance(settings{});
     BOOST_REQUIRE(value != instance.short_ids());
     instance.set_short_ids(value);
     BOOST_REQUIRE(value == instance.short_ids());
@@ -479,7 +500,7 @@ BOOST_AUTO_TEST_CASE(compact_block__short_ids_setter_2__roundtrip__success)
     };
     message::compact_block::short_id_list dup(value);
 
-    message::compact_block instance;
+    message::compact_block instance(settings{});
     BOOST_REQUIRE(value != instance.short_ids());
     instance.set_short_ids(std::move(dup));
     BOOST_REQUIRE(value == instance.short_ids());
@@ -492,7 +513,8 @@ BOOST_AUTO_TEST_CASE(compact_block__transactions_accessor_1__always__returns_ini
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list short_ids = {
@@ -519,7 +541,8 @@ BOOST_AUTO_TEST_CASE(compact_block__transactions_accessor_2__always__returns_ini
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list short_ids = {
@@ -547,7 +570,7 @@ BOOST_AUTO_TEST_CASE(compact_block__transactions_setter_1__roundtrip__success)
         message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))
     };
 
-    message::compact_block instance;
+    message::compact_block instance(settings{});
     BOOST_REQUIRE(value != instance.transactions());
     instance.set_transactions(value);
     BOOST_REQUIRE(value == instance.transactions());
@@ -562,7 +585,7 @@ BOOST_AUTO_TEST_CASE(compact_block__transactions_setter_2__roundtrip__success)
     };
     message::prefilled_transaction::list dup(value);
 
-    message::compact_block instance;
+    message::compact_block instance(settings{});
     BOOST_REQUIRE(value != instance.transactions());
     instance.set_transactions(std::move(dup));
     BOOST_REQUIRE(value == instance.transactions());
@@ -570,12 +593,14 @@ BOOST_AUTO_TEST_CASE(compact_block__transactions_setter_2__roundtrip__success)
 
 BOOST_AUTO_TEST_CASE(compact_block__operator_assign_equals__always__matches_equivalent)
 {
+    const settings settings;
     const chain::header header(10u,
         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings);
 
     uint64_t nonce = 453245u;
     const message::compact_block::short_id_list short_ids = {
@@ -593,7 +618,7 @@ BOOST_AUTO_TEST_CASE(compact_block__operator_assign_equals__always__matches_equi
 
     message::compact_block value(header, nonce, short_ids, transactions);
     BOOST_REQUIRE(value.is_valid());
-    message::compact_block instance;
+    message::compact_block instance(settings);
     BOOST_REQUIRE_EQUAL(false, instance.is_valid());
     instance = std::move(value);
     BOOST_REQUIRE(instance.is_valid());
@@ -611,7 +636,8 @@ BOOST_AUTO_TEST_CASE(compact_block__operator_boolean_equals__duplicates__returns
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         12334u,
         {
             base16_literal("aaaaaaaaaaaa"),
@@ -631,13 +657,15 @@ BOOST_AUTO_TEST_CASE(compact_block__operator_boolean_equals__duplicates__returns
 
 BOOST_AUTO_TEST_CASE(compact_block__operator_boolean_equals__differs__returns_false)
 {
+    const settings settings;
     const message::compact_block expected(
         chain::header(10u,
             hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         12334u,
         {
             base16_literal("aaaaaaaaaaaa"),
@@ -651,7 +679,7 @@ BOOST_AUTO_TEST_CASE(compact_block__operator_boolean_equals__differs__returns_fa
             message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))
         });
 
-    message::compact_block instance;
+    message::compact_block instance(settings);
     BOOST_REQUIRE_EQUAL(false, instance == expected);
 }
 
@@ -663,7 +691,8 @@ BOOST_AUTO_TEST_CASE(compact_block__operator_boolean_not_equals__duplicates__ret
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings()),
         12334u,
         {
             base16_literal("aaaaaaaaaaaa"),
@@ -683,13 +712,15 @@ BOOST_AUTO_TEST_CASE(compact_block__operator_boolean_not_equals__duplicates__ret
 
 BOOST_AUTO_TEST_CASE(compact_block__operator_boolean_not_equals__differs__returns_true)
 {
+    const settings settings;
     const message::compact_block expected(
         chain::header(10u,
             hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         12334u,
         {
             base16_literal("aaaaaaaaaaaa"),
@@ -703,7 +734,7 @@ BOOST_AUTO_TEST_CASE(compact_block__operator_boolean_not_equals__differs__return
             message::prefilled_transaction(30, chain::transaction(4, 16, {}, {}))
         });
 
-    message::compact_block instance;
+    message::compact_block instance(settings);
     BOOST_REQUIRE(instance != expected);
 }
 

--- a/test/message/header.cpp
+++ b/test/message/header.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_SUITE(message_header_tests)
 
 BOOST_AUTO_TEST_CASE(header__constructor_1__always__initialized_invalid)
 {
-    message::header instance;
+    message::header instance(settings{});
     BOOST_REQUIRE_EQUAL(false, instance.is_valid());
 }
 
@@ -38,7 +38,8 @@ BOOST_AUTO_TEST_CASE(header__constructor_2__always__equals_params)
     uint32_t bits = 6523454u;
     uint32_t nonce = 68644u;
 
-    message::header instance(version, previous, merkle, timestamp, bits, nonce);
+    message::header instance(version, previous, merkle, timestamp, bits, nonce,
+        settings());
     BOOST_REQUIRE(instance.is_valid());
     BOOST_REQUIRE_EQUAL(version, instance.version());
     BOOST_REQUIRE_EQUAL(timestamp, instance.timestamp());
@@ -57,7 +58,8 @@ BOOST_AUTO_TEST_CASE(header__constructor_3__always__equals_params)
     uint32_t bits = 6523454u;
     uint32_t nonce = 68644u;
 
-    message::header instance(version, std::move(previous), std::move(merkle), timestamp, bits, nonce);
+    message::header instance(version, std::move(previous), std::move(merkle),
+        timestamp, bits, nonce, settings());
     BOOST_REQUIRE(instance.is_valid());
     BOOST_REQUIRE_EQUAL(version, instance.version());
     BOOST_REQUIRE_EQUAL(timestamp, instance.timestamp());
@@ -75,7 +77,8 @@ BOOST_AUTO_TEST_CASE(header__constructor_4__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        1234u);
+        1234u,
+        settings());
 
     message::header instance(expected);
     BOOST_REQUIRE(instance.is_valid());
@@ -90,7 +93,8 @@ BOOST_AUTO_TEST_CASE(header__constructor_5__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        123u);
+        123u,
+        settings());
 
     message::header instance(std::move(expected));
     BOOST_REQUIRE(instance.is_valid());
@@ -105,7 +109,8 @@ BOOST_AUTO_TEST_CASE(header__constructor_6__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     message::header instance(expected);
     BOOST_REQUIRE(instance.is_valid());
@@ -120,7 +125,8 @@ BOOST_AUTO_TEST_CASE(header__constructor_7__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     message::header instance(std::move(expected));
     BOOST_REQUIRE(instance.is_valid());
@@ -130,7 +136,7 @@ BOOST_AUTO_TEST_CASE(header__constructor_7__always__equals_params)
 BOOST_AUTO_TEST_CASE(header__from_data__insufficient_bytes__failure)
 {
     data_chunk data(10);
-    message::header header;
+    message::header header(settings{});
     BOOST_REQUIRE_EQUAL(false, header.from_data(message::header::version_maximum, data));
     BOOST_REQUIRE_EQUAL(false, header.is_valid());
 }
@@ -138,6 +144,7 @@ BOOST_AUTO_TEST_CASE(header__from_data__insufficient_bytes__failure)
 BOOST_AUTO_TEST_CASE(header__factory_1__valid_input_canonical_version__no_transaction_count)
 {
     const auto version = message::version::level::canonical;
+    const settings settings;
     message::header expected
     {
         10u,
@@ -145,12 +152,13 @@ BOOST_AUTO_TEST_CASE(header__factory_1__valid_input_canonical_version__no_transa
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u
+        68644u,
+        settings
     };
 
     const auto data = expected.to_data(version);
 
-    const auto result = message::header::factory(version, data);
+    const auto result = message::header::factory(version, data, settings);
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -161,6 +169,7 @@ BOOST_AUTO_TEST_CASE(header__factory_1__valid_input_canonical_version__no_transa
 BOOST_AUTO_TEST_CASE(header__factory_1__valid_input__success)
 {
     const auto version = message::header::version_minimum;
+    const settings settings;
     message::header expected
     {
         10u,
@@ -168,12 +177,13 @@ BOOST_AUTO_TEST_CASE(header__factory_1__valid_input__success)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u
+        68644u,
+        settings
     };
 
     const auto data = expected.to_data(version);
 
-    const auto result = message::header::factory(version, data);
+    const auto result = message::header::factory(version, data, settings);
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -184,6 +194,7 @@ BOOST_AUTO_TEST_CASE(header__factory_1__valid_input__success)
 BOOST_AUTO_TEST_CASE(header__factory_2__valid_input__success)
 {
     const auto version = message::header::version_minimum;
+    const settings settings;
     message::header expected
     {
         10u,
@@ -191,13 +202,14 @@ BOOST_AUTO_TEST_CASE(header__factory_2__valid_input__success)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u
+        68644u,
+        settings
     };
 
     const auto data = expected.to_data(version);
     data_source istream(data);
 
-    const auto result = message::header::factory(version, istream);
+    const auto result = message::header::factory(version, istream, settings);
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -208,6 +220,7 @@ BOOST_AUTO_TEST_CASE(header__factory_2__valid_input__success)
 BOOST_AUTO_TEST_CASE(header__factory_3__valid_input__success)
 {
     const auto version = message::header::version_minimum;
+    const settings settings;
     message::header expected
     {
         10u,
@@ -215,14 +228,15 @@ BOOST_AUTO_TEST_CASE(header__factory_3__valid_input__success)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u
+        68644u,
+        settings
     };
 
     const auto data = expected.to_data(version);
     data_source istream(data);
     istream_reader source(istream);
 
-    const auto result = message::header::factory(version, source);
+    const auto result = message::header::factory(version, source, settings);
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -232,17 +246,19 @@ BOOST_AUTO_TEST_CASE(header__factory_3__valid_input__success)
 
 BOOST_AUTO_TEST_CASE(header__operator_assign_equals_1__always__matches_equivalent)
 {
+    const settings settings;
     chain::header value(
         10u,
         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings);
 
     BOOST_REQUIRE(value.is_valid());
 
-    message::header instance;
+    message::header instance(settings);
     BOOST_REQUIRE(!instance.is_valid());
 
     instance = std::move(value);
@@ -252,17 +268,19 @@ BOOST_AUTO_TEST_CASE(header__operator_assign_equals_1__always__matches_equivalen
 
 BOOST_AUTO_TEST_CASE(header__operator_assign_equals_2__always__matches_equivalent)
 {
+    const settings settings;
     message::header value(
         10u,
         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings);
 
     BOOST_REQUIRE(value.is_valid());
 
-    message::header instance;
+    message::header instance(settings);
     BOOST_REQUIRE(!instance.is_valid());
 
     instance = std::move(value);
@@ -278,7 +296,8 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_equals_1__duplicates__returns_true
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        3565u);
+        3565u,
+        settings());
 
     message::header instance(expected);
     BOOST_REQUIRE(instance == expected);
@@ -286,15 +305,17 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_equals_1__duplicates__returns_true
 
 BOOST_AUTO_TEST_CASE(header__operator_boolean_equals_1__differs__returns_false)
 {
+    const settings settings;
     const chain::header expected(
         10u,
         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         6523454u,
         68644u,
-        4453u);
+        4453u,
+        settings);
 
-    message::header instance;
+    message::header instance(settings);
     BOOST_REQUIRE_EQUAL(false, instance == expected);
 }
 
@@ -306,7 +327,8 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_not_equals_1__duplicates__returns_
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         6523454u,
         68644u,
-        2345u);
+        2345u,
+        settings());
 
     message::header instance(expected);
     BOOST_REQUIRE_EQUAL(false, instance != expected);
@@ -314,15 +336,17 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_not_equals_1__duplicates__returns_
 
 BOOST_AUTO_TEST_CASE(header__operator_boolean_not_equals_1__differs__returns_true)
 {
+    const settings settings;
     const chain::header expected(
         10u,
         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         68644u,
-        47476u);
+        47476u,
+        settings);
 
-    message::header instance;
+    message::header instance(settings);
     BOOST_REQUIRE(instance != expected);
 }
 
@@ -334,7 +358,8 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_equals_2__duplicates__returns_true
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     message::header instance(expected);
     BOOST_REQUIRE(instance == expected);
@@ -342,15 +367,17 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_equals_2__duplicates__returns_true
 
 BOOST_AUTO_TEST_CASE(header__operator_boolean_equals_2__differs__returns_false)
 {
+    const settings settings;
     const message::header expected(
         10u,
         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings);
 
-    message::header instance;
+    message::header instance(settings);
     BOOST_REQUIRE_EQUAL(false, instance == expected);
 }
 
@@ -362,7 +389,8 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_not_equals_2__duplicates__returns_
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings());
 
     message::header instance(expected);
     BOOST_REQUIRE_EQUAL(false, instance != expected);
@@ -370,15 +398,17 @@ BOOST_AUTO_TEST_CASE(header__operator_boolean_not_equals_2__duplicates__returns_
 
 BOOST_AUTO_TEST_CASE(header__operator_boolean_not_equals_2__differs__returns_true)
 {
+    const settings settings;
     const message::header expected(
         10u,
         hash_literal("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234u,
         6523454u,
-        68644u);
+        68644u,
+        settings);
 
-    message::header instance;
+    message::header instance(settings);
     BOOST_REQUIRE(instance != expected);
 }
 

--- a/test/message/headers.cpp
+++ b/test/message/headers.cpp
@@ -32,6 +32,7 @@ BOOST_AUTO_TEST_CASE(headers__constructor_1__always__initialized_invalid)
 
 BOOST_AUTO_TEST_CASE(headers__constructor_2__always__equals_params)
 {
+    const settings settings;
     const header::list expected
     {
         header(
@@ -40,14 +41,16 @@ BOOST_AUTO_TEST_CASE(headers__constructor_2__always__equals_params)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         header(
             11234u,
             hash_literal("abababababababababababababababababababababababababababababababab"),
             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
             753234u,
             4356344u,
-            34564u)
+            34564u,
+            settings)
     };
 
     headers instance(expected);
@@ -57,6 +60,7 @@ BOOST_AUTO_TEST_CASE(headers__constructor_2__always__equals_params)
 
 BOOST_AUTO_TEST_CASE(headers__constructor_3__always__equals_params)
 {
+    const settings settings;
     const header::list expected
     {
         header(
@@ -65,14 +69,16 @@ BOOST_AUTO_TEST_CASE(headers__constructor_3__always__equals_params)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         header(
             11234u,
             hash_literal("abababababababababababababababababababababababababababababababab"),
             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
             753234u,
             4356344u,
-            34564u)
+            34564u,
+            settings)
     };
 
     headers instance(std::move(expected));
@@ -82,6 +88,7 @@ BOOST_AUTO_TEST_CASE(headers__constructor_3__always__equals_params)
 
 BOOST_AUTO_TEST_CASE(headers__constructor_4__always__equals_params)
 {
+    const settings settings;
     headers instance(
     {
         header(
@@ -90,14 +97,16 @@ BOOST_AUTO_TEST_CASE(headers__constructor_4__always__equals_params)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         header(
             11234u,
             hash_literal("abababababababababababababababababababababababababababababababab"),
             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
             753234u,
             4356344u,
-            34564u)
+            34564u,
+            settings)
     });
 
     BOOST_REQUIRE(instance.is_valid());
@@ -106,6 +115,7 @@ BOOST_AUTO_TEST_CASE(headers__constructor_4__always__equals_params)
 
 BOOST_AUTO_TEST_CASE(headers__constructor_5__always__equals_params)
 {
+    const settings settings;
     const headers expected(
     {
         header(
@@ -114,14 +124,16 @@ BOOST_AUTO_TEST_CASE(headers__constructor_5__always__equals_params)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         header(
             11234u,
             hash_literal("abababababababababababababababababababababababababababababababab"),
             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
             753234u,
             4356344u,
-            34564u)
+            34564u,
+            settings)
     });
 
     headers instance(expected);
@@ -130,6 +142,7 @@ BOOST_AUTO_TEST_CASE(headers__constructor_5__always__equals_params)
 
 BOOST_AUTO_TEST_CASE(headers__constructor_6__always__equals_params)
 {
+    const settings settings;
     headers expected(
     {
         header(
@@ -138,7 +151,8 @@ BOOST_AUTO_TEST_CASE(headers__constructor_6__always__equals_params)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u
+            68644u,
+            settings
         ),
         header(
             11234u,
@@ -146,7 +160,8 @@ BOOST_AUTO_TEST_CASE(headers__constructor_6__always__equals_params)
             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
             753234u,
             4356344u,
-            34564u)
+            34564u,
+            settings)
     });
 
     headers instance(std::move(expected));
@@ -157,11 +172,13 @@ BOOST_AUTO_TEST_CASE(headers__from_data__insufficient_bytes__failure)
 {
     const data_chunk raw{ 0xab, 0xcd };
     headers instance{};
-    BOOST_REQUIRE_EQUAL(false, instance.from_data(headers::version_minimum, raw));
+    BOOST_REQUIRE_EQUAL(false, instance.from_data(headers::version_minimum, raw,
+        settings()));
 }
 
 BOOST_AUTO_TEST_CASE(headers__from_data__insufficient_version__failure)
 {
+    const settings settings;
     static const headers expected
     {
         {
@@ -170,17 +187,20 @@ BOOST_AUTO_TEST_CASE(headers__from_data__insufficient_version__failure)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings
         }
     };
 
     const data_chunk data = expected.to_data(headers::version_minimum);
     headers instance{};
-    BOOST_REQUIRE(!instance.from_data(headers::version_minimum - 1, data));
+    BOOST_REQUIRE(!instance.from_data(headers::version_minimum - 1, data,
+        settings));
 }
 
 BOOST_AUTO_TEST_CASE(headers__factory_1__valid_input__success)
 {
+    const settings settings;
     static const headers expected
     {
         {
@@ -189,13 +209,14 @@ BOOST_AUTO_TEST_CASE(headers__factory_1__valid_input__success)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings
         }
     };
 
     static const auto version = headers::version_minimum;
     const auto data = expected.to_data(version);
-    const auto result = headers::factory(version, data);
+    const auto result = headers::factory(version, data, settings);
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(result == expected);
     BOOST_REQUIRE_EQUAL(result.serialized_size(version), data.size());
@@ -204,6 +225,7 @@ BOOST_AUTO_TEST_CASE(headers__factory_1__valid_input__success)
 
 BOOST_AUTO_TEST_CASE(headers__factory_2__valid_input__success)
 {
+    const settings settings;
     static const headers expected
     {
         {
@@ -212,14 +234,15 @@ BOOST_AUTO_TEST_CASE(headers__factory_2__valid_input__success)
             hash_literal("4a5e1e4bbbccddee32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             542344,
             1247742,
-            34632
+            34632,
+            settings
         }
     };
 
     static const auto version = headers::version_minimum;
     const auto data = expected.to_data(version);
     data_source istream(data);
-    auto result = headers::factory(version, istream);
+    auto result = headers::factory(version, istream, settings);
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(result == expected);
     BOOST_REQUIRE_EQUAL(data.size(), result.serialized_size(version));
@@ -228,6 +251,7 @@ BOOST_AUTO_TEST_CASE(headers__factory_2__valid_input__success)
 
 BOOST_AUTO_TEST_CASE(headers__factory_3__valid_input__success)
 {
+    const settings settings;
     static const headers expected
     {
         {
@@ -236,7 +260,8 @@ BOOST_AUTO_TEST_CASE(headers__factory_3__valid_input__success)
             hash_literal("4321432143214321432143214321432143214321432143214321432143214321"),
             83221,
             4353212,
-            54234
+            54234,
+            settings
         }
     };
 
@@ -244,7 +269,7 @@ BOOST_AUTO_TEST_CASE(headers__factory_3__valid_input__success)
     const auto data = expected.to_data(version);
     data_source istream(data);
     istream_reader source(istream);
-    const auto result = headers::factory(version, source);
+    const auto result = headers::factory(version, source, settings);
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(result == expected);
     BOOST_REQUIRE_EQUAL(data.size(), result.serialized_size(version));
@@ -253,6 +278,7 @@ BOOST_AUTO_TEST_CASE(headers__factory_3__valid_input__success)
 
 BOOST_AUTO_TEST_CASE(headers__elements_accessor_1__always__returns_initialized_value)
 {
+    const settings settings;
     const header::list expected
     {
         header(
@@ -261,14 +287,16 @@ BOOST_AUTO_TEST_CASE(headers__elements_accessor_1__always__returns_initialized_v
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         header(
             11234u,
             hash_literal("abababababababababababababababababababababababababababababababab"),
             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
             753234u,
             4356344u,
-            34564u)
+            34564u,
+            settings)
     };
 
     message::headers instance(expected);
@@ -277,6 +305,7 @@ BOOST_AUTO_TEST_CASE(headers__elements_accessor_1__always__returns_initialized_v
 
 BOOST_AUTO_TEST_CASE(headers__elements_accessor_2__always__returns_initialized_value)
 {
+    const settings settings;
     const header::list expected
     {
         header(
@@ -285,14 +314,16 @@ BOOST_AUTO_TEST_CASE(headers__elements_accessor_2__always__returns_initialized_v
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         header(
             11234u,
             hash_literal("abababababababababababababababababababababababababababababababab"),
             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
             753234u,
             4356344u,
-            34564u)
+            34564u,
+            settings)
     };
 
     const message::headers instance(expected);
@@ -301,6 +332,7 @@ BOOST_AUTO_TEST_CASE(headers__elements_accessor_2__always__returns_initialized_v
 
 BOOST_AUTO_TEST_CASE(headers__command_setter_1__roundtrip__success)
 {
+    const settings settings;
     const header::list expected
     {
         header(
@@ -309,14 +341,16 @@ BOOST_AUTO_TEST_CASE(headers__command_setter_1__roundtrip__success)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         header(
             11234u,
             hash_literal("abababababababababababababababababababababababababababababababab"),
             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
             753234u,
             4356344u,
-            34564u)
+            34564u,
+            settings)
     };
 
     message::headers instance;
@@ -327,6 +361,7 @@ BOOST_AUTO_TEST_CASE(headers__command_setter_1__roundtrip__success)
 
 BOOST_AUTO_TEST_CASE(headers__command_setter_2__roundtrip__success)
 {
+    const settings settings;
     header::list values
     {
         header(
@@ -335,14 +370,16 @@ BOOST_AUTO_TEST_CASE(headers__command_setter_2__roundtrip__success)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234u,
             6523454u,
-            68644u),
+            68644u,
+            settings),
         header(
             11234u,
             hash_literal("abababababababababababababababababababababababababababababababab"),
             hash_literal("fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe"),
             753234u,
             4356344u,
-            34564u)
+            34564u,
+            settings)
     };
 
     message::headers instance;
@@ -353,6 +390,7 @@ BOOST_AUTO_TEST_CASE(headers__command_setter_2__roundtrip__success)
 
 BOOST_AUTO_TEST_CASE(headers__operator_assign_equals__always__matches_equivalent)
 {
+    const settings settings;
     message::headers value(
     {
         header
@@ -362,7 +400,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_assign_equals__always__matches_equivalent
             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
             10u,
             100u,
-            1000u
+            1000u,
+            settings
         },
         header
         {
@@ -371,7 +410,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_assign_equals__always__matches_equivalent
             hash_literal("babababababababababababababababababababababababababababababababa"),
             20u,
             200u,
-            2000u
+            2000u,
+            settings
         },
         header
         {
@@ -380,7 +420,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_assign_equals__always__matches_equivalent
             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
             30u,
             300u,
-            3000u
+            3000u,
+            settings
         }
     });
 
@@ -393,6 +434,7 @@ BOOST_AUTO_TEST_CASE(headers__operator_assign_equals__always__matches_equivalent
 
 BOOST_AUTO_TEST_CASE(headers__operator_boolean_equals__duplicates__returns_true)
 {
+    const settings settings;
     const message::headers expected(
     {
         header
@@ -402,7 +444,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_equals__duplicates__returns_true)
             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
             10u,
             100u,
-            1000u
+            1000u,
+            settings
         },
         header
         {
@@ -411,7 +454,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_equals__duplicates__returns_true)
             hash_literal("babababababababababababababababababababababababababababababababa"),
             20u,
             200u,
-            2000u
+            2000u,
+            settings
         },
         header
         {
@@ -420,7 +464,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_equals__duplicates__returns_true)
             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
             30u,
             300u,
-            3000u
+            3000u,
+            settings
         }
     });
 
@@ -430,6 +475,7 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_equals__duplicates__returns_true)
 
 BOOST_AUTO_TEST_CASE(headers__operator_boolean_equals__differs__returns_false)
 {
+    const settings settings;
     const message::headers expected(
     {
         header
@@ -439,7 +485,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_equals__differs__returns_false)
             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
             10u,
             100u,
-            1000u
+            1000u,
+            settings
         },
         header
         {
@@ -448,7 +495,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_equals__differs__returns_false)
             hash_literal("babababababababababababababababababababababababababababababababa"),
             20u,
             200u,
-            2000u
+            2000u,
+            settings
         },
         header
         {
@@ -457,7 +505,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_equals__differs__returns_false)
             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
             30u,
             300u,
-            3000u
+            3000u,
+            settings
         }
     });
 
@@ -467,6 +516,7 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_equals__differs__returns_false)
 
 BOOST_AUTO_TEST_CASE(headers__operator_boolean_not_equals__duplicates__returns_false)
 {
+    const settings settings;
     const message::headers expected(
     {
         header
@@ -476,7 +526,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_not_equals__duplicates__returns_f
             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
             10u,
             100u,
-            1000u
+            1000u,
+            settings
         },
         header
         {
@@ -485,7 +536,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_not_equals__duplicates__returns_f
             hash_literal("babababababababababababababababababababababababababababababababa"),
             20u,
             200u,
-            2000u
+            2000u,
+            settings
         },
         header
         {
@@ -494,7 +546,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_not_equals__duplicates__returns_f
             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
             30u,
             300u,
-            3000u
+            3000u,
+            settings
         }
     });
 
@@ -504,6 +557,7 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_not_equals__duplicates__returns_f
 
 BOOST_AUTO_TEST_CASE(headers__operator_boolean_not_equals__differs__returns_true)
 {
+    const settings settings;
     const message::headers expected(
     {
         header
@@ -513,7 +567,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_not_equals__differs__returns_true
             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
             10u,
             100u,
-            1000u
+            1000u,
+            settings
         },
         header
         {
@@ -522,7 +577,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_not_equals__differs__returns_true
             hash_literal("babababababababababababababababababababababababababababababababa"),
             20u,
             200u,
-            2000u
+            2000u,
+            settings
         },
         header
         {
@@ -531,7 +587,8 @@ BOOST_AUTO_TEST_CASE(headers__operator_boolean_not_equals__differs__returns_true
             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
             30u,
             300u,
-            3000u
+            3000u,
+            settings
         }
     });
 
@@ -556,6 +613,7 @@ BOOST_AUTO_TEST_CASE(headers__to_hashes__non_empty__returns_header_hash_list)
         hash_literal("d9bbb4b47ca45ec8477cba125262b07b17daae944b54d1780e0a6373d2eed879")
     };
 
+    const settings settings;
     const message::headers instance(
     {
         header
@@ -565,7 +623,8 @@ BOOST_AUTO_TEST_CASE(headers__to_hashes__non_empty__returns_header_hash_list)
             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
             10u,
             100u,
-            1000u
+            1000u,
+            settings
         },
         header
         {
@@ -574,7 +633,8 @@ BOOST_AUTO_TEST_CASE(headers__to_hashes__non_empty__returns_header_hash_list)
             hash_literal("babababababababababababababababababababababababababababababababa"),
             20u,
             200u,
-            2000u
+            2000u,
+            settings
         },
         header
         {
@@ -583,7 +643,8 @@ BOOST_AUTO_TEST_CASE(headers__to_hashes__non_empty__returns_header_hash_list)
             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
             30u,
             300u,
-            3000u
+            3000u,
+            settings
         }
     });
 
@@ -610,6 +671,7 @@ BOOST_AUTO_TEST_CASE(headers__to_inventory__non_empty__returns_header_hash_inven
         inventory_vector(inventory_vector::type_id::block, hash_literal("d9bbb4b47ca45ec8477cba125262b07b17daae944b54d1780e0a6373d2eed879"))
     };
 
+    const settings settings;
     const headers instance(
     {
         header
@@ -619,7 +681,8 @@ BOOST_AUTO_TEST_CASE(headers__to_inventory__non_empty__returns_header_hash_inven
             hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
             10u,
             100u,
-            1000u
+            1000u,
+            settings
         },
         header
         {
@@ -628,7 +691,8 @@ BOOST_AUTO_TEST_CASE(headers__to_inventory__non_empty__returns_header_hash_inven
             hash_literal("babababababababababababababababababababababababababababababababa"),
             20u,
             200u,
-            2000u
+            2000u,
+            settings
         },
         header
         {
@@ -637,7 +701,8 @@ BOOST_AUTO_TEST_CASE(headers__to_inventory__non_empty__returns_header_hash_inven
             hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
             30u,
             300u,
-            3000u
+            3000u,
+            settings
         }
     });
 
@@ -656,6 +721,7 @@ BOOST_AUTO_TEST_CASE(headers__is_sequential__empty__true)
 
 BOOST_AUTO_TEST_CASE(headers__is_sequential__single__true)
 {
+    const settings settings;
     static const header first
     {
         1u,
@@ -663,7 +729,8 @@ BOOST_AUTO_TEST_CASE(headers__is_sequential__single__true)
         hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
         10u,
         100u,
-        1000u
+        1000u,
+        settings
     };
 
     const headers instance({ first });
@@ -672,6 +739,7 @@ BOOST_AUTO_TEST_CASE(headers__is_sequential__single__true)
 
 BOOST_AUTO_TEST_CASE(headers__is_sequential__sequential__true)
 {
+    const settings settings;
     static const header first
     {
         1u,
@@ -679,7 +747,8 @@ BOOST_AUTO_TEST_CASE(headers__is_sequential__sequential__true)
         hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
         10u,
         100u,
-        1000u
+        1000u,
+        settings
     };
 
     static const header second
@@ -689,7 +758,8 @@ BOOST_AUTO_TEST_CASE(headers__is_sequential__sequential__true)
         hash_literal("babababababababababababababababababababababababababababababababa"),
         20u,
         200u,
-        2000u
+        2000u,
+        settings
     };
 
     static const header third
@@ -699,7 +769,8 @@ BOOST_AUTO_TEST_CASE(headers__is_sequential__sequential__true)
         hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
         30u,
         300u,
-        3000u
+        3000u,
+        settings
     };
 
     const headers instance({ first, second, third });
@@ -708,6 +779,7 @@ BOOST_AUTO_TEST_CASE(headers__is_sequential__sequential__true)
 
 BOOST_AUTO_TEST_CASE(headers__is_sequential__disordered__false)
 {
+    const settings settings;
     static const header first
     {
         1u,
@@ -715,7 +787,8 @@ BOOST_AUTO_TEST_CASE(headers__is_sequential__disordered__false)
         hash_literal("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"),
         10u,
         100u,
-        1000u
+        1000u,
+        settings
     };
 
     static const header second
@@ -725,7 +798,8 @@ BOOST_AUTO_TEST_CASE(headers__is_sequential__disordered__false)
         hash_literal("babababababababababababababababababababababababababababababababa"),
         20u,
         200u,
-        2000u
+        2000u,
+        settings
     };
 
     static const header third
@@ -735,7 +809,8 @@ BOOST_AUTO_TEST_CASE(headers__is_sequential__disordered__false)
         hash_literal("7373737373737373737373737373737373737373737373737373737373737373"),
         30u,
         300u,
-        3000u
+        3000u,
+        settings
     };
 
     const headers instance({ first, second, third });

--- a/test/message/merkle_block.cpp
+++ b/test/message/merkle_block.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_SUITE(merkle_block_tests)
 
 BOOST_AUTO_TEST_CASE(merkle_block__constructor_1__always__invalid)
 {
-    const message::merkle_block instance;
+    const message::merkle_block instance(settings{});
     BOOST_REQUIRE(!instance.is_valid());
 }
 
@@ -37,7 +37,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__constructor_2__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234,
         6523454,
-        68644
+        68644,
+        settings()
     );
 
     const size_t count = 1234u;
@@ -68,7 +69,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__constructor_3__always__equals_params)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings()
         },
         1234u,
         {
@@ -91,7 +93,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__constructor_4__always__equals_params)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings()
         },
         4321234u,
         {
@@ -115,7 +118,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__constructor_5__always__equals_params)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234,
         6523454,
-        68644
+        68644,
+        settings()
     );
 
     const size_t count = 654576u;
@@ -140,14 +144,17 @@ BOOST_AUTO_TEST_CASE(merkle_block__constructor_5__always__equals_params)
 BOOST_AUTO_TEST_CASE(from_data_insufficient_data_fails)
 {
     const data_chunk data{ 10 };
-    message::merkle_block instance{};
+    const settings settings;
+    message::merkle_block instance(settings);
 
-    BOOST_REQUIRE(!instance.from_data(message::version::level::maximum, data));
+    BOOST_REQUIRE(!instance.from_data(message::version::level::maximum, data,
+        settings));
     BOOST_REQUIRE(!instance.is_valid());
 }
 
 BOOST_AUTO_TEST_CASE(from_data_insufficient_version_fails)
 {
+    const settings settings;
     const message::merkle_block expected
     {
         {
@@ -156,7 +163,8 @@ BOOST_AUTO_TEST_CASE(from_data_insufficient_version_fails)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings
         },
         34523u,
         {
@@ -168,14 +176,16 @@ BOOST_AUTO_TEST_CASE(from_data_insufficient_version_fails)
     };
 
     const auto data = expected.to_data(message::version::level::maximum);
-    message::merkle_block instance{};
+    message::merkle_block instance(settings);
 
-    BOOST_REQUIRE(!instance.from_data(message::merkle_block::version_minimum - 1, data));
+    BOOST_REQUIRE(!instance.from_data(
+        message::merkle_block::version_minimum - 1, data, settings));
     BOOST_REQUIRE(!instance.is_valid());
 }
 
 BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_chunk)
 {
+    const settings settings;
     const message::merkle_block expected
     {
         {
@@ -184,7 +194,8 @@ BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_chunk)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings
         },
         45633u,
         {
@@ -196,7 +207,8 @@ BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_chunk)
     };
 
     const auto data = expected.to_data(message::version::level::maximum);
-    const auto result = message::merkle_block::factory(message::version::level::maximum, data);
+    const auto result = message::merkle_block::factory(
+        message::version::level::maximum, data, settings);
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -204,6 +216,7 @@ BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_chunk)
 
 BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_stream)
 {
+    const settings settings;
     const  message::merkle_block expected
     {
         {
@@ -212,7 +225,8 @@ BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_stream)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings
         },
         543563u,
         {
@@ -225,7 +239,8 @@ BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_stream)
 
     const auto data = expected.to_data(message::version::level::maximum);
     data_source istream(data);
-    const auto result = message::merkle_block::factory(message::version::level::maximum, istream);
+    const auto result = message::merkle_block::factory(
+        message::version::level::maximum, istream, settings);
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -233,6 +248,7 @@ BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_stream)
 
 BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_reader)
 {
+    const settings settings;
     const message::merkle_block expected
     {
         {
@@ -241,7 +257,8 @@ BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_reader)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings
         },
         5324u,
         {
@@ -255,7 +272,8 @@ BOOST_AUTO_TEST_CASE(roundtrip_to_data_factory_reader)
     const auto data = expected.to_data(message::version::level::maximum);
     data_source istream(data);
     istream_reader source(istream);
-    const auto result = message::merkle_block::factory(message::version::level::maximum, source);
+    const auto result = message::merkle_block::factory(
+        message::version::level::maximum, source, settings);
 
     BOOST_REQUIRE(result.is_valid());
     BOOST_REQUIRE(expected == result);
@@ -270,7 +288,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__header_accessor_1__always__returns_initialize
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234,
         6523454,
-        68644
+        68644,
+        settings()
     };
 
     const message::merkle_block instance(
@@ -295,7 +314,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__header_accessor_2__always__returns_initialize
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234,
         6523454,
-        68644
+        68644,
+        settings()
     };
 
     const message::merkle_block instance(
@@ -313,6 +333,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__header_accessor_2__always__returns_initialize
 
 BOOST_AUTO_TEST_CASE(merkle_block__header_setter_1__roundtrip__success)
 {
+    const settings settings;
     const chain::header expected
     {
         10,
@@ -320,10 +341,11 @@ BOOST_AUTO_TEST_CASE(merkle_block__header_setter_1__roundtrip__success)
         hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
         531234,
         6523454,
-        68644
+        68644,
+        settings
     };
 
-    message::merkle_block instance;
+    message::merkle_block instance(settings);
     BOOST_REQUIRE(expected != instance.header());
     instance.set_header(expected);
     BOOST_REQUIRE(expected == instance.header());
@@ -331,7 +353,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__header_setter_1__roundtrip__success)
 
 BOOST_AUTO_TEST_CASE(merkle_block__header_setter_2__roundtrip__success)
 {
-    message::merkle_block instance;
+    const settings settings;
+    message::merkle_block instance(settings);
     BOOST_REQUIRE(!instance.header().is_valid());
     instance.set_header(
         chain::header
@@ -341,7 +364,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__header_setter_2__roundtrip__success)
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings
         });
 
     BOOST_REQUIRE(instance.header().is_valid());
@@ -364,7 +388,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__hashes_accessor_1__always__returns_initialize
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings()
         },
         2456u,
         expected,
@@ -390,7 +415,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__hashes_accessor_2__always__returns_initialize
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings()
         },
         9137u,
         expected,
@@ -408,7 +434,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__hashes_setter_1__roundtrip__success)
         hash_literal("ccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddd"),
     };
 
-    message::merkle_block instance;
+    message::merkle_block instance(settings{});
     BOOST_REQUIRE(expected != instance.hashes());
     instance.set_hashes(expected);
     BOOST_REQUIRE(expected == instance.hashes());
@@ -416,7 +442,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__hashes_setter_1__roundtrip__success)
 
 BOOST_AUTO_TEST_CASE(merkle_block__hashes_setter_2__roundtrip__success)
 {
-    message::merkle_block instance;
+    message::merkle_block instance(settings{});
     BOOST_REQUIRE(instance.hashes().empty());
     instance.set_hashes(hash_list
     {
@@ -440,7 +466,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__flags_accessor_1__always__returns_initialized
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings()
         },
         8264u,
         {
@@ -464,7 +491,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__flags_accessor_2__always__returns_initialized
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings()
         },
         6428u,
         {
@@ -480,7 +508,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__flags_accessor_2__always__returns_initialized
 BOOST_AUTO_TEST_CASE(merkle_block__flags_setter_1__roundtrip__success)
 {
     const data_chunk expected{ 0xae, 0x56, 0x0f };
-    message::merkle_block instance;
+    message::merkle_block instance(settings{});
     BOOST_REQUIRE(expected != instance.flags());
     instance.set_flags(expected);
     BOOST_REQUIRE(expected == instance.flags());
@@ -488,7 +516,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__flags_setter_1__roundtrip__success)
 
 BOOST_AUTO_TEST_CASE(merkle_block__flags_setter_2__roundtrip__success)
 {
-    message::merkle_block instance;
+    message::merkle_block instance(settings{});
     BOOST_REQUIRE(instance.flags().empty());
     instance.set_flags(data_chunk{ 0xae, 0x56, 0x0f });
     BOOST_REQUIRE(!instance.flags().empty());
@@ -496,6 +524,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__flags_setter_2__roundtrip__success)
 
 BOOST_AUTO_TEST_CASE(merkle_block__operator_assign_equals__always__matches_equivalent)
 {
+    const settings settings;
     message::merkle_block value(
         chain::header
         {
@@ -504,7 +533,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__operator_assign_equals__always__matches_equiv
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings
         },
         3197u,
         {
@@ -517,7 +547,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__operator_assign_equals__always__matches_equiv
 
     BOOST_REQUIRE(value.is_valid());
 
-    message::merkle_block instance;
+    message::merkle_block instance(settings);
     BOOST_REQUIRE(!instance.is_valid());
 
     instance = std::move(value);
@@ -534,7 +564,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__operator_boolean_equals__duplicates__returns_
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings()
         },
         9821u,
         {
@@ -551,6 +582,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__operator_boolean_equals__duplicates__returns_
 
 BOOST_AUTO_TEST_CASE(merkle_block__operator_boolean_equals__differs__returns_false)
 {
+    const settings settings;
     const message::merkle_block expected(
         chain::header
         {
@@ -559,7 +591,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__operator_boolean_equals__differs__returns_fal
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings
         },
         1469u,
         {
@@ -570,7 +603,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__operator_boolean_equals__differs__returns_fal
         { 0xae, 0x56, 0x0f }
     );
 
-    message::merkle_block instance;
+    message::merkle_block instance(settings);
     BOOST_REQUIRE(!(instance == expected));
 }
 
@@ -584,7 +617,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__operator_boolean_not_equals__duplicates__retu
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings()
         },
         3524u,
         {
@@ -601,6 +635,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__operator_boolean_not_equals__duplicates__retu
 
 BOOST_AUTO_TEST_CASE(merkle_block__operator_boolean_not_equals__differs__returns_true)
 {
+    const settings settings;
     const message::merkle_block expected(
         chain::header
         {
@@ -609,7 +644,8 @@ BOOST_AUTO_TEST_CASE(merkle_block__operator_boolean_not_equals__differs__returns
             hash_literal("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"),
             531234,
             6523454,
-            68644
+            68644,
+            settings
         },
         8642u,
         {
@@ -620,7 +656,7 @@ BOOST_AUTO_TEST_CASE(merkle_block__operator_boolean_not_equals__differs__returns
         { 0xae, 0x56, 0x0f }
     );
 
-    message::merkle_block instance;
+    message::merkle_block instance(settings);
     BOOST_REQUIRE(instance != expected);
 }
 

--- a/test/settings.cpp
+++ b/test/settings.cpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2011-2018 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <boost/test/unit_test.hpp>
+#include <bitcoin/bitcoin.hpp>
+
+using namespace bc;
+
+BOOST_AUTO_TEST_SUITE(settings_tests)
+
+// constructors
+//-----------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(settings__construct__default_context__expected)
+{
+    settings configuration;
+    BOOST_REQUIRE_EQUAL(configuration.retargeting_factor, 4);
+    BOOST_REQUIRE_EQUAL(configuration.target_spacing_seconds, 600);
+    BOOST_REQUIRE_EQUAL(configuration.easy_spacing_seconds, 1200);
+    BOOST_REQUIRE_EQUAL(configuration.timestamp_future_seconds, 7200);
+    BOOST_REQUIRE_EQUAL(configuration.target_timespan_seconds, 1209600);
+    BOOST_REQUIRE_EQUAL(configuration.retarget_proof_of_work_limit, 0x1d00ffff);
+    BOOST_REQUIRE_EQUAL(configuration.no_retarget_proof_of_work_limit, 0x207fffff);
+    BOOST_REQUIRE_EQUAL(configuration.min_timespan, 302400);
+    BOOST_REQUIRE_EQUAL(configuration.max_timespan, 4838400);
+    BOOST_REQUIRE_EQUAL(configuration.retargeting_interval, 2016);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The constants are parametrized such that libbitcoin can be used by various altcoins by solely editing the config file.

Further constants will be parametrized in upcoming pull requests.

As soon as this patch is in a satisfactory state I'll fix the unit tests and will open PRs in other libbitcoin repos to propagate these changes. Please comment.