### PR TITLE
NDBEUG typo

### DIFF
--- a/src/chain/transaction.cpp
+++ b/src/chain/transaction.cpp
@@ -72,7 +72,7 @@ bool read(Source& source, std::vector<Put>& puts, bool wire, bool witness)
     const auto deserialize = [&](Put& put)
     {
         result = result && put.from_data(source, wire, witness);
-#ifndef NDBEUG
+#ifndef NDEBUG
         put.script().operations();
 #endif
     };


### PR DESCRIPTION
if not defined NDEBUG is a double negative. prior builds have never excluded `put.script().operations();` and I don't know what the implications are, if any, of fixing this typo and therefore (correctly) excluding this call to do put.script() when NDEBUG is defined.