### PR TITLE
eliminate settings::work_limit()

### DIFF
--- a/include/bitcoin/bitcoin/settings.hpp
+++ b/include/bitcoin/bitcoin/settings.hpp
@@ -32,8 +32,6 @@ class BC_API settings
 public:
     settings();
 
-    uint32_t work_limit(bool retarget=true) const;
-
     uint32_t retargeting_factor;
     uint32_t target_spacing_seconds;
     uint32_t easy_spacing_seconds;

--- a/src/chain/chain_state.cpp
+++ b/src/chain/chain_state.cpp
@@ -601,7 +601,7 @@ chain_state::data chain_state::to_pool(const chain_state& top,
     // Hash and bits.self are unused.
     data.height = height;
     data.hash = null_hash;
-    data.bits.self = settings.work_limit(retarget);
+    data.bits.self = 0;
     data.version.self = signal_version(forks);
     return data;
 }

--- a/src/chain/header.cpp
+++ b/src/chain/header.cpp
@@ -459,7 +459,9 @@ bool header::is_valid_timestamp() const
 bool header::is_valid_proof_of_work(bool retarget) const
 {
     const auto bits = compact(bits_);
-    static const uint256_t pow_limit(compact{ settings_.work_limit(retarget) });
+    const auto work_limit = retarget ? settings_.retarget_proof_of_work_limit :
+        settings_.no_retarget_proof_of_work_limit;
+    static const uint256_t pow_limit(compact{ work_limit });
 
     if (bits.is_overflowed())
         return false;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -36,10 +36,4 @@ settings::settings()
 {
 }
 
-uint32_t settings::work_limit(bool retarget) const
-{
-    return retarget ? retarget_proof_of_work_limit :
-        no_retarget_proof_of_work_limit;
-}
-
 } // namespace libbitcoin


### PR DESCRIPTION
settings::work_limit() doesn't really fit the settings class. Because it's effectively used only once it can be inlined.