### PR TITLE
Add copy assignment operator for config::block.

### DIFF
--- a/include/bitcoin/bitcoin/config/block.hpp
+++ b/include/bitcoin/bitcoin/config/block.hpp
@@ -59,6 +59,12 @@ public:
     block(const block& other);
 
     /**
+     * Copy assignment operator.
+     * @param[in]  other  The object to copy into self on assignment.
+     */
+    block& operator=(const block& other);
+
+    /**
      * Move assignment operator.
      * @param[in]  other  The object to move into self on assignment.
      */

--- a/src/config/block.cpp
+++ b/src/config/block.cpp
@@ -49,6 +49,12 @@ block::block(const block& other)
 {
 }
 
+block& block::operator=(const block& other)
+{
+    value_ = chain::block(other.value_);
+    return *this;
+}
+
 block& block::operator=(chain::block&& other)
 {
     value_ = std::move(other);

--- a/test/config/block.cpp
+++ b/test/config/block.cpp
@@ -65,6 +65,13 @@ BOOST_AUTO_TEST_CASE(block__construct__copy__expected)
     BOOST_REQUIRE_EQUAL(block, genesis_block);
 }
 
+BOOST_AUTO_TEST_CASE(block__copy_assign__always__expected)
+{
+    block block;
+    block = genesis_block;
+    BOOST_REQUIRE_EQUAL(block, genesis_block);
+}
+
 BOOST_AUTO_TEST_CASE(block__construct__string__expected)
 {
     const block block(encoded_genesis_block);


### PR DESCRIPTION
This is the last bit needed to make `config::block` work using `boost::program_options`. It's necessary to implement the copy assignment explicitly because the copy assignment operator for `chain::block`, which is its internal type, has been deleted.