### PR TITLE
Fix deserialize trim param, clean up new warnings.

### DIFF
--- a/include/bitcoin/bitcoin/impl/utility/string.ipp
+++ b/include/bitcoin/bitcoin/impl/utility/string.ipp
@@ -49,7 +49,7 @@ void deserialize(std::vector<Value>& collection, const std::string& text,
     for (const auto& token: tokens)
     {
         Value value;
-        deserialize(value, token, true);
+        deserialize(value, token, trim);
         collection.push_back(value);
     }
 }

--- a/include/bitcoin/bitcoin/unicode/console_streambuf.hpp
+++ b/include/bitcoin/bitcoin/unicode/console_streambuf.hpp
@@ -64,12 +64,14 @@ protected:
      */
     virtual std::wstreambuf::int_type underflow();
 
+#ifdef _MSC_VER
 private:
     // The constructed buffer size.
     size_t buffer_size_;
 
     // The dynamically-allocated buffers.
     wchar_t* buffer_;
+#endif
 };
 
 } // namespace libbitcoin

--- a/src/chain/compact.cpp
+++ b/src/chain/compact.cpp
@@ -35,8 +35,8 @@ static constexpr uint32_t mantissa_max = ~(exp_byte | sign_bit);
 static constexpr uint32_t mantissa_bits = (sizeof(uint32_t) - 1) * 8;
 
 // assertions
-static constexpr uint32_t mantissa_mask = ~mantissa_max;
-static constexpr uint32_t first_byte_mask = 0xffffff00;
+DEBUG_ONLY(static constexpr uint32_t mantissa_mask = ~mantissa_max;)
+DEBUG_ONLY(static constexpr uint32_t first_byte_mask = 0xffffff00;)
 
 // Inlines
 //-----------------------------------------------------------------------------

--- a/src/chain/transaction.cpp
+++ b/src/chain/transaction.cpp
@@ -987,7 +987,7 @@ hash_list transaction::missing_previous_transactions() const
     hashes.reserve(points.size());
     const auto hasher = [&hashes](const output_point& point)
     {
-        return point.hash();
+        hashes.push_back(point.hash());
     };
 
     std::for_each(points.begin(), points.end(), hasher);

--- a/src/math/elliptic_curve.cpp
+++ b/src/math/elliptic_curve.cpp
@@ -411,7 +411,7 @@ bool verify_signature(data_slice point, const hash_digest& hash,
 bool sign_recoverable(recoverable_signature& out, const ec_secret& secret,
     const hash_digest& hash)
 {
-    int recovery_id;
+    int recovery_id = 0;
     const auto context = signing.context();
     secp256k1_ecdsa_recoverable_signature signature;
 

--- a/src/unicode/console_streambuf.cpp
+++ b/src/unicode/console_streambuf.cpp
@@ -43,7 +43,12 @@ namespace libbitcoin {
 // This class/mathod is a no-op on non-windows platforms.
 // When working in Windows console set font to "Lucida Console".
 // This is the factory method to privately instantiate a singleton class.
-void console_streambuf::initialize(size_t size)
+void console_streambuf::initialize(
+#ifdef _MSC_VER
+    size_t size)
+#else
+    size_t)
+#endif
 {
 #ifdef _MSC_VER
     // Set the console to operate in UTF-8 for this process.
@@ -61,12 +66,14 @@ void console_streambuf::initialize(size_t size)
 }
 
 console_streambuf::console_streambuf(
+#ifdef _MSC_VER
     const std::wstreambuf& stream_buffer, size_t size)
+#else
+    const std::wstreambuf&, size_t)
+#endif
 #ifdef _MSC_VER
   : buffer_size_(size), buffer_(new wchar_t[buffer_size_]),
     std::wstreambuf(stream_buffer)
-#else
-  : buffer_size_(0), buffer_(nullptr)
 #endif
 {
 }
@@ -78,8 +85,12 @@ console_streambuf::~console_streambuf()
 #endif
 }
 
-std::streamsize console_streambuf::xsgetn(wchar_t* buffer,
-    std::streamsize size)
+std::streamsize console_streambuf::xsgetn(
+#ifdef _MSC_VER
+    wchar_t* buffer, std::streamsize size)
+#else
+    wchar_t*, std::streamsize)
+#endif
 {
     std::streamsize read_size = 0;
 

--- a/src/unicode/unicode.cpp
+++ b/src/unicode/unicode.cpp
@@ -330,7 +330,12 @@ std::wstring to_utf16(const std::string& narrow)
 
 LCOV_EXCL_START("Untestable but visually-verifiable section.")
 
-static void set_utf8_stdio(FILE* file)
+static void set_utf8_stdio(
+#ifdef _MSC_VER
+    FILE* file)
+#else
+    FILE*)
+#endif
 {
 #ifdef _MSC_VER
     if (_setmode(_fileno(file), _O_U8TEXT) == -1)
@@ -338,7 +343,12 @@ static void set_utf8_stdio(FILE* file)
 #endif
 }
 
-static void set_binary_stdio(FILE* file)
+static void set_binary_stdio(
+#ifdef _MSC_VER
+    FILE* file)
+#else
+    FILE*)
+#endif
 {
 #ifdef _MSC_VER
     if (_setmode(_fileno(file), _O_BINARY) == -1)

--- a/src/unicode/unicode_istream.cpp
+++ b/src/unicode/unicode_istream.cpp
@@ -24,8 +24,12 @@
 
 namespace libbitcoin {
 
-unicode_istream::unicode_istream(std::istream& narrow_stream,
-    std::wistream& wide_stream, size_t size)
+unicode_istream::unicode_istream(
+#ifdef _MSC_VER
+    std::istream&, std::wistream& wide_stream, size_t size)
+#else
+    std::istream& narrow_stream, std::wistream&, size_t)
+#endif
 #ifdef _MSC_VER
   : std::istream(new unicode_streambuf(wide_stream.rdbuf(), size))
 #else

--- a/src/unicode/unicode_ostream.cpp
+++ b/src/unicode/unicode_ostream.cpp
@@ -24,8 +24,12 @@
 
 namespace libbitcoin {
 
-unicode_ostream::unicode_ostream(std::ostream& narrow_stream,
-    std::wostream& wide_stream, size_t size)
+unicode_ostream::unicode_ostream(
+#ifdef _MSC_VER
+    std::ostream&, std::wostream& wide_stream, size_t size)
+#else
+    std::ostream& narrow_stream, std::wostream&, size_t)
+#endif
 #ifdef _MSC_VER
   : std::ostream(new unicode_streambuf(wide_stream.rdbuf(), size))
 #else

--- a/src/wallet/encrypted_keys.cpp
+++ b/src/wallet/encrypted_keys.cpp
@@ -71,12 +71,16 @@ static bool address_salt(ek_salt& salt, const ec_compressed& point,
     return address ? address_salt(salt, address) : false;
 }
 
+#ifdef WITH_ICU
+
 static bool address_salt(ek_salt& salt, const ec_secret& secret,
     uint8_t version, bool compressed)
 {
     payment_address address({ secret, version, compressed });
     return address ? address_salt(salt, address) : false;
 }
+
+#endif
 
 static bool address_validate(const ek_salt& salt,
     const payment_address& address)
@@ -85,12 +89,16 @@ static bool address_validate(const ek_salt& salt,
     return std::equal(hash.begin(), hash.begin() + salt.size(), salt.begin());
 }
 
+#ifdef WITH_ICU
+
 static bool address_validate(const ek_salt& salt, const ec_compressed& point,
     uint8_t version, bool compressed)
 {
     payment_address address({ point, compressed }, version);
     return address ? address_validate(salt, address) : false;
 }
+
+#endif
 
 static bool address_validate(const ek_salt& salt, const ec_secret& secret,
     uint8_t version, bool compressed)
@@ -116,13 +124,19 @@ static one_byte point_sign(uint8_t byte, const hash_digest& hash)
     return to_array(sign_byte);
 }
 
+#ifdef WITH_ICU
+
 static one_byte point_sign(const one_byte& single, const hash_digest& hash)
 {
     return point_sign(single.front(), hash);
 }
 
+#endif
+
 // scrypt_
 // ----------------------------------------------------------------------------
+
+#ifdef WITH_ICU
 
 static hash_digest scrypt_token(data_slice data, data_slice salt)
 {
@@ -130,17 +144,23 @@ static hash_digest scrypt_token(data_slice data, data_slice salt)
     return scrypt<hash_size>(data, salt, 16384u, 8u, 8u);
 }
 
+#endif
+
 static long_hash scrypt_pair(data_slice data, data_slice salt)
 {
     // Arbitrary scrypt parameters from BIP38.
     return scrypt<long_hash_size>(data, salt, 1024u, 1u, 1u);
 }
 
+#ifdef WITH_ICU
+
 static long_hash scrypt_private(data_slice data, data_slice salt)
 {
     // Arbitrary scrypt parameters from BIP38.
     return scrypt<long_hash_size>(data, salt, 16384u, 8u, 8u);
 }
+
+#endif
 
 // set_flags
 // ----------------------------------------------------------------------------
@@ -166,10 +186,14 @@ static one_byte set_flags(bool compressed, bool lot_sequence)
     return set_flags(compressed, lot_sequence, false);
 }
 
+#ifdef WITH_ICU
+
 static one_byte set_flags(bool compressed)
 {
     return set_flags(compressed, false);
 }
+
+#endif
 
 // create_key_pair
 // ----------------------------------------------------------------------------

--- a/test/wallet/encrypted_keys.cpp
+++ b/test/wallet/encrypted_keys.cpp
@@ -568,7 +568,6 @@ BOOST_AUTO_TEST_CASE(encrypted__encrypt__compressed_testnet__matches_secret_vers
     encrypted_private out_private_key;
     const uint8_t version = 111;
     const auto is_compressed = true;
-    const auto seed = base16_literal("baadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d");
     BOOST_REQUIRE(encrypt(out_private_key, secret, passphrase, version, is_compressed));
 
     // Decrypt the secret from the private key.


### PR DESCRIPTION
@thecodefactory Please review [remaining warnings](https://travis-ci.org/libbitcoin/libbitcoin/builds/401945319) from PNG and QRCode.