### PR TITLE
A simple shutdown_ flag to avoid shutdown deadlock

### DIFF
--- a/include/bitcoin/bitcoin/utility/threadpool.hpp
+++ b/include/bitcoin/bitcoin/utility/threadpool.hpp
@@ -110,6 +110,7 @@ private:
 
     std::shared_ptr<asio::service::work> work_;
     mutable upgrade_mutex work_mutex_;
+    bool shutdown_; // prevents deadlock due to threads_ that may spawn_once during shutdown    
 };
 
 } // namespace libbitcoin


### PR DESCRIPTION
This adds the shutdown_ bool flag as private.