### PR TITLE
witness param supported in to_data(witness)

### DIFF
--- a/src/chain/block.cpp
+++ b/src/chain/block.cpp
@@ -230,7 +230,7 @@ data_chunk block::to_data(bool witness) const
     const auto size = serialized_size(witness);
     data.reserve(size);
     data_sink ostream(data);
-    to_data(ostream);
+    to_data(ostream, witness);
     ostream.flush();
     BITCOIN_ASSERT(data.size() == size);
     return data;


### PR DESCRIPTION
this was a bug in v3 also, if anyone had ever tried to retrieve witness data with block.to_data(true)