### PR TITLE
Fix MSVC unicode stream regression.

### DIFF
--- a/src/unicode/unicode_streambuf.cpp
+++ b/src/unicode/unicode_streambuf.cpp
@@ -116,7 +116,7 @@ std::streambuf::int_type unicode_streambuf::overflow(
         const auto written = wide_buffer_->sputn(wide_, chars);
 
         // Handle write failure as an EOF.
-        if (written != static_cast<uint8_t>(chars))
+        if (written != static_cast<std::streamsize>(chars))
             return traits_type::eof();
     }
 


### PR DESCRIPTION
@pmienk This was introduced in the warnings fix. It would only be caught in the MSVC test run.