### PR TITLE
-Wreorder gives warnings about order of initialization.

### DIFF
--- a/include/bitcoin/bitcoin/impl/utility/deserializer.ipp
+++ b/include/bitcoin/bitcoin/impl/utility/deserializer.ipp
@@ -34,14 +34,14 @@ namespace libbitcoin {
 // Since the end is not used just use begin.
 template <typename Iterator, bool CheckSafe>
 deserializer<Iterator, CheckSafe>::deserializer(const Iterator begin)
-  : iterator_(begin), end_(begin), valid_(true)
+  : valid_(true), iterator_(begin), end_(begin)
 {
 }
 
 template <typename Iterator, bool CheckSafe>
 deserializer<Iterator, CheckSafe>::deserializer(const Iterator begin,
     const Iterator end)
-  : iterator_(begin), end_(end), valid_(true)
+  : valid_(true), iterator_(begin), end_(end)
 {
 }
 

--- a/include/bitcoin/bitcoin/impl/utility/serializer.ipp
+++ b/include/bitcoin/bitcoin/impl/utility/serializer.ipp
@@ -31,7 +31,7 @@ namespace libbitcoin {
 
 template <typename Iterator>
 serializer<Iterator>::serializer(const Iterator begin)
-  : iterator_(begin), valid_(true)
+  : valid_(true), iterator_(begin)
 {
 }
 


### PR DESCRIPTION
Constructor initialization of variables should follow layout in class definition otherwise compiler gives warnings when set in strict compile modes such as -Wall